### PR TITLE
GUI: Add new file menu option to inspect and set finder info

### DIFF
--- a/tailtalk-gui/main.rs
+++ b/tailtalk-gui/main.rs
@@ -2,11 +2,9 @@ use std::path::{Path, PathBuf};
 
 #[cfg(any(feature = "ethertalk", feature = "tashtalk"))]
 use std::rc::Rc;
-
 #[cfg(feature = "tashtalk")]
 use std::cell::RefCell;
 
-#[cfg(any(feature = "ethertalk", feature = "tashtalk"))]
 use slint::SharedString;
 #[cfg(feature = "tashtalk")]
 use slint::Model as _;
@@ -368,6 +366,79 @@ fn main() -> anyhow::Result<()> {
         });
     });
 
+    ui.on_clamp_ostype(|s| s.chars().take(4).collect::<String>().into());
+
+    let ui_weak = ui.as_weak();
+    ui.on_inspect_finder_info(move || {
+        let ui_weak = ui_weak.clone();
+        let volume_path = ui_weak
+            .upgrade()
+            .map(|ui| ui.get_volume_path().to_string())
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from);
+        std::thread::spawn(move || {
+            let mut dialog = rfd::FileDialog::new().set_title("Choose a file to inspect");
+            if let Some(ref dir) = volume_path {
+                dialog = dialog.set_directory(dir);
+            }
+            let Some(path) = dialog.pick_file() else {
+                return;
+            };
+
+            let info = match tailtalk::afp::read_finder_info(&path) {
+                Ok(v) => v,
+                Err(e) => {
+                    let msg = format!("Could not read Finder Info: {e}");
+                    slint::invoke_from_event_loop(move || {
+                        if let Some(ui) = ui_weak.upgrade() {
+                            ui.set_error_message(msg.into());
+                        }
+                    })
+                    .ok();
+                    return;
+                }
+            };
+
+            let type_str = ostype_to_string(&info[0..4]);
+            let creator_str = ostype_to_string(&info[4..8]);
+            // finder-info-path stores the actual file path (used for saving too)
+            let path_str: SharedString = path.to_string_lossy().into_owned().into();
+
+            slint::invoke_from_event_loop(move || {
+                if let Some(ui) = ui_weak.upgrade() {
+                    ui.set_finder_info_type(type_str.into());
+                    ui.set_finder_info_creator(creator_str.into());
+                    ui.set_finder_info_path(path_str);
+                    ui.set_finder_info_visible(true);
+                }
+            })
+            .ok();
+        });
+    });
+
+    let ui_weak = ui.as_weak();
+    ui.on_save_finder_info(move || {
+        let Some(ui) = ui_weak.upgrade() else { return };
+        let path = PathBuf::from(ui.get_finder_info_path().as_str());
+
+        let type_bytes = string_to_ostype(&ui.get_finder_info_type());
+        let creator_bytes = string_to_ostype(&ui.get_finder_info_creator());
+
+        let mut info = tailtalk::afp::read_finder_info(&path).unwrap_or([0u8; 32]);
+        info[0..4].copy_from_slice(&type_bytes);
+        info[4..8].copy_from_slice(&creator_bytes);
+
+        match tailtalk::afp::write_finder_info(&path, &info) {
+            Ok(()) => {
+                ui.set_finder_info_visible(false);
+            }
+            Err(e) => {
+                let msg = format!("Could not write Finder Info: {e}");
+                ui.set_error_message(msg.into());
+            }
+        }
+    });
+
     let ui_weak = ui.as_weak();
     ui.on_import_stuffit(move || {
         let ui_weak = ui_weak.clone();
@@ -552,6 +623,28 @@ fn show_info(ui_weak: slint::Weak<AppWindow>, message: String) {
         }
     })
     .ok();
+}
+
+// ── OSType (4-byte Mac type/creator code) helpers ────────────────────────────
+
+/// Convert a 4-byte OSType to a displayable string, replacing non-graphic bytes with spaces.
+fn ostype_to_string(bytes: &[u8]) -> String {
+    if bytes.iter().all(|&b| b == 0) {
+        return String::new();
+    }
+    bytes
+        .iter()
+        .map(|&b| if b.is_ascii_graphic() || b == b' ' { b as char } else { ' ' })
+        .collect()
+}
+
+/// Convert a user-supplied string to a 4-byte OSType, truncating or space-padding as needed.
+fn string_to_ostype(s: &str) -> [u8; 4] {
+    let mut out = [b' '; 4];
+    for (dst, src) in out.iter_mut().zip(s.bytes()) {
+        *dst = src;
+    }
+    out
 }
 
 // ── Mac resource fork parsing ─────────────────────────────────────────────────

