### PR TITLE
AFP+GUI: Use a defined type for Finder Info, async-ify GUI

### DIFF
--- a/tailtalk-gui/main.rs
+++ b/tailtalk-gui/main.rs
@@ -160,6 +160,9 @@ fn main() -> anyhow::Result<()> {
 
     let _log_guard = init_logging();
 
+    let rt = tokio::runtime::Runtime::new()?;
+    let rt_handle = rt.handle().clone();
+
     let ui = AppWindow::new()?;
 
     // Inform the UI which transport sections to show
@@ -230,11 +233,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     let ui_handle = ui.as_weak();
-    std::thread::spawn(move || {
-        tokio::runtime::Runtime::new()
-            .unwrap()
-            .block_on(server_loop(cmd_rx, ui_handle));
-    });
+    rt_handle.spawn(server_loop(cmd_rx, ui_handle));
 
     let ui_weak = ui.as_weak();
     #[cfg(feature = "ethertalk")]
@@ -331,11 +330,13 @@ fn main() -> anyhow::Result<()> {
     });
 
     let ui_weak = ui.as_weak();
+    let rt_handle_bv = rt_handle.clone();
     ui.on_browse_volume(move || {
         let ui_weak = ui_weak.clone();
-        std::thread::spawn(move || {
-            if let Some(path) = rfd::FileDialog::new().pick_folder() {
-                let path_str: slint::SharedString = path.to_string_lossy().into_owned().into();
+        rt_handle_bv.spawn(async move {
+            if let Some(handle) = rfd::AsyncFileDialog::new().pick_folder().await {
+                let path_str: slint::SharedString =
+                    handle.path().to_string_lossy().into_owned().into();
                 slint::invoke_from_event_loop(move || {
                     if let Some(ui) = ui_weak.upgrade() {
                         ui.set_volume_path(path_str);
@@ -347,15 +348,18 @@ fn main() -> anyhow::Result<()> {
     });
 
     let ui_weak = ui.as_weak();
+    let rt_handle_bp = rt_handle.clone();
     ui.on_browse_pcap(move || {
         let ui_weak = ui_weak.clone();
-        std::thread::spawn(move || {
-            if let Some(path) = rfd::FileDialog::new()
+        rt_handle_bp.spawn(async move {
+            if let Some(handle) = rfd::AsyncFileDialog::new()
                 .add_filter("pcap capture", &["pcap"])
                 .set_file_name("tailtalk_capture.pcap")
                 .save_file()
+                .await
             {
-                let path_str: slint::SharedString = path.to_string_lossy().into_owned().into();
+                let path_str: slint::SharedString =
+                    handle.path().to_string_lossy().into_owned().into();
                 slint::invoke_from_event_loop(move || {
                     if let Some(ui) = ui_weak.upgrade() {
                         ui.set_pcap_path(path_str);
@@ -369,6 +373,7 @@ fn main() -> anyhow::Result<()> {
     ui.on_clamp_ostype(|s| s.chars().take(4).collect::<String>().into());
 
     let ui_weak = ui.as_weak();
+    let rt_handle_fi = rt_handle.clone();
     ui.on_inspect_finder_info(move || {
         let ui_weak = ui_weak.clone();
         let volume_path = ui_weak
@@ -376,16 +381,16 @@ fn main() -> anyhow::Result<()> {
             .map(|ui| ui.get_volume_path().to_string())
             .filter(|s| !s.is_empty())
             .map(PathBuf::from);
-        std::thread::spawn(move || {
-            let mut dialog = rfd::FileDialog::new().set_title("Choose a file to inspect");
+        rt_handle_fi.spawn(async move {
+            let mut dialog = rfd::AsyncFileDialog::new().set_title("Choose a file to inspect");
             if let Some(ref dir) = volume_path {
                 dialog = dialog.set_directory(dir);
             }
-            let Some(path) = dialog.pick_file() else {
-                return;
-            };
+            let path = dialog.pick_file().await.map(|h| h.path().to_path_buf());
 
-            let info = match tailtalk::afp::read_finder_info(&path) {
+            let Some(path) = path else { return };
+
+            let info = match tailtalk::afp::read_finder_info(&path).await {
                 Ok(v) => v,
                 Err(e) => {
                     let msg = format!("Could not read Finder Info: {e}");
@@ -399,9 +404,8 @@ fn main() -> anyhow::Result<()> {
                 }
             };
 
-            let type_str = ostype_to_string(&info[0..4]);
-            let creator_str = ostype_to_string(&info[4..8]);
-            // finder-info-path stores the actual file path (used for saving too)
+            let type_str = ostype_to_string(&info.file_type);
+            let creator_str = ostype_to_string(&info.creator);
             let path_str: SharedString = path.to_string_lossy().into_owned().into();
 
             slint::invoke_from_event_loop(move || {
@@ -417,31 +421,35 @@ fn main() -> anyhow::Result<()> {
     });
 
     let ui_weak = ui.as_weak();
+    let rt_handle_sfi = rt_handle.clone();
     ui.on_save_finder_info(move || {
         let Some(ui) = ui_weak.upgrade() else { return };
         let path = PathBuf::from(ui.get_finder_info_path().as_str());
+        let file_type = string_to_ostype(&ui.get_finder_info_type());
+        let creator = string_to_ostype(&ui.get_finder_info_creator());
+        let ui_weak = ui_weak.clone();
 
-        let type_bytes = string_to_ostype(&ui.get_finder_info_type());
-        let creator_bytes = string_to_ostype(&ui.get_finder_info_creator());
-
-        let mut info = tailtalk::afp::read_finder_info(&path).unwrap_or([0u8; 32]);
-        info[0..4].copy_from_slice(&type_bytes);
-        info[4..8].copy_from_slice(&creator_bytes);
-
-        match tailtalk::afp::write_finder_info(&path, &info) {
-            Ok(()) => {
-                ui.set_finder_info_visible(false);
-            }
-            Err(e) => {
-                let msg = format!("Could not write Finder Info: {e}");
-                ui.set_error_message(msg.into());
-            }
-        }
+        rt_handle_sfi.spawn(async move {
+            let mut info = tailtalk::afp::read_finder_info(&path).await.unwrap_or_default();
+            info.file_type = file_type;
+            info.creator = creator;
+            let result = tailtalk::afp::write_finder_info(&path, &info).await;
+            slint::invoke_from_event_loop(move || {
+                let Some(ui) = ui_weak.upgrade() else { return };
+                match result {
+                    Ok(()) => ui.set_finder_info_visible(false),
+                    Err(e) => ui.set_error_message(format!("Could not write Finder Info: {e}").into()),
+                }
+            })
+            .ok();
+        });
     });
 
     let ui_weak = ui.as_weak();
+    let rt_handle_sit = rt_handle.clone();
     ui.on_import_stuffit(move || {
         let ui_weak = ui_weak.clone();
+        let rt_handle_sit = rt_handle_sit.clone();
 
         let (volume_path, is_running) = {
             let Some(ui) = ui_weak.upgrade() else { return };
@@ -463,16 +471,18 @@ fn main() -> anyhow::Result<()> {
             return;
         }
 
-        std::thread::spawn(move || {
-            let Some(sit_path) = rfd::FileDialog::new()
+        rt_handle_sit.spawn(async move {
+            let Some(handle) = rfd::AsyncFileDialog::new()
                 .add_filter("StuffIt Archive", &["sit"])
                 .set_title("Import StuffIt Archive")
                 .pick_file()
+                .await
             else {
                 return;
             };
+            let sit_path = handle.path().to_path_buf();
 
-            match extract_sit(&sit_path, &volume_path) {
+            match extract_sit(&sit_path, &volume_path).await {
                 Ok(count) => show_info(
                     ui_weak,
                     format!("Extracted {count} file(s) from the archive successfully."),
@@ -993,8 +1003,8 @@ fn register_appl_from_resource_fork(
 
 /// Extract a StuffIt archive into `volume_path`, placing resource fork sidecars
 /// under `<volume_path>/.tailtalk/rsrc/<relative_path>` to match TailTalk's layout.
-fn extract_sit(sit_path: &Path, volume_path: &Path) -> Result<usize, String> {
-    let bytes = std::fs::read(sit_path)
+async fn extract_sit(sit_path: &Path, volume_path: &Path) -> Result<usize, String> {
+    let bytes = tokio::fs::read(sit_path).await
         .map_err(|e| format!("Failed to read archive: {e}"))?;
 
     let archive = stuffit::SitArchive::parse(&bytes)
@@ -1020,7 +1030,7 @@ fn extract_sit(sit_path: &Path, volume_path: &Path) -> Result<usize, String> {
         }
 
         if entry.is_folder {
-            std::fs::create_dir_all(volume_path.join(&rel))
+            tokio::fs::create_dir_all(volume_path.join(&rel)).await
                 .map_err(|e| format!("Failed to create '{}': {e}", rel.display()))?;
             continue;
         }
@@ -1029,7 +1039,7 @@ fn extract_sit(sit_path: &Path, volume_path: &Path) -> Result<usize, String> {
         if let Some(parent) = rel.parent()
             && !parent.as_os_str().is_empty()
         {
-            std::fs::create_dir_all(volume_path.join(parent))
+            tokio::fs::create_dir_all(volume_path.join(parent)).await
                 .map_err(|e| format!("Failed to create parent for '{}': {e}", rel.display()))?;
         }
 
@@ -1040,26 +1050,28 @@ fn extract_sit(sit_path: &Path, volume_path: &Path) -> Result<usize, String> {
         // Always create the data fork file, even when empty, so that AFP can
         // serve the resource fork sidecar for resource-only files (e.g. apps).
         let dest = volume_path.join(&rel);
-        std::fs::write(&dest, &data_fork)
+        tokio::fs::write(&dest, &data_fork).await
             .map_err(|e| format!("Failed to write '{}': {e}", dest.display()))?;
         file_count += 1;
 
         // Preserve the Mac file type and creator from the archive so that AFP
         // reports correct FinderInfo (the Finder needs type=APPL to launch apps).
-        let mut finder_info = [0u8; 32];
-        finder_info[0..4].copy_from_slice(&entry.file_type);
-        finder_info[4..8].copy_from_slice(&entry.creator);
-        if let Err(e) = tailtalk::afp::write_finder_info(&dest, &finder_info) {
+        let finder_info = tailtalk::afp::FinderInfo {
+            file_type: entry.file_type,
+            creator: entry.creator,
+            ..Default::default()
+        };
+        if let Err(e) = tailtalk::afp::write_finder_info(&dest, &finder_info).await {
             tracing::warn!("Could not set FinderInfo for '{}': {e}", rel.display());
         }
 
         if !rsrc_fork.is_empty() {
             let rsrc_dest = volume_path.join(".tailtalk").join("rsrc").join(&rel);
             if let Some(parent) = rsrc_dest.parent() {
-                std::fs::create_dir_all(parent)
+                tokio::fs::create_dir_all(parent).await
                     .map_err(|e| format!("Failed to create rsrc dir for '{}': {e}", rel.display()))?;
             }
-            std::fs::write(&rsrc_dest, &rsrc_fork)
+            tokio::fs::write(&rsrc_dest, &rsrc_fork).await
                 .map_err(|e| format!("Failed to write resource fork for '{}': {e}", rel.display()))?;
 
             let file_name = rel.file_name().and_then(|n| n.to_str()).unwrap_or("");

--- a/tailtalk-packets/src/afp/types.rs
+++ b/tailtalk-packets/src/afp/types.rs
@@ -1,3 +1,49 @@
+use bitflags::bitflags;
+
+bitflags! {
+    /// Finder flags word (fdFlags / frFlags) stored in bytes 8–9 of the 32-byte Finder Info blob.
+    ///
+    /// Bit definitions from *Inside Macintosh: Files* and the Finder Interface chapter.
+    /// Bits 1–3 encode a 3-bit label/colour index and are not representable as individual
+    /// flags; read them with `FinderFlags::label()` instead.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+    pub struct FinderFlags: u16 {
+        /// Icon is on the desktop (MFS only; ignored by HFS).
+        const IS_ON_DESK      = 0x0001;
+        /// Application can be launched by multiple users at the same time.
+        const IS_SHARED       = 0x0040;
+        /// Application has no system-extension (INIT) resources.
+        const HAS_NO_INITS    = 0x0080;
+        /// The Finder has already loaded the application's bundle resources.
+        const HAS_BEEN_INITED = 0x0100;
+        /// File has a custom icon stored in its resource fork.
+        const HAS_CUSTOM_ICON = 0x0400;
+        /// File is a stationery pad; opening it creates a copy.
+        const IS_STATIONERY   = 0x0800;
+        /// File's name cannot be changed in the Finder.
+        const NAME_LOCKED     = 0x1000;
+        /// File has a `'BNDL'` resource associating icons with file types.
+        const HAS_BUNDLE      = 0x2000;
+        /// File is hidden from the Finder's directory listings.
+        const IS_INVISIBLE    = 0x4000;
+        /// File is an alias (points to another file or folder).
+        const IS_ALIAS        = 0x8000;
+    }
+}
+
+impl FinderFlags {
+    /// Extract the 3-bit label/colour index from bits 1–3 (values 0–7).
+    /// 0 means no label; 1–7 correspond to the seven Finder label colours.
+    pub fn label(self) -> u8 {
+        ((self.bits() & 0x000E) >> 1) as u8
+    }
+
+    /// Return a copy of these flags with the label index set to `value` (0–7).
+    pub fn with_label(self, value: u8) -> Self {
+        Self::from_bits_retain((self.bits() & !0x000E) | (((value as u16) & 0x7) << 1))
+    }
+}
+
 /// AFP Error Codes. For AppleTalk implementations these result codes are passed via the
 /// ASP CmdResult field (i.e the 4 user bytes of an ATP packet)
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -183,6 +229,47 @@ impl From<CreateFlag> for u8 {
 pub enum FileType {
     Directory,
     File,
+}
+
+/// The 32-byte Finder Info blob stored as the `com.apple.FinderInfo` xattr.
+///
+/// Layout (Inside Macintosh, Files):
+///   [0..4]   file_type  — OSType (e.g. `TEXT`, `APPL`)
+///   [4..8]   creator    — OSType (e.g. `ttxt`, `MACS`)
+///   [8..10]  flags      — fdFlags / frFlags (big-endian u16)
+///   [10..32] reserved   — icon position, folder ref, extended info
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct FinderInfo {
+    pub file_type: [u8; 4],
+    pub creator: [u8; 4],
+    pub flags: FinderFlags,
+    pub reserved: [u8; 22],
+}
+
+impl From<[u8; 32]> for FinderInfo {
+    fn from(raw: [u8; 32]) -> Self {
+        let mut reserved = [0u8; 22];
+        reserved.copy_from_slice(&raw[10..32]);
+        Self {
+            file_type: raw[0..4].try_into().unwrap(),
+            creator: raw[4..8].try_into().unwrap(),
+            flags: FinderFlags::from_bits_retain(u16::from_be_bytes([raw[8], raw[9]])),
+            reserved,
+        }
+    }
+}
+
+impl From<FinderInfo> for [u8; 32] {
+    fn from(info: FinderInfo) -> Self {
+        let mut raw = [0u8; 32];
+        raw[0..4].copy_from_slice(&info.file_type);
+        raw[4..8].copy_from_slice(&info.creator);
+        let flags = info.flags.bits().to_be_bytes();
+        raw[8] = flags[0];
+        raw[9] = flags[1];
+        raw[10..32].copy_from_slice(&info.reserved);
+        raw
+    }
 }
 
 impl From<u8> for FileType {

--- a/tailtalk/src/afp/mod.rs
+++ b/tailtalk/src/afp/mod.rs
@@ -4,4 +4,5 @@ mod volume;
 
 pub use desktop::DesktopDatabase;
 pub use server::{AfpServer, AfpServerConfig};
+pub use tailtalk_packets::afp::{FinderFlags, FinderInfo};
 pub use volume::{read_finder_info, write_finder_info, Volume};

--- a/tailtalk/src/afp/volume.rs
+++ b/tailtalk/src/afp/volume.rs
@@ -4,8 +4,8 @@ use std::time::SystemTime;
 
 use tailtalk_packets::afp::{
     AfpError, CreateFlag, FPByteRangeLockFlags, FPDelete, FPDirectoryBitmap, FPEnumerate,
-    FPFileBitmap, FPRead, FPSetForkParms, FPVolume, FPVolumeBitmap, FileType, ForkType,
-    VolumeSignature,
+    FPFileBitmap, FPRead, FPSetForkParms, FPVolume, FPVolumeBitmap, FileType, FinderFlags,
+    FinderInfo, ForkType, VolumeSignature,
 };
 
 use crate::time_to_afp_v1;
@@ -43,50 +43,52 @@ fn infer_type_creator_from_content(path: &Path) -> Option<TypeCreator> {
     }
 }
 
-/// Read the 32-byte Finder Info blob from the platform-native metadata store.
-/// Returns all-zeros if no Finder Info is set (does not infer from extension).
-pub fn read_finder_info(path: &Path) -> std::io::Result<[u8; 32]> {
-    #[cfg(unix)]
-    {
-        match xattr::get(path, FINDER_INFO_XATTR) {
-            Ok(Some(data)) if data.len() >= 32 => {
-                let mut info = [0u8; 32];
-                info.copy_from_slice(&data[0..32]);
-                Ok(info)
+/// Read Finder Info from the platform-native metadata store.
+/// Returns a zeroed `FinderInfo` if no attribute is set (does not infer from extension).
+pub async fn read_finder_info(path: &Path) -> std::io::Result<FinderInfo> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        #[cfg(unix)]
+        {
+            match xattr::get(&path, FINDER_INFO_XATTR) {
+                Ok(Some(data)) if data.len() >= 32 => {
+                    Ok(FinderInfo::from(<[u8; 32]>::try_from(&data[0..32]).unwrap()))
+                }
+                Ok(_) => Ok(FinderInfo::default()),
+                Err(e) => Err(e),
             }
-            Ok(_) => Ok([0u8; 32]),
-            Err(e) => Err(e),
         }
-    }
-    #[cfg(windows)]
-    {
-        let stream_path = format!("{}:{}", path.display(), FINDER_INFO_STREAM);
-        match std::fs::read(&stream_path) {
-            Ok(data) if data.len() >= 32 => {
-                let mut info = [0u8; 32];
-                info.copy_from_slice(&data[0..32]);
-                Ok(info)
+        #[cfg(windows)]
+        {
+            let stream_path = format!("{}:{}", path.display(), FINDER_INFO_STREAM);
+            match std::fs::read(&stream_path) {
+                Ok(data) if data.len() >= 32 => {
+                    Ok(FinderInfo::from(<[u8; 32]>::try_from(&data[0..32]).unwrap()))
+                }
+                Ok(_) => Ok(FinderInfo::default()),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(FinderInfo::default()),
+                Err(e) => Err(e),
             }
-            Ok(_) => Ok([0u8; 32]),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok([0u8; 32]),
-            Err(e) => Err(e),
         }
-    }
+    })
+    .await
+    .map_err(std::io::Error::other)?
 }
 
-/// Write a 32-byte Finder Info blob directly to the platform-native metadata
-/// store for `path`.  The first 4 bytes are the file type, bytes 4–7 are the
-/// creator; the remainder may be zero.
-pub fn write_finder_info(path: &Path, info: &[u8; 32]) -> std::io::Result<()> {
+/// Write Finder Info to the platform-native metadata store.
+pub async fn write_finder_info(path: &Path, info: &FinderInfo) -> std::io::Result<()> {
+    let raw: [u8; 32] = (*info).into();
+    let path = path.to_path_buf();
     #[cfg(unix)]
-    {
-        xattr::set(path, FINDER_INFO_XATTR, info)
-    }
+    tokio::task::spawn_blocking(move || xattr::set(&path, FINDER_INFO_XATTR, &raw))
+        .await
+        .map_err(std::io::Error::other)??;
     #[cfg(windows)]
     {
         let stream_path = format!("{}:{}", path.display(), FINDER_INFO_STREAM);
-        std::fs::write(&stream_path, info)
+        tokio::fs::write(&stream_path, &raw).await?;
     }
+    Ok(())
 }
 
 #[derive(Debug)]
@@ -142,99 +144,56 @@ impl Node {
     /// Read Finder Info from the platform-native metadata store.
     /// If no Finder Info exists for a file, attempts to infer type/creator from
     /// the file extension and persists the result so future reads are consistent.
-    pub fn get_finder_info(&self, volume_root: &Path) -> [u8; 32] {
+    pub async fn get_finder_info(&self, volume_root: &Path) -> FinderInfo {
         let absolute_path = volume_root.join(&self.path);
-        let stored = {
-            #[cfg(unix)]
-            {
-                match xattr::get(&absolute_path, FINDER_INFO_XATTR) {
-                    Ok(Some(data)) if data.len() >= 32 => {
-                        let mut info = [0u8; 32];
-                        info.copy_from_slice(&data[0..32]);
-                        info
-                    }
-                    _ => [0u8; 32],
-                }
-            }
-            #[cfg(windows)]
-            {
-                let stream_path = format!("{}:{}", absolute_path.display(), FINDER_INFO_STREAM);
-                match std::fs::read(&stream_path) {
-                    Ok(data) if data.len() >= 32 => {
-                        let mut info = [0u8; 32];
-                        info.copy_from_slice(&data[0..32]);
-                        info
-                    }
-                    _ => [0u8; 32],
-                }
-            }
-        };
+        let stored = read_finder_info(&absolute_path).await.unwrap_or_default();
 
-        if stored == [0u8; 32]
-            && !self.is_dir
-            && let Some(tc) = infer_type_creator_from_content(&absolute_path)
-        {
-            let mut inferred = [0u8; 32];
-            inferred[0..4].copy_from_slice(&tc.file_type);
-            inferred[4..8].copy_from_slice(&tc.creator);
-            if let Err(e) = write_finder_info(&absolute_path, &inferred) {
-                error!("Failed to persist inferred Finder Info for {:?}: {:?}", self.path, e);
+        if stored == FinderInfo::default() && !self.is_dir {
+            let abs = absolute_path.clone();
+            let maybe_tc = tokio::task::spawn_blocking(move || infer_type_creator_from_content(&abs))
+                .await
+                .unwrap_or(None);
+            if let Some(tc) = maybe_tc {
+                let inferred = FinderInfo {
+                    file_type: tc.file_type,
+                    creator: tc.creator,
+                    ..Default::default()
+                };
+                if let Err(e) = write_finder_info(&absolute_path, &inferred).await {
+                    error!("Failed to persist inferred Finder Info for {:?}: {:?}", self.path, e);
+                }
+                return inferred;
             }
-            return inferred;
         }
 
         stored
     }
 
     /// Write Finder Info to the platform-native metadata store.
-    pub fn set_finder_info(&self, volume_root: &Path, info: &[u8; 32]) -> Result<(), AfpError> {
-        let absolute_path = volume_root.join(&self.path);
-        #[cfg(unix)]
-        {
-            xattr::set(&absolute_path, FINDER_INFO_XATTR, info).map_err(|e| {
-                error!("Failed to set Finder Info for {:?}: {:?}", self.path, e);
-                AfpError::AccessDenied
-            })
-        }
-        #[cfg(windows)]
-        {
-            let stream_path = format!("{}:{}", absolute_path.display(), FINDER_INFO_STREAM);
-            std::fs::write(&stream_path, info).map_err(|e| {
-                error!("Failed to set Finder Info for {:?}: {:?}", self.path, e);
-                AfpError::AccessDenied
-            })
-        }
+    pub async fn set_finder_info(&self, volume_root: &Path, info: &FinderInfo) -> Result<(), AfpError> {
+        write_finder_info(&volume_root.join(&self.path), info).await.map_err(|e| {
+            error!("Failed to set Finder Info for {:?}: {:?}", self.path, e);
+            AfpError::AccessDenied
+        })
     }
 
     /// Get AFP file/dir attributes derived from the Finder Info xattr.
     /// Bit 0 (Invisible) maps to fdFlags bit 14 (kIsInvisible, 0x4000).
-    pub fn get_attributes(&self, volume_root: &Path) -> u16 {
-        let finder_info = self.get_finder_info(volume_root);
-        let fd_flags = u16::from_be_bytes([finder_info[8], finder_info[9]]);
-        let mut attrs: u16 = 0;
-        if fd_flags & 0x4000 != 0 {
-            attrs |= 0x0001; // Invisible
-        }
-        attrs
+    pub async fn get_attributes(&self, volume_root: &Path) -> u16 {
+        let finder_info = self.get_finder_info(volume_root).await;
+        if finder_info.flags.contains(FinderFlags::IS_INVISIBLE) { 0x0001 } else { 0 }
     }
 
     /// Set AFP Attributes by updating Finder Info (e.g. Invisible bit)
-    pub fn set_attributes(&self, volume_root: &Path, attributes: u16) -> Result<(), AfpError> {
-        let mut finder_info = self.get_finder_info(volume_root);
-        let mut fd_flags = u16::from_be_bytes([finder_info[8], finder_info[9]]);
-
-        // AFP Attribute Invisible (Bit 0) -> kIsInvisible (Bit 14, 0x4000)
+    pub async fn set_attributes(&self, volume_root: &Path, attributes: u16) -> Result<(), AfpError> {
+        let mut finder_info = self.get_finder_info(volume_root).await;
+        // AFP Attribute Invisible (Bit 0) -> kIsInvisible (Bit 14)
         if (attributes & 0x0001) != 0 {
-            fd_flags |= 0x4000;
+            finder_info.flags |= FinderFlags::IS_INVISIBLE;
         } else {
-            fd_flags &= !0x4000;
+            finder_info.flags &= !FinderFlags::IS_INVISIBLE;
         }
-
-        let fd_flags_bytes = fd_flags.to_be_bytes();
-        finder_info[8] = fd_flags_bytes[0];
-        finder_info[9] = fd_flags_bytes[1];
-
-        self.set_finder_info(volume_root, &finder_info)
+        self.set_finder_info(volume_root, &finder_info).await
     }
 
     /// Process file parameter bitmap and write response to output buffer.
@@ -254,7 +213,7 @@ impl Node {
             .map_err(|_| AfpError::ObjectNotFound)?;
 
         if bitmap.contains(FPFileBitmap::ATTRIBUTES) {
-            let attributes = self.get_attributes(volume_root);
+            let attributes = self.get_attributes(volume_root).await;
             output[offset..offset + 2].copy_from_slice(&attributes.to_be_bytes());
             offset += 2;
         }
@@ -282,8 +241,8 @@ impl Node {
         }
 
         if bitmap.contains(FPFileBitmap::FINDER_INFO) {
-            let finder_info = self.get_finder_info(volume_root);
-            output[offset..offset + 32].copy_from_slice(&finder_info);
+            let raw: [u8; 32] = self.get_finder_info(volume_root).await.into();
+            output[offset..offset + 32].copy_from_slice(&raw);
             offset += 32;
         }
 
@@ -567,7 +526,7 @@ impl Volume {
         };
         if has_attributes {
             let attributes = u16::from_be_bytes([data[offset], data[offset + 1]]);
-            node.set_attributes(&volume_root, attributes)?;
+            node.set_attributes(&volume_root, attributes).await?;
             offset += 2;
         }
 
@@ -608,9 +567,8 @@ impl Volume {
             file_bitmap.contains(FPFileBitmap::FINDER_INFO)
         };
         if has_finder_info {
-            let mut finder_info = [0u8; 32];
-            finder_info.copy_from_slice(&data[offset..offset + 32]);
-            node.set_finder_info(&volume_root, &finder_info)?;
+            let raw: [u8; 32] = data[offset..offset + 32].try_into().unwrap();
+            node.set_finder_info(&volume_root, &FinderInfo::from(raw)).await?;
         }
 
         Ok(())
@@ -747,7 +705,7 @@ impl Volume {
             let mut read_dir = tokio::fs::read_dir(&current_dir).await?;
             while let Some(entry) = read_dir.next_entry().await? {
                 let name = entry.file_name().to_string_lossy().to_string();
-                if name == ".tailtalk" {
+                if name == ".tailtalk" || name == ".AppleDesktop" {
                     continue;
                 }
 
@@ -800,7 +758,7 @@ impl Volume {
 
         while let Some(entry) = read_dir.next_entry().await? {
             let name = entry.file_name().to_string_lossy().to_string();
-            if name == ".tailtalk" {
+            if name == ".tailtalk" || name == ".AppleDesktop" {
                 continue;
             }
             let rel_path = dir_path.join(&name);
@@ -986,7 +944,7 @@ impl Volume {
         while let Some(entry) = entries.next_entry().await? {
             let name = entry.file_name();
             let name = name.to_string_lossy();
-            if name == ".tailtalk" {
+            if name == ".tailtalk" || name == ".AppleDesktop" {
                 continue;
             }
             count = count.saturating_add(1);
@@ -1012,7 +970,7 @@ impl Volume {
         let full_path = self.path.join(relative_path);
 
         if bitmap.contains(FPDirectoryBitmap::ATTRIBUTES) {
-            let attributes = node.get_attributes(&self.path);
+            let attributes = node.get_attributes(&self.path).await;
             output[offset..offset + 2].copy_from_slice(&attributes.to_be_bytes());
             offset += 2;
         }
@@ -1041,8 +999,8 @@ impl Volume {
         }
 
         if bitmap.contains(FPDirectoryBitmap::FINDER_INFO) {
-            let finder_info = node.get_finder_info(&self.path);
-            output[offset..offset + 32].copy_from_slice(&finder_info);
+            let raw: [u8; 32] = node.get_finder_info(&self.path).await.into();
+            output[offset..offset + 32].copy_from_slice(&raw);
             offset += 32;
         }
 
@@ -1478,7 +1436,7 @@ impl Volume {
             .map_err(|_| AfpError::ObjectNotFound)?
         {
             let name = entry.file_name().to_string_lossy().to_string();
-            if name == ".tailtalk" {
+            if name == ".tailtalk" || name == ".AppleDesktop" {
                 continue;
             }
 


### PR DESCRIPTION
Moves our code off of hand rolling and unrolling the 32-byte finder info and instead to a real type that we can serialise and deserialise to. Updated all call sites to use this new one.

Additionally async-ifies our GUI versus the awkward scattered thread creation everywhere. As part of this our TailTalk side code has shedded the sync FS calls in favour of Tokio async ones.

No notable change is expected here for end-users, purely an API level tweak and cleanup.