### PR TITLE
Split addressing into per-interface EtherTalk/LocalTalk handles

### DIFF
--- a/tailtalk-packets/src/aarp.rs
+++ b/tailtalk-packets/src/aarp.rs
@@ -1,8 +1,6 @@
 use byteorder::{BigEndian, ReadBytesExt};
-use bytes::{Buf, BufMut, BytesMut};
+use bytes::{BufMut, BytesMut};
 use std::io::{Cursor, Error, Read};
-
-const AARP_MIN_LEN: usize = 28;
 
 pub type EthernetMac = [u8; 6];
 
@@ -10,6 +8,7 @@ pub type EthernetMac = [u8; 6];
 pub enum AarpError {
     InvalidSize,
     UnknownOpcode(u16),
+    UnsupportedHardwareSize(u8),
     StdIoError(Error),
 }
 
@@ -70,8 +69,8 @@ pub enum AarpOpcode {
 pub struct AarpPacket {
     pub hardware_type: u16,
     pub protocol_type: u16,
-    pub hardware_size: u8, // Always 6 for EtherTalk networks - Only case supported
-    pub protocol_size: u8, // Always 4 for typical AppleTalk networks
+    pub hardware_size: u8,
+    pub protocol_size: u8,
     pub opcode: AarpOpcode,
     pub sender_addr: EthernetMac,
     pub sender_protocol: AppleTalkAddress,
@@ -83,7 +82,7 @@ impl AarpPacket {
     pub const LEN: usize = 28;
 
     pub fn parse(buf: &[u8]) -> Result<Self, AarpError> {
-        if buf.len() < AARP_MIN_LEN {
+        if buf.len() < Self::LEN {
             return Err(AarpError::InvalidSize);
         }
 
@@ -92,29 +91,28 @@ impl AarpPacket {
         let protocol_type = cursor.read_u16::<BigEndian>()?;
         let hardware_size = cursor.read_u8()?;
         let protocol_size = cursor.read_u8()?;
-        let opcode = {
-            let opcode = cursor.read_u16::<BigEndian>()?;
-
-            match opcode {
-                1 => AarpOpcode::Request,
-                2 => AarpOpcode::Response,
-                3 => AarpOpcode::Probe,
-                _ => return Err(AarpError::UnknownOpcode(opcode)),
-            }
+        let opcode = match cursor.read_u16::<BigEndian>()? {
+            1 => AarpOpcode::Request,
+            2 => AarpOpcode::Response,
+            3 => AarpOpcode::Probe,
+            n => return Err(AarpError::UnknownOpcode(n)),
         };
 
-        let mut sender_addr: [u8; 6] = [0u8; 6];
-        cursor.read_exact(&mut sender_addr)?;
+        if hardware_size != 6 {
+            return Err(AarpError::UnsupportedHardwareSize(hardware_size));
+        }
 
-        let mut protocol: [u8; 4] = [0u8; 4];
-        cursor.read_exact(&mut protocol)?;
-        let sender_protocol = AppleTalkAddress::decode(protocol);
+        let mut proto_buf = [0u8; 4];
 
-        let mut target_addr: [u8; 6] = [0u8; 6];
-        cursor.read_exact(&mut target_addr)?;
+        let mut sender_mac = [0u8; 6];
+        cursor.read_exact(&mut sender_mac)?;
+        cursor.read_exact(&mut proto_buf)?;
+        let sender_protocol = AppleTalkAddress::decode(proto_buf);
 
-        cursor.read_exact(&mut protocol)?;
-        let target_protocol = AppleTalkAddress::decode(protocol);
+        let mut target_mac = [0u8; 6];
+        cursor.read_exact(&mut target_mac)?;
+        cursor.read_exact(&mut proto_buf)?;
+        let target_protocol = AppleTalkAddress::decode(proto_buf);
 
         Ok(Self {
             hardware_type,
@@ -122,15 +120,15 @@ impl AarpPacket {
             hardware_size,
             protocol_size,
             opcode,
-            sender_addr,
+            sender_addr: sender_mac,
             sender_protocol,
-            target_addr,
+            target_addr: target_mac,
             target_protocol,
         })
     }
 
     pub fn to_bytes(&self, buffer: &mut [u8]) -> usize {
-        let mut buf = BytesMut::with_capacity(buffer.len());
+        let mut buf = BytesMut::with_capacity(Self::LEN);
         buf.put_u16(self.hardware_type);
         buf.put_u16(self.protocol_type);
         buf.put_u8(self.hardware_size);
@@ -139,20 +137,18 @@ impl AarpPacket {
 
         buf.put_slice(&self.sender_addr);
 
-        let mut sender_protocol_encoded = [0u8; 4];
-        self.sender_protocol.encode(&mut sender_protocol_encoded);
-        buf.put_slice(&sender_protocol_encoded);
+        let mut encoded = [0u8; 4];
+        self.sender_protocol.encode(&mut encoded);
+        buf.put_slice(&encoded);
 
         buf.put_slice(&self.target_addr);
 
-        let mut target_protocol_encoded = [0u8; 4];
-        self.target_protocol.encode(&mut target_protocol_encoded);
-        buf.put_slice(&target_protocol_encoded);
+        self.target_protocol.encode(&mut encoded);
+        buf.put_slice(&encoded);
 
-        let used = buf.chunk();
-        buffer[..used.len()].copy_from_slice(used);
-
-        used.len()
+        let used = buf.len();
+        buffer[..used].copy_from_slice(&buf);
+        used
     }
 }
 
@@ -204,7 +200,6 @@ mod tests {
         };
 
         let mut test_buf: [u8; 100] = [0u8; 100];
-
         let pkt_size = test_pkt.to_bytes(&mut test_buf);
         let sized = &test_buf[..pkt_size];
         let expected_bin_data = &[

--- a/tailtalk/src/addressing.rs
+++ b/tailtalk/src/addressing.rs
@@ -3,7 +3,7 @@ use im::hashmap::HashMap;
 use rand::Rng;
 use std::sync::Arc;
 use std::{io::Error, time::Duration};
-use tailtalk_packets::{aarp::*};
+use tailtalk_packets::aarp::*;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::{CancellationToken, DropGuard};
 
@@ -33,10 +33,12 @@ enum AarpCommand {
 pub struct Addressing {
     packet_recv: mpsc::Receiver<(AarpPacket, AddressSource)>,
     request_recv: mpsc::Receiver<AarpCommand>,
+    lt_ack_recv: mpsc::Receiver<u8>,
+    lt_enq_recv: mpsc::Receiver<u8>,
     pending: HashMap<AppleTalkAddress, Vec<Arc<AarpRequest>>>,
     cache: Arc<DashMap<AppleTalkAddress, Node>>,
     outbound: OutboundHandle,
-    our_mac: EthernetMac,
+    our_mac: Option<EthernetMac>,
     cancel: CancellationToken,
 }
 
@@ -49,12 +51,14 @@ impl Addressing {
     /// without any AARP probe — useful when the caller wants a specific node number.
     /// If `None`, a random node in network 1 is chosen and confirmed via AARP probe.
     pub fn spawn(
-        our_mac: EthernetMac,
+        our_mac: Option<EthernetMac>,
         outbound: OutboundHandle,
         fixed_addr: Option<AppleTalkAddress>,
     ) -> AddressingHandle {
         let (request_send, request_recv) = mpsc::channel(100);
         let (packet_send, packet_recv) = mpsc::channel(100);
+        let (lt_ack_send, lt_ack_recv) = mpsc::channel(16);
+        let (lt_enq_send, lt_enq_recv) = mpsc::channel(16);
         let cache = Arc::new(DashMap::new());
         let token = CancellationToken::new();
         let handle_token = token.clone();
@@ -65,6 +69,8 @@ impl Addressing {
             cancel: token,
             request_recv,
             packet_recv,
+            lt_ack_recv,
+            lt_enq_recv,
             our_mac,
             outbound,
         };
@@ -75,8 +81,9 @@ impl Addressing {
             _cancel: Arc::new(handle_token.drop_guard()),
             request_send,
             packet_send,
+            lt_ack_send,
+            lt_enq_send,
             cache,
-            our_mac,
         }
     }
 
@@ -88,15 +95,16 @@ impl Addressing {
         opcode: AarpOpcode,
         source_type: AddressSource,
     ) -> DataLinkPacket {
+        let our_mac = self.our_mac.expect("AARP requires an Ethernet MAC");
         let aarp_header = AarpPacket {
             hardware_type: 1,      // Ethernet
-            protocol_type: 0x809b, // Appletalk LLAP Bridging
+            protocol_type: 0x809b, // AppleTalk
             hardware_size: 6,
             protocol_size: 4,
             opcode,
-            sender_addr: self.our_mac,
+            sender_addr: our_mac,
             sender_protocol: our_addr,
-            target_addr: target_mac, // Use requester's MAC for responses
+            target_addr: target_mac,
             target_protocol: target,
         };
         let mut payload = [0u8; AarpPacket::LEN];
@@ -117,7 +125,43 @@ impl Addressing {
     }
 
     async fn run(mut self, fixed_addr: Option<AppleTalkAddress>) {
-        let our_addr = if let Some(addr) = fixed_addr {
+        let our_addr = if self.our_mac.is_none() {
+            // LocalTalk: probe via LLAP ENQ. Send ENQ with dst=tentative, src=tentative;
+            // if any node ACKs within 10 ms the address is taken — pick a new one and retry.
+            let mut node_num = fixed_addr
+                .map(|a| a.node_number)
+                .unwrap_or_else(|| rand::rng().random_range(1..=253));
+
+            'enq: loop {
+                tracing::info!("LocalTalk: probing node {node_num}");
+
+                let enq = DataLinkPacket {
+                    dest_node: Node::LocalTalk(node_num),
+                    protocol: DataLinkProtocol::LlapEnq,
+                    payload: Box::new([]),
+                    src_node_id: node_num,
+                };
+                self.outbound.send(enq).await.expect("failed to dispatch LLAP ENQ");
+
+                let deadline = tokio::time::Instant::now() + Duration::from_millis(10);
+                loop {
+                    tokio::select! {
+                        _ = tokio::time::sleep_until(deadline) => {
+                            tracing::info!("LocalTalk: node {node_num} confirmed");
+                            break 'enq AppleTalkAddress { network_number: 0, node_number: node_num };
+                        }
+                        ack = self.lt_ack_recv.recv() => {
+                            if matches!(ack, Some(src) if src == node_num) {
+                                tracing::warn!("LocalTalk: node {node_num} in use, retrying");
+                                node_num = rand::rng().random_range(1..=253);
+                                continue 'enq;
+                            }
+                        }
+                        _ = self.cancel.cancelled() => return,
+                    }
+                }
+            }
+        } else if let Some(addr) = fixed_addr {
             tracing::info!(
                 "addressing: Using fixed address {}.{}",
                 addr.network_number,
@@ -125,11 +169,9 @@ impl Addressing {
             );
             addr
         } else {
-            // Outer loop retries with a new random address on conflict.
+            // EtherTalk: probe via AARP. Retry with a new random address on conflict.
             'probe: loop {
-                let node_num = {
-                    rand::rng().random_range(1..=254)
-                };
+                let node_num = rand::rng().random_range(1..=254);
                 let addr = AppleTalkAddress {
                     network_number: 1,
                     node_number: node_num,
@@ -149,7 +191,6 @@ impl Addressing {
                     .await
                     .expect("failed to dispatch probe packet");
 
-                // Wait up to 1 second for a conflicting probe.
                 let probe_deadline = tokio::time::Instant::now() + Duration::from_secs(1);
                 loop {
                     tokio::select! {
@@ -227,6 +268,20 @@ impl Addressing {
                         }
                     }
                 }
+                enq_node = self.lt_enq_recv.recv() => {
+                    if let Some(node) = enq_node
+                        && node == our_addr.node_number
+                    {
+                        tracing::debug!("LocalTalk: sending ACK for ENQ on node {node}");
+                        let ack = DataLinkPacket {
+                            dest_node: Node::LocalTalk(node),
+                            protocol: DataLinkProtocol::LlapAck,
+                            payload: Box::new([]),
+                            src_node_id: our_addr.node_number,
+                        };
+                        let _ = self.outbound.send(ack).await;
+                    }
+                }
                 _ = self.cancel.cancelled() => {
                     break;
                 }
@@ -240,10 +295,11 @@ impl Addressing {
         our_addr: AppleTalkAddress,
         source_type: AddressSource,
     ) {
+        let target_mac = pkt.sender_addr;
         // Response: we are the sender, requester is the target
         let packet = self.create_packet(
             pkt.sender_protocol, // Target AppleTalk address (requester)
-            pkt.sender_addr,     // Target MAC (requester)
+            target_mac,          // Target MAC (requester)
             our_addr,            // Our AppleTalk address (sender)
             AarpOpcode::Response,
             source_type,
@@ -259,16 +315,28 @@ impl Addressing {
 pub struct AddressingHandle {
     request_send: mpsc::Sender<AarpCommand>,
     packet_send: mpsc::Sender<(AarpPacket, AddressSource)>,
-    pub(crate) cache: Arc<DashMap<AppleTalkAddress, Node>>,
-    our_mac: EthernetMac,
+    lt_ack_send: mpsc::Sender<u8>,
+    lt_enq_send: mpsc::Sender<u8>,
+    cache: Arc<DashMap<AppleTalkAddress, Node>>,
     _cancel: Arc<DropGuard>,
 }
 
 impl AddressingHandle {
+    pub fn received_llap_ack(&self, src_node: u8) {
+        let _ = self.lt_ack_send.try_send(src_node);
+    }
+
+    pub fn received_llap_enq(&self, dst_node: u8) {
+        let _ = self.lt_enq_send.try_send(dst_node);
+    }
+
+    pub fn learn(&self, addr: AppleTalkAddress, node: Node) {
+        self.cache.insert(addr, node);
+    }
+
     pub fn try_lookup(&self, addr: &AppleTalkAddress) -> Option<Node> {
-        // LocalTalk-only: node IDs are the link-layer addresses, no
-        // AARP resolution needed. Route everything as LocalTalk.
-        if self.our_mac == [0; 6] {
+        // Network 0 is LocalTalk — node number is the link-layer address directly.
+        if addr.network_number == 0 {
             return Some(Node::LocalTalk(addr.node_number));
         }
 
@@ -317,7 +385,8 @@ impl AddressingHandle {
         let node = match source {
             AddressSource::EtherTalkPhase2 => Node::EtherTalkPhase2(headers.sender_addr),
             AddressSource::EtherTalkPhase1 => Node::EtherTalkPhase1(headers.sender_addr),
-            AddressSource::LocalTalk => return Ok(()), // Intentionally blank as AARP is not used in LocalTalk,
+            // AARP is not used on LocalTalk; address assignment uses LLAP ENQ/ACK instead.
+            AddressSource::LocalTalk => return Ok(()),
         };
         self.cache.insert(headers.sender_protocol, node);
 

--- a/tailtalk/src/ddp.rs
+++ b/tailtalk/src/ddp.rs
@@ -104,11 +104,16 @@ pub struct DdpProcessor {
     command_rx: mpsc::Receiver<DdpCommand>,
     command_tx: mpsc::Sender<DdpCommand>,
     ethertalk: OutboundHandle,
-    addressing: AddressingHandle,
+    et_addressing: Option<AddressingHandle>,
+    lt_addressing: Option<AddressingHandle>,
 }
 
 impl DdpProcessor {
-    pub fn spawn(addressing: AddressingHandle, ethertalk: OutboundHandle) -> DdpHandle {
+    pub fn spawn(
+        et_addressing: Option<AddressingHandle>,
+        lt_addressing: Option<AddressingHandle>,
+        ethertalk: OutboundHandle,
+    ) -> DdpHandle {
         let (command_tx, command_rx) = mpsc::channel(100);
 
         let processor = Self {
@@ -116,7 +121,8 @@ impl DdpProcessor {
             command_rx,
             command_tx: command_tx.clone(),
             ethertalk,
-            addressing,
+            et_addressing,
+            lt_addressing,
         };
 
         tokio::spawn(async move { processor.run().await });
@@ -171,54 +177,49 @@ impl DdpProcessor {
     }
 
     async fn handle_packet(&mut self, packet: DdpPacket) {
-        let our_addr = self
-            .addressing
-            .addr()
-            .await
-            .expect("failed to get our addr");
-
-        // Auto-cache the source address if we don't already know it
+        // Auto-cache EtherTalk source addresses; LocalTalk is resolved directly by node number.
         let source_addr = AppleTalkAddress {
             network_number: packet.headers.src_network_num,
             node_number: packet.headers.src_node_id,
         };
 
-        if self.addressing.try_lookup(&source_addr).is_none() {
-            tracing::debug!(
-                "Learning new address from DDP packet: {}.{} -> {:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x} ({})",
-                source_addr.network_number,
-                source_addr.node_number,
-                packet.source_mac[0],
-                packet.source_mac[1],
-                packet.source_mac[2],
-                packet.source_mac[3],
-                packet.source_mac[4],
-                packet.source_mac[5],
-                match packet.source {
-                    AppleTalkAddressSource::EtherTalkPhase2 => "EtherTalkPhase2",
-                    AppleTalkAddressSource::EtherTalkPhase1 => "EtherTalkPhase1",
-                    AppleTalkAddressSource::LocalTalk => "LocalTalk",
+        match packet.source {
+            AppleTalkAddressSource::LocalTalk => {}
+            _ => {
+                if let Some(et) = &self.et_addressing
+                    && et.try_lookup(&source_addr).is_none() {
+                        let node = match packet.source {
+                            AppleTalkAddressSource::EtherTalkPhase2 => Node::EtherTalkPhase2(packet.source_mac),
+                            AppleTalkAddressSource::EtherTalkPhase1 => Node::EtherTalkPhase1(packet.source_mac),
+                            AppleTalkAddressSource::LocalTalk => unreachable!(),
+                        };
+                        tracing::debug!(
+                            "Learning new address from DDP packet: {}.{} ({:?})",
+                            source_addr.network_number, source_addr.node_number, packet.source
+                        );
+                        et.learn(source_addr, node);
                 }
-            );
-            // Cache it using the addressing handle's internal cache
-            // We need to use the internal cache directly since try_lookup uses it
-            let node = match packet.source {
-                AppleTalkAddressSource::EtherTalkPhase2 => Node::EtherTalkPhase2(packet.source_mac),
-                AppleTalkAddressSource::EtherTalkPhase1 => Node::EtherTalkPhase1(packet.source_mac),
-                AppleTalkAddressSource::LocalTalk => Node::LocalTalk(packet.headers.src_node_id),
-            };
-            self.addressing.cache.insert(source_addr, node);
+            }
         }
 
-        // Accept packets addressed to us or broadcast (node 255)
-        let is_for_us = packet.headers.dest_node_id == 255
-            || our_addr.matches(
-                &AppleTalkAddress {
-                    network_number: packet.headers.dest_network_num,
-                    node_number: packet.headers.dest_node_id,
-                },
-                packet.source,
-            );
+        // Accept broadcast or any packet that matches one of our interface addresses.
+        let dest = AppleTalkAddress {
+            network_number: packet.headers.dest_network_num,
+            node_number: packet.headers.dest_node_id,
+        };
+        let is_for_us = packet.headers.dest_node_id == 255 || {
+            let mut matched = false;
+            if let Some(et) = &self.et_addressing
+                && let Ok(our) = et.addr().await {
+                    matched |= our.matches(&dest, packet.source);
+            }
+            if !matched
+                && let Some(lt) = &self.lt_addressing
+                && let Ok(our) = lt.addr().await {
+                    matched |= our.matches(&dest, packet.source);
+            }
+            matched
+        };
 
         if !is_for_us {
             return;
@@ -245,18 +246,32 @@ impl DdpProcessor {
     }
 
     async fn handle_outbound(&mut self, packet: OutboundPacket) {
-        let our_addr = self
-            .addressing
-            .addr()
-            .await
-            .expect("failed to get our addr");
-        tracing::debug!("DDP outbound: dest={:?} proto={:?} len={}", packet.dest, packet.protocol, packet.payload.len());
-        let dest_node = self
-            .addressing
-            .lookup(packet.dest.addr)
-            .await
-            .expect("unknown addr");
-        tracing::debug!("DDP outbound: resolved to {:?}", dest_node);
+        let dest_node = if packet.dest.addr.network_number == 0 {
+            if self.lt_addressing.is_none() {
+                tracing::error!(
+                    "DDP: dropping packet to {}.{} — LocalTalk (network 0) not configured",
+                    packet.dest.addr.network_number,
+                    packet.dest.addr.node_number,
+                );
+                return;
+            }
+            Node::LocalTalk(packet.dest.addr.node_number)
+        } else {
+            let Some(et) = &self.et_addressing else {
+                tracing::error!(
+                    "DDP: dropping packet to {}.{} — EtherTalk not configured",
+                    packet.dest.addr.network_number,
+                    packet.dest.addr.node_number,
+                );
+                return;
+            };
+            et.lookup(packet.dest.addr).await.expect("unknown addr")
+        };
+
+        let our_addr = match &dest_node {
+            Node::LocalTalk(_) => self.lt_addressing.as_ref().unwrap().addr().await.unwrap(),
+            _ => self.et_addressing.as_ref().unwrap().addr().await.unwrap(),
+        };
 
         // Short DDP (DDP-S, 5-byte header) is LocalTalk only.
         let use_short = matches!(dest_node, Node::LocalTalk(_));

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -31,6 +31,8 @@ pub mod stylewriter;
 pub enum DataLinkProtocol {
     Ddp,
     Aarp,
+    LlapEnq,
+    LlapAck,
 }
 
 #[derive(Debug)]
@@ -297,7 +299,13 @@ impl PacketProcessor {
         self.our_mac
     }
 
-    pub async fn run(self, addressing: addressing::AddressingHandle, ddp: ddp::DdpHandle, token: CancellationToken) {
+    pub async fn run(
+        self,
+        et_addressing: Option<addressing::AddressingHandle>,
+        lt_addressing: Option<addressing::AddressingHandle>,
+        ddp: ddp::DdpHandle,
+        token: CancellationToken,
+    ) {
         // Extract pcap senders before any other field moves.
         // pcap_rx_sender goes into the TashTalk receive task; pcap_tx_sender stays in the outbound loop.
         let pcap_rx_sender = self.pcap_sender.clone();
@@ -306,7 +314,7 @@ impl PacketProcessor {
         // ── EtherTalk RX task ────────────────────────────────────────────────
         if let Some(rx_cap) = self.pcap_rx {
             let ddp_rx = ddp.clone();
-            let addressing_rx = addressing.clone();
+            let addressing_rx = et_addressing.clone().expect("EtherTalk RX task requires ET addressing");
             let rx_token = token.clone();
 
             let rx_cap = match rx_cap.setnonblock() {
@@ -435,7 +443,7 @@ impl PacketProcessor {
             let (tx, mut tashtalk_rx) = mpsc::channel::<Vec<u8>>(100);
 
             let ddp_handle = ddp.clone();
-            let addressing_handle = addressing.clone();
+            let addressing_handle = lt_addressing.clone().expect("TashTalk task requires LT addressing");
             let tash_token = token.clone();
             let ready = tashtalk_ready_tx; // moved into the spawned task
 
@@ -519,6 +527,12 @@ impl PacketProcessor {
                                                         [0; 6],
                                                     );
                                                 }
+                                            }
+                                            LlapType::Enquiry => {
+                                                addressing_handle.received_llap_enq(llap.dst_node);
+                                            }
+                                            LlapType::Acknowledge => {
+                                                addressing_handle.received_llap_ack(llap.src_node);
                                             }
                                             LlapType::DdpLong => {
                                                 tracing::info!("TashTalk: LocalTalk DDP Long");
@@ -638,6 +652,30 @@ impl PacketProcessor {
 
                             frame_end + 2
                         }
+                    }
+                }
+                DataLinkProtocol::LlapEnq | DataLinkProtocol::LlapAck => {
+                    match pkt.dest_node {
+                        addressing::Node::LocalTalk(node_id) => {
+                            let type_ = if pkt.protocol == DataLinkProtocol::LlapEnq {
+                                LlapType::Enquiry
+                            } else {
+                                LlapType::Acknowledge
+                            };
+                            let llap_pkt = LlapPacket {
+                                dst_node: node_id,
+                                src_node: pkt.src_node_id,
+                                type_,
+                            };
+                            let header_len = llap_pkt
+                                .to_bytes(&mut output_buf)
+                                .expect("failed to frame LLAP control");
+                            let crc = tashtalk::lt_crc(&output_buf[..header_len]);
+                            output_buf[header_len] = crc[0];
+                            output_buf[header_len + 1] = crc[1];
+                            header_len + 2
+                        }
+                        _ => 0,
                     }
                 }
                 DataLinkProtocol::Aarp => {
@@ -769,7 +807,10 @@ impl ShutdownHandle {
 /// # Ok(()) }
 /// ```
 pub struct TalkStack {
-    pub addressing: addressing::AddressingHandle,
+    /// EtherTalk addressing handle, present when an Ethernet interface is configured.
+    pub et_addressing: Option<addressing::AddressingHandle>,
+    /// LocalTalk addressing handle, present when a TashTalk serial interface is configured.
+    pub lt_addressing: Option<addressing::AddressingHandle>,
     pub ddp: ddp::DdpHandle,
     pub nbp: nbp::NbpHandle,
     pub echo: echo::EchoHandle,
@@ -885,38 +926,48 @@ impl TalkStackBuilder {
         }
         let (processor, outbound) = pp.build()?;
 
-        // On LocalTalk-only setups, short DDP carries no network number (implying 0).
-        // If we let AARP pick network 1, NBP advertises net 1 but packets appear as
-        // net 0 — clients reject server-initiated requests (WriteContinue) due to the
-        // mismatch. Force network 0 so the address is consistent end-to-end.
-        let fixed_addr = if self.fixed_addr.is_some() {
-            self.fixed_addr
-        } else if self.ethernet_intf.is_none() && self.localtalk_serial_path.is_some() {
-            Some(tailtalk_packets::aarp::AppleTalkAddress {
-                network_number: 0,
-                node_number: rand::rng().random_range(1..=253u8),
-            })
+        // EtherTalk addressing: AARP probe (or fixed address if caller specified one).
+        let et_addressing = if self.ethernet_intf.is_some() {
+            Some(addressing::Addressing::spawn(
+                processor.get_mac(),
+                outbound.clone(),
+                self.fixed_addr,
+            ))
         } else {
             None
         };
 
-        let mac = processor.get_mac().unwrap_or([0u8; 6]);
-        let addressing = addressing::Addressing::spawn(mac, outbound.clone(), fixed_addr);
-        let ddp = ddp::DdpProcessor::spawn(addressing.clone(), outbound);
+        // LocalTalk addressing: always a fixed random address on network 0.
+        // LocalTalk short-DDP carries no network number (implying 0), so we
+        // must stay on network 0 to keep addresses consistent end-to-end.
+        let lt_addressing = if self.localtalk_serial_path.is_some() {
+            let lt_fixed = Some(tailtalk_packets::aarp::AppleTalkAddress {
+                network_number: 0,
+                node_number: rand::rng().random_range(1..=253u8),
+            });
+            Some(addressing::Addressing::spawn(None, outbound.clone(), lt_fixed))
+        } else {
+            None
+        };
+
+        let ddp = ddp::DdpProcessor::spawn(et_addressing.clone(), lt_addressing.clone(), outbound);
         let echo = echo::Echo::spawn(&ddp).await;
-        let nbp = nbp::Nbp::spawn(&ddp, addressing.clone()).await;
+        let nbp = nbp::Nbp::spawn(&ddp, et_addressing.clone(), lt_addressing.clone()).await;
 
         let service_token = CancellationToken::new();
         let transport_token = CancellationToken::new();
         let services_done = CancellationToken::new();
-        tokio::spawn(processor.run(addressing.clone(), ddp.clone(), transport_token.clone()));
+        tokio::spawn(processor.run(et_addressing.clone(), lt_addressing.clone(), ddp.clone(), transport_token.clone()));
 
-        // Wait until AARP has confirmed our node address before returning.
-        // Without this, callers could attempt to send packets before addressing
-        // is ready, especially when probing is required (no fixed address).
-        addressing.addr().await?;
+        // Wait until addressing has settled on all active interfaces.
+        if let Some(et) = &et_addressing {
+            et.addr().await?;
+        }
+        if let Some(lt) = &lt_addressing {
+            lt.addr().await?;
+        }
 
-        Ok(TalkStack { addressing, ddp, nbp, echo, service_token, transport_token, services_done })
+        Ok(TalkStack { et_addressing, lt_addressing, ddp, nbp, echo, service_token, transport_token, services_done })
     }
 }
 

--- a/tailtalk/src/nbp.rs
+++ b/tailtalk/src/nbp.rs
@@ -42,14 +42,19 @@ struct PendingLookup {
 pub struct Nbp {
     sock: DdpSocket,
     registered_names: Vec<RegisteredName>,
-    addressing: AddressingHandle,
+    et_addressing: Option<AddressingHandle>,
+    lt_addressing: Option<AddressingHandle>,
     request_recv: mpsc::Receiver<NbpCommand>,
     pending_lookups: HashMap<u8, PendingLookup>,
     next_tid: u8,
 }
 
 impl Nbp {
-    pub async fn spawn(ddp: &DdpHandle, addressing: AddressingHandle) -> NbpHandle {
+    pub async fn spawn(
+        ddp: &DdpHandle,
+        et_addressing: Option<AddressingHandle>,
+        lt_addressing: Option<AddressingHandle>,
+    ) -> NbpHandle {
         let sock = ddp
             .new_sock(DdpProtocolType::Nbp, Some(2))
             .await
@@ -60,7 +65,8 @@ impl Nbp {
         let nbp = Nbp {
             sock,
             registered_names: Vec::new(),
-            addressing,
+            et_addressing,
+            lt_addressing,
             request_recv,
             pending_lookups: HashMap::new(),
             next_tid: 1,
@@ -100,14 +106,17 @@ impl Nbp {
                                 let tid = self.next_tid;
                                 self.next_tid = self.next_tid.wrapping_add(1);
 
-                                let our_addr = self.addressing.addr()
-                                    .await
-                                    .expect("failed to get our addr");
+                                // Use the primary address (ET if available, else LT) in the lookup tuple.
+                                let primary_addr = if let Some(et) = &self.et_addressing {
+                                    et.addr().await.expect("failed to get ET addr")
+                                } else {
+                                    self.lt_addressing.as_ref().expect("no addressing").addr().await.expect("failed to get LT addr")
+                                };
 
                                 let tuple = NbpTuple {
-                                    network_number: our_addr.network_number,
-                                    node_id: our_addr.node_number,
-                                    socket_number: 2, // Default NBP socket
+                                    network_number: primary_addr.network_number,
+                                    node_id: primary_addr.node_number,
+                                    socket_number: 2,
                                     enumerator: 0,
                                     entity_name: lookup.request,
                                 };
@@ -120,23 +129,50 @@ impl Nbp {
 
                                 let mut buf = [0u8; 1024];
                                 let size = packet.to_bytes(&mut buf).expect("failed to serialize");
-                                // Send to broadcast
-                                let dest = crate::ddp::DdpAddress::new(
-                                    tailtalk_packets::aarp::AppleTalkAddress {
-                                        network_number: 0,
-                                        node_number: 255,
-                                    },
-                                    2 // NBP socket
-                                );
 
-                                if let Err(e) = self.sock.send_to(&buf[..size], dest).await {
-                                    let _ = lookup.chan.send(Err(e));
-                                } else {
+                                let mut send_ok = true;
+
+                                // Send over LocalTalk (network 0 = this LocalTalk cable).
+                                if self.lt_addressing.is_some() {
+                                    let dest = crate::ddp::DdpAddress::new(
+                                        tailtalk_packets::aarp::AppleTalkAddress {
+                                            network_number: 0,
+                                            node_number: 255,
+                                        },
+                                        2,
+                                    );
+                                    if let Err(e) = self.sock.send_to(&buf[..size], dest).await {
+                                        tracing::error!("NBP LkUp: failed to send on LocalTalk: {e}");
+                                        send_ok = false;
+                                    }
+                                }
+
+                                // Send over EtherTalk (our assigned network, node 255 = cable broadcast).
+                                if let Some(et) = &self.et_addressing {
+                                    let et_addr = et.addr().await.expect("failed to get ET addr");
+                                    let dest = crate::ddp::DdpAddress::new(
+                                        tailtalk_packets::aarp::AppleTalkAddress {
+                                            network_number: et_addr.network_number,
+                                            node_number: 255,
+                                        },
+                                        2,
+                                    );
+                                    if let Err(e) = self.sock.send_to(&buf[..size], dest).await {
+                                        tracing::error!("NBP LkUp: failed to send on EtherTalk: {e}");
+                                        send_ok = false;
+                                    }
+                                }
+
+                                if send_ok {
                                     self.pending_lookups.insert(tid, PendingLookup {
                                         chan: lookup.chan,
                                         start_time: Instant::now(),
                                         results: Vec::new(),
                                     });
+                                } else {
+                                    let _ = lookup.chan.send(Err(io::Error::other(
+                                        "failed to send NBP lookup on all transports",
+                                    )));
                                 }
                             },
                         }
@@ -207,7 +243,7 @@ impl Nbp {
 
         match packet.operation {
             NbpOperation::Lookup => {
-                let response = self.generate_response(&packet).await;
+                let response = self.generate_response(&packet, ddp.src_network_num).await;
 
                 // Only send a reply if we have at least one matching tuple
                 if !response.tuples.is_empty() {
@@ -256,12 +292,19 @@ impl Nbp {
         }
     }
 
-    async fn generate_response(&self, nbp: &NbpPacket) -> NbpPacket {
-        let our_addr = self
-            .addressing
-            .addr()
-            .await
-            .expect("failed to get our addr");
+    async fn generate_response(&self, nbp: &NbpPacket, source_network: u16) -> NbpPacket {
+        // Respond with the address on the same interface the lookup arrived from.
+        let our_addr = if source_network == 0 {
+            if let Some(lt) = &self.lt_addressing {
+                lt.addr().await.expect("failed to get LT addr")
+            } else {
+                self.et_addressing.as_ref().expect("no addressing").addr().await.expect("failed to get ET addr")
+            }
+        } else if let Some(et) = &self.et_addressing {
+            et.addr().await.expect("failed to get ET addr")
+        } else {
+            self.lt_addressing.as_ref().expect("no addressing").addr().await.expect("failed to get LT addr")
+        };
 
         let mut tuples = Vec::new();
 

--- a/tailtalk/tests/adsp_test.rs
+++ b/tailtalk/tests/adsp_test.rs
@@ -65,8 +65,8 @@ impl TestClient {
             }
         });
 
-        let addressing = Addressing::spawn(mac, outbound_handle.clone(), None);
-        let ddp = DdpProcessor::spawn(addressing.clone(), outbound_handle.clone());
+        let addressing = Addressing::spawn(Some(mac), outbound_handle.clone(), None);
+        let ddp = DdpProcessor::spawn(Some(addressing.clone()), None, outbound_handle.clone());
 
         let mut rx = hub_rx;
         let ddp_handle = ddp.clone();
@@ -97,6 +97,7 @@ impl TestClient {
                                 let _ = addressing_handle
                                     .received_pkt(&pkt.payload, AddressSource::EtherTalkPhase2);
                             }
+                            DataLinkProtocol::LlapEnq | DataLinkProtocol::LlapAck => {}
                         }
                     }
                 }

--- a/tailtalk/tests/asp_session_test.rs
+++ b/tailtalk/tests/asp_session_test.rs
@@ -74,8 +74,8 @@ impl TestClient {
             }
         });
 
-        let addressing = Addressing::spawn(mac, outbound_handle.clone(), None);
-        let ddp = DdpProcessor::spawn(addressing.clone(), outbound_handle.clone());
+        let addressing = Addressing::spawn(Some(mac), outbound_handle.clone(), None);
+        let ddp = DdpProcessor::spawn(Some(addressing.clone()), None, outbound_handle.clone());
 
         let echo = Echo::spawn(&ddp).await;
         let (_atp_socket, atp_req, mut atp_resp) = Atp::spawn(&ddp, None).await;
@@ -87,7 +87,7 @@ impl TestClient {
             }
         });
 
-        let nbp = Nbp::spawn(&ddp, addressing.clone()).await;
+        let nbp = Nbp::spawn(&ddp, Some(addressing.clone()), None).await;
 
         let mut rx = hub_rx;
         let ddp_handle = ddp.clone();
@@ -119,6 +119,7 @@ impl TestClient {
                                 let _ = addressing_handle
                                     .received_pkt(&pkt.payload, AddressSource::EtherTalkPhase2);
                             }
+                            DataLinkProtocol::LlapEnq | DataLinkProtocol::LlapAck => {}
                         }
                     }
                 }
@@ -167,10 +168,10 @@ async fn test_asp_session_workflow() {
         }
     });
 
-    let addr_server = Addressing::spawn(mac_server, outbound_server.clone(), None);
-    let ddp_server = DdpProcessor::spawn(addr_server.clone(), outbound_server.clone());
+    let addr_server = Addressing::spawn(Some(mac_server), outbound_server.clone(), None);
+    let ddp_server = DdpProcessor::spawn(Some(addr_server.clone()), None, outbound_server.clone());
     // Start NBP for server
-    let nbp_server = Nbp::spawn(&ddp_server, addr_server.clone()).await;
+    let nbp_server = Nbp::spawn(&ddp_server, Some(addr_server.clone()), None).await;
 
     // Start incoming packet loop for server
     let mut rx_server = hub_ref.subscribe();
@@ -194,6 +195,7 @@ async fn test_asp_session_workflow() {
                             let _ =
                                 addr_handle_s.received_pkt(&pkt.payload, AddressSource::EtherTalkPhase2);
                         }
+                        DataLinkProtocol::LlapEnq | DataLinkProtocol::LlapAck => {}
                     }
                 }
             }

--- a/tailtalk/tests/asp_status_test.rs
+++ b/tailtalk/tests/asp_status_test.rs
@@ -73,8 +73,8 @@ impl TestClient {
             }
         });
 
-        let addressing = Addressing::spawn(mac, outbound_handle.clone(), None);
-        let ddp = DdpProcessor::spawn(addressing.clone(), outbound_handle.clone());
+        let addressing = Addressing::spawn(Some(mac), outbound_handle.clone(), None);
+        let ddp = DdpProcessor::spawn(Some(addressing.clone()), None, outbound_handle.clone());
 
         let echo = Echo::spawn(&ddp).await;
         let (_atp_socket, atp_req, mut atp_resp) = Atp::spawn(&ddp, None).await;
@@ -86,7 +86,7 @@ impl TestClient {
             }
         });
 
-        let nbp = Nbp::spawn(&ddp, addressing.clone()).await;
+        let nbp = Nbp::spawn(&ddp, Some(addressing.clone()), None).await;
 
         let mut rx = hub_rx;
         let ddp_handle = ddp.clone();
@@ -118,6 +118,7 @@ impl TestClient {
                                 let _ = addressing_handle
                                     .received_pkt(&pkt.payload, AddressSource::EtherTalkPhase2);
                             }
+                            DataLinkProtocol::LlapEnq | DataLinkProtocol::LlapAck => {}
                         }
                     }
                 }
@@ -168,10 +169,10 @@ async fn test_asp_get_status() {
         }
     });
 
-    let addr_server = Addressing::spawn(mac_server, outbound_server.clone(), None);
-    let ddp_server = DdpProcessor::spawn(addr_server.clone(), outbound_server.clone());
+    let addr_server = Addressing::spawn(Some(mac_server), outbound_server.clone(), None);
+    let ddp_server = DdpProcessor::spawn(Some(addr_server.clone()), None, outbound_server.clone());
     // Start NBP for server
-    let nbp_server = Nbp::spawn(&ddp_server, addr_server.clone()).await;
+    let nbp_server = Nbp::spawn(&ddp_server, Some(addr_server.clone()), None).await;
 
     // Start incoming packet loop for server
     let mut rx_server = hub_ref.subscribe();
@@ -195,6 +196,7 @@ async fn test_asp_get_status() {
                             let _ =
                                 addr_handle_s.received_pkt(&pkt.payload, AddressSource::EtherTalkPhase2);
                         }
+                        DataLinkProtocol::LlapEnq | DataLinkProtocol::LlapAck => {}
                     }
                 }
             }

--- a/tailtalk/tests/client_exchange.rs
+++ b/tailtalk/tests/client_exchange.rs
@@ -76,8 +76,8 @@ impl TestClient {
             }
         });
 
-        let addressing = Addressing::spawn(mac, outbound_handle.clone(), None);
-        let ddp = DdpProcessor::spawn(addressing.clone(), outbound_handle.clone());
+        let addressing = Addressing::spawn(Some(mac), outbound_handle.clone(), None);
+        let ddp = DdpProcessor::spawn(Some(addressing.clone()), None, outbound_handle.clone());
 
         let echo = Echo::spawn(&ddp).await;
         let (_atp_socket, atp_req, mut atp_resp) = Atp::spawn(&ddp, atp_socket).await;
@@ -89,7 +89,7 @@ impl TestClient {
             }
         });
 
-        let nbp = Nbp::spawn(&ddp, addressing.clone()).await;
+        let nbp = Nbp::spawn(&ddp, Some(addressing.clone()), None).await;
 
         let mut rx = hub_rx;
         let ddp_handle = ddp.clone();
@@ -133,6 +133,7 @@ impl TestClient {
                                 let _ = addressing_handle
                                     .received_pkt(&pkt.payload, AddressSource::EtherTalkPhase2);
                             }
+                            DataLinkProtocol::LlapEnq | DataLinkProtocol::LlapAck => {}
                         }
                     } else {
                         tracing::info!(

--- a/tailtalk/tests/pap_test.rs
+++ b/tailtalk/tests/pap_test.rs
@@ -81,14 +81,14 @@ impl TestClient {
             }
         });
 
-        let addressing = Addressing::spawn(mac, outbound_handle.clone(), None);
-        let ddp = DdpProcessor::spawn(addressing.clone(), outbound_handle.clone());
+        let addressing = Addressing::spawn(Some(mac), outbound_handle.clone(), None);
+        let ddp = DdpProcessor::spawn(Some(addressing.clone()), None, outbound_handle.clone());
 
         let echo = Echo::spawn(&ddp).await;
         // spawn returns (socket, req, resp)
         let (_sock, atp_req, atp_resp) = Atp::spawn(&ddp, atp_socket).await;
 
-        let nbp = Nbp::spawn(&ddp, addressing.clone()).await;
+        let nbp = Nbp::spawn(&ddp, Some(addressing.clone()), None).await;
 
         let mut rx = hub_rx;
         let ddp_handle = ddp.clone();
@@ -120,6 +120,7 @@ impl TestClient {
                                 let _ = addressing_handle
                                     .received_pkt(&pkt.payload, AddressSource::EtherTalkPhase2);
                             }
+                            DataLinkProtocol::LlapEnq | DataLinkProtocol::LlapAck => {}
                         }
                     }
                 }


### PR DESCRIPTION
Coming out of #3 - This finally starts to clear up our addressing logic which was originally EtherTalk exclusive and had LocalTalk bolted on to it. With this we now have a somewhat clean split between EtherTalk and LocalTalk, with the lookup method now immediately returning the LocalTalk address if called for network zero.

Additionally DDP has been reworked a bit so it no longer attempts to call lookups for a LocalTalk destined packet, because there is no need for lookup there. 

Lastly this now makes it so we actually probe for our LocalTalk address rather than just assuming it is free. Whilst it is unlikely to occur in a 2 node network, it was still a 1 in 253 chance we'd collide silently.