### PR TITLE
Support LocalTalk-only operation and fix a couple bugs

### DIFF
--- a/examples/aep-echo/main.rs
+++ b/examples/aep-echo/main.rs
@@ -5,12 +5,16 @@ use tailtalk_packets::aarp::AppleTalkAddress;
 #[derive(Parser, Debug)]
 #[command(about = "Send an AppleTalk AEP (Echo Protocol) request")]
 struct Args {
-    /// Network interface to bind to
+    /// Network interface to bind to (EtherTalk)
     #[arg(short, long)]
-    interface: String,
+    interface: Option<String>,
+
+    /// TashTalk serial port path (LocalTalk)
+    #[arg(short, long)]
+    tashtalk: Option<String>,
 
     /// Destination AppleTalk network number
-    #[arg(short, long)]
+    #[arg(short = 'N', long)]
     network: u16,
 
     /// Destination AppleTalk node number
@@ -20,15 +24,27 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt().init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
     let args = Args::parse();
 
-    let stack = TalkStack::builder()
-        .ethernet(&args.interface)
-        .build()
-        .await
-        .expect("failed to build AppleTalk stack");
+    if args.interface.is_none() && args.tashtalk.is_none() {
+        anyhow::bail!("at least one of --interface or --tashtalk is required");
+    }
+
+    let mut builder = TalkStack::builder();
+    if let Some(ref intf) = args.interface {
+        builder = builder.ethernet(intf);
+    }
+    if let Some(ref tty) = args.tashtalk {
+        builder = builder.localtalk(tty);
+    }
+    let stack = builder.build().await.expect("failed to build AppleTalk stack");
 
     let addr = AppleTalkAddress {
         network_number: args.network,

--- a/examples/afp-server/main.rs
+++ b/examples/afp-server/main.rs
@@ -8,15 +8,15 @@ use tailtalk::{
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Network interface to bind to
+    /// Network interface to bind to (EtherTalk)
     #[arg(short, long)]
-    interface: String,
+    interface: Option<String>,
 
     /// Path to serve via AFP
     #[arg(short, long)]
     path: PathBuf,
 
-    /// Optional TashTalk serial port path
+    /// TashTalk serial port path (LocalTalk)
     #[arg(short, long)]
     tashtalk: Option<String>,
 }
@@ -24,12 +24,23 @@ struct Args {
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
         .init();
 
     let args = Args::parse();
 
-    let mut builder = TalkStack::builder().ethernet(&args.interface);
+    if args.interface.is_none() && args.tashtalk.is_none() {
+        eprintln!("error: at least one of --interface or --tashtalk is required");
+        std::process::exit(1);
+    }
+
+    let mut builder = TalkStack::builder();
+    if let Some(ref intf) = args.interface {
+        builder = builder.ethernet(intf);
+    }
     if let Some(ref tty) = args.tashtalk {
         builder = builder.localtalk(tty);
     }
@@ -44,7 +55,8 @@ async fn main() {
         .await
         .expect("failed to spawn AFP server");
 
-    tracing::info!("AFP server serving {:?} on {}", args.path, args.interface);
+    let transport = args.interface.as_deref().unwrap_or("LocalTalk");
+    tracing::info!("AFP server serving {:?} on {}", args.path, transport);
     tracing::info!("Press Ctrl+C to exit");
 
     tokio::signal::ctrl_c()

--- a/examples/nbp-lookup/main.rs
+++ b/examples/nbp-lookup/main.rs
@@ -5,9 +5,13 @@ use tailtalk_packets::nbp::EntityName;
 #[derive(Parser, Debug)]
 #[command(about = "Perform an NBP lookup on the AppleTalk network")]
 struct Args {
-    /// Network interface to bind to
+    /// Network interface to bind to (EtherTalk)
     #[arg(short, long)]
-    interface: String,
+    interface: Option<String>,
+
+    /// TashTalk serial port path (LocalTalk)
+    #[arg(short, long)]
+    tashtalk: Option<String>,
 
     /// Entity to look up in Object:Type@Zone format. Use = as wildcard.
     #[arg(default_value = "=:=@*")]
@@ -20,17 +24,24 @@ async fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
 
+    if args.interface.is_none() && args.tashtalk.is_none() {
+        anyhow::bail!("at least one of --interface or --tashtalk is required");
+    }
+
     let entity: EntityName = args
         .entity
         .as_str()
         .try_into()
         .map_err(|e| anyhow::anyhow!("Invalid entity name: {}", e))?;
 
-    let stack = TalkStack::builder()
-        .ethernet(&args.interface)
-        .build()
-        .await
-        .expect("failed to build AppleTalk stack");
+    let mut builder = TalkStack::builder();
+    if let Some(ref intf) = args.interface {
+        builder = builder.ethernet(intf);
+    }
+    if let Some(ref tty) = args.tashtalk {
+        builder = builder.localtalk(tty);
+    }
+    let stack = builder.build().await.expect("failed to build AppleTalk stack");
 
     println!("Looking up '{}'...", entity);
     match stack.nbp.lookup(entity).await {

--- a/tailtalk/src/addressing.rs
+++ b/tailtalk/src/addressing.rs
@@ -76,6 +76,7 @@ impl Addressing {
             request_send,
             packet_send,
             cache,
+            our_mac,
         }
     }
 
@@ -259,13 +260,19 @@ pub struct AddressingHandle {
     request_send: mpsc::Sender<AarpCommand>,
     packet_send: mpsc::Sender<(AarpPacket, AddressSource)>,
     pub(crate) cache: Arc<DashMap<AppleTalkAddress, Node>>,
+    our_mac: EthernetMac,
     _cancel: Arc<DropGuard>,
 }
 
 impl AddressingHandle {
     pub fn try_lookup(&self, addr: &AppleTalkAddress) -> Option<Node> {
+        // LocalTalk-only: node IDs are the link-layer addresses, no
+        // AARP resolution needed. Route everything as LocalTalk.
+        if self.our_mac == [0; 6] {
+            return Some(Node::LocalTalk(addr.node_number));
+        }
+
         if addr.node_number == 255 {
-            // Broadcast - default to EtherTalkPhase2
             return Some(Node::EtherTalkPhase2(Addressing::BROADCAST_MAC));
         }
         self.cache.get(addr).map(|v| *v)

--- a/tailtalk/src/ddp.rs
+++ b/tailtalk/src/ddp.rs
@@ -250,11 +250,13 @@ impl DdpProcessor {
             .addr()
             .await
             .expect("failed to get our addr");
+        tracing::debug!("DDP outbound: dest={:?} proto={:?} len={}", packet.dest, packet.protocol, packet.payload.len());
         let dest_node = self
             .addressing
             .lookup(packet.dest.addr)
             .await
             .expect("unknown addr");
+        tracing::debug!("DDP outbound: resolved to {:?}", dest_node);
 
         // Short DDP (DDP-S, 5-byte header) is LocalTalk only.
         let use_short = matches!(dest_node, Node::LocalTalk(_));

--- a/tailtalk/src/echo.rs
+++ b/tailtalk/src/echo.rs
@@ -22,6 +22,8 @@ struct PendingRequest {
     tx: oneshot::Sender<Result<Duration, Error>>,
 }
 
+const ECHO_TIMEOUT: Duration = Duration::from_secs(5);
+
 pub struct Echo {
     request_rx: mpsc::Receiver<EchoRequest>,
     sock: DdpSocket,
@@ -49,6 +51,8 @@ impl Echo {
     }
 
     async fn run(mut self) {
+        let mut timeout_check = tokio::time::interval(Duration::from_millis(500));
+        timeout_check.tick().await; // first tick completes immediately
         loop {
             tokio::select! {
                 try_req = self.request_rx.recv() => {
@@ -63,6 +67,27 @@ impl Echo {
                         Err(_) => break,
                     }
                 }
+                _ = timeout_check.tick() => {
+                    self.check_timeouts();
+                }
+            }
+        }
+    }
+
+    fn check_timeouts(&mut self) {
+        let expired: Vec<AppleTalkAddress> = self
+            .pending
+            .iter()
+            .filter(|(_, req)| req.start_time.elapsed() > ECHO_TIMEOUT)
+            .map(|(addr, _)| *addr)
+            .collect();
+        for addr in expired {
+            if let Some(req) = self.pending.remove(&addr) {
+                tracing::warn!("AEP echo to {}.{} timed out", addr.network_number, addr.node_number);
+                let _ = req.tx.send(Err(Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("echo to {}.{} timed out after {}s", addr.network_number, addr.node_number, ECHO_TIMEOUT.as_secs()),
+                )));
             }
         }
     }

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -430,12 +430,14 @@ impl PacketProcessor {
         // and ddp handles, which callers construct using the OutboundHandle that
         // build() returns.
         let tashtalk_features = self.tashtalk_features;
+        let (tashtalk_ready_tx, mut tashtalk_ready_rx) = tokio::sync::watch::channel(false);
         let tashtalk_tx: Option<mpsc::Sender<Vec<u8>>> = if let Some(mut tashtalk_instance) = self.tashtalk {
             let (tx, mut tashtalk_rx) = mpsc::channel::<Vec<u8>>(100);
 
             let ddp_handle = ddp.clone();
             let addressing_handle = addressing.clone();
             let tash_token = token.clone();
+            let ready = tashtalk_ready_tx; // moved into the spawned task
 
             tokio::spawn(async move {
                 tracing::info!("Resetting TashTalk buffers...");
@@ -472,6 +474,7 @@ impl PacketProcessor {
                 }
 
                 tracing::info!("Starting TashTalk async loop");
+                let _ = ready.send(true);
                 let mut last_receive_was_error = false;
                 loop {
                     tokio::select! {
@@ -556,6 +559,9 @@ impl PacketProcessor {
 
             Some(tx)
         } else {
+            // No TashTalk — signal ready immediately so the outbound
+            // loop doesn't block waiting for a device that doesn't exist.
+            let _ = tashtalk_ready_tx.send(true);
             None
         };
 
@@ -563,6 +569,11 @@ impl PacketProcessor {
         let our_mac = self.our_mac.unwrap_or([0; 6]);
         let mut rx = self.outbound_rx;
         let mut pcap_tx = self.pcap_tx;
+
+        // Wait for TashTalk init (reset + set_features + set_node_ids) to
+        // finish before processing outbound frames. Without this, frames
+        // queued during init would be sent before the firmware is configured.
+        let _ = tashtalk_ready_rx.wait_for(|ready| *ready).await;
 
         loop {
             let pkt = tokio::select! {


### PR DESCRIPTION
@FeralFirmware I don't know how you feel about contributions that have been made by AI - This one is from my explorations of an alternative LocalTalk adapter based on a Pi Pico.  I'm using TailTalk to test it, and these changes were required so that I could run without EtherTalk and have reliable scripted tests.  Let me know if you want this or if I should stay out of your way.  I can also split up into multiple commits if you prefer.

LocalTalk addressing:
- On LocalTalk-only setups (no EtherTalk interface), all address lookups resolve directly as Node::LocalTalk(node_number) — no AARP. Previously, broadcasts defaulted to EtherTalkPhase2 (silently dropping NBP lookups), and unicast fell through to AARP (which panics on LocalTalk).

Echo timeout:
- AEP echo requests now time out after 5 seconds instead of hanging indefinitely when no reply is received.

Init race:
- The outbound packet loop now waits for TashTalk init (reset + set_features + set_node_ids) to complete before processing frames. Previously, frames queued during the ~200ms init window could be sent before the firmware was configured. When no TashTalk is configured, the outbound loop starts immediately.

DDP tracing:
- Added debug-level tracing for outbound packet routing.

CLI examples:
- afp-server, nbp-lookup, aep-echo: --interface is now optional; --tashtalk added to nbp-lookup and aep-echo. At least one transport is required.
- afp-server, aep-echo: default log level INFO, respects RUST_LOG.