--- a/tailtalk-gui/ui/app.slint
+++ b/tailtalk-gui/ui/app.slint
@@ -24,10 +24,19 @@ export component AppWindow inherits Window {
     in-out property <string> pcap-path;
     in-out property <string> info-message: "";
 
+    in-out property <bool> finder-info-visible: false;
+    in-out property <string> finder-info-path: "";
+    in-out property <string> finder-info-type: "";
+    in-out property <string> finder-info-creator: "";
+
     callback start-stop();
     callback browse-volume();
     callback browse-pcap();
     callback import-stuffit();
+    callback inspect-finder-info();
+    callback save-finder-info();
+    // Returns the input truncated to 4 characters; registered in Rust.
+    callback clamp-ostype(string) -> string;
 
     MenuBar {
         Menu {
@@ -35,6 +44,10 @@ export component AppWindow inherits Window {
             MenuItem {
                 title: "Import StuffIt Archive…";
                 activated => { root.import-stuffit(); }
+            }
+            MenuItem {
+                title: "Inspect Finder Info…";
+                activated => { root.inspect-finder-info(); }
             }
         }
     }
@@ -201,6 +214,79 @@ export component AppWindow inherits Window {
                     Button {
                         text: "OK";
                         clicked => { root.error-message = ""; }
+                    }
+                }
+            }
+        }
+    }
+
+    // Finder Info dialog — file type and creator editor
+    if root.finder-info-visible : Rectangle {
+        x: 0; y: 0;
+        width: root.width;
+        height: root.height;
+        background: rgba(0, 0, 0, 0.45);
+
+        Rectangle {
+            width: 380px;
+            height: fi-content.preferred-height;
+            x: (parent.width - self.width) / 2;
+            y: (parent.height - self.height) / 2;
+            background: #f5f5f5;
+            border-radius: 8px;
+            drop-shadow-blur: 20px;
+            drop-shadow-color: rgba(0, 0, 0, 0.35);
+
+            fi-content := VerticalBox {
+                padding: 20px;
+                spacing: 14px;
+
+                Text {
+                    text: "Finder Info";
+                    font-size: 15px;
+                    font-weight: 700;
+                    horizontal-alignment: center;
+                    color: #1a1a1a;
+                }
+
+                Text {
+                    text: root.finder-info-path;
+                    wrap: word-wrap;
+                    horizontal-alignment: center;
+                    color: #555555;
+                    font-size: 11px;
+                }
+
+                HorizontalBox {
+                    Text { text: "File Type:"; min-width: 80px; vertical-alignment: center; color: #1a1a1a; }
+                    LineEdit {
+                        text <=> root.finder-info-type;
+                        placeholder-text: "    ";
+                        horizontal-stretch: 1;
+                        edited(t) => { root.finder-info-type = root.clamp-ostype(t); }
+                    }
+                }
+
+                HorizontalBox {
+                    Text { text: "Creator:"; min-width: 80px; vertical-alignment: center; color: #1a1a1a; }
+                    LineEdit {
+                        text <=> root.finder-info-creator;
+                        placeholder-text: "    ";
+                        horizontal-stretch: 1;
+                        edited(t) => { root.finder-info-creator = root.clamp-ostype(t); }
+                    }
+                }
+
+                HorizontalBox {
+                    alignment: center;
+                    spacing: 8px;
+                    Button {
+                        text: "Cancel";
+                        clicked => { root.finder-info-visible = false; }
+                    }
+                    Button {
+                        text: "Save";
+                        clicked => { root.save-finder-info(); }
                     }
                 }
             }

--- a/tailtalk/src/afp/mod.rs
+++ b/tailtalk/src/afp/mod.rs
@@ -4,4 +4,4 @@ mod volume;
 
 pub use desktop::DesktopDatabase;
 pub use server::{AfpServer, AfpServerConfig};
-pub use volume::{write_finder_info, Volume};
+pub use volume::{read_finder_info, write_finder_info, Volume};

--- a/tailtalk/src/afp/volume.rs
+++ b/tailtalk/src/afp/volume.rs
@@ -43,6 +43,37 @@ fn infer_type_creator_from_content(path: &Path) -> Option<TypeCreator> {
     }
 }
 
+/// Read the 32-byte Finder Info blob from the platform-native metadata store.
+/// Returns all-zeros if no Finder Info is set (does not infer from extension).
+pub fn read_finder_info(path: &Path) -> std::io::Result<[u8; 32]> {
+    #[cfg(unix)]
+    {
+        match xattr::get(path, FINDER_INFO_XATTR) {
+            Ok(Some(data)) if data.len() >= 32 => {
+                let mut info = [0u8; 32];
+                info.copy_from_slice(&data[0..32]);
+                Ok(info)
+            }
+            Ok(_) => Ok([0u8; 32]),
+            Err(e) => Err(e),
+        }
+    }
+    #[cfg(windows)]
+    {
+        let stream_path = format!("{}:{}", path.display(), FINDER_INFO_STREAM);
+        match std::fs::read(&stream_path) {
+            Ok(data) if data.len() >= 32 => {
+                let mut info = [0u8; 32];
+                info.copy_from_slice(&data[0..32]);
+                Ok(info)
+            }
+            Ok(_) => Ok([0u8; 32]),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok([0u8; 32]),
+            Err(e) => Err(e),
+        }
+    }
+}
+
 /// Write a 32-byte Finder Info blob directly to the platform-native metadata
 /// store for `path`.  The first 4 bytes are the file type, bytes 4–7 are the
 /// creator; the remainder may be zero.


### PR DESCRIPTION
Adds a new context menu button to view the current finder info (specifically the creator / file type) and optionally set it. This can be used to override the defaults set by TailTalk or a previous run.