### PR TITLE
Code cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5531,7 +5531,6 @@ dependencies = [
  "mac_address",
  "magic-db",
  "pcap",
- "pure-magic",
  "rand",
  "sled",
  "tailtalk-packets",
@@ -5601,6 +5600,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ anyhow = "^1.0.102" #unified
 byteorder = "^1.5.0" #unified
 bytes = "^1.11.1" #unified
 clap = { version = "^4.6.0", features = ["derive"] } #unified
+encoding_rs = "^0.8.35" #unified
 futures = "^0.3.32" #unified
+hfs-reader = { path = "hfs-reader", version = "^0.1.1" } #unified
 tailtalk = { path = "tailtalk" } #unified
 tailtalk-packets = { path = "tailtalk-packets", version = "^0.4" } #unified
 tashtalk = { path = "tashtalk", version = "^0.2" } #unified

--- a/examples/adsp-stylewriter/main.rs
+++ b/examples/adsp-stylewriter/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use tailtalk::{
     TalkStack,
-    adsp::{Adsp, AdspAddress},
+    adsp::AdspAddress,
     stylewriter::StyleWriterEncoder,
 };
 use tailtalk_packets::nbp::EntityName;
@@ -72,7 +72,7 @@ async fn main() -> anyhow::Result<()> {
     let planar_scanline_len = width_pixels / 8;
 
     println!("Connecting ADSP session to printer...");
-    let mut adsp_stream = Adsp::connect(&stack.ddp, printer_addr).await?;
+    let mut adsp_stream = stack.connect_adsp(printer_addr).await?;
     println!("ADSP session established!");
 
     // Send the initialization boundaries

--- a/examples/afp-server/main.rs
+++ b/examples/afp-server/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use std::path::PathBuf;
 use tailtalk::{
     TalkStack,
-    afp::{AfpServer, AfpServerConfig},
+    afp::AfpServerConfig,
 };
 
 #[derive(Parser, Debug)]
@@ -51,7 +51,7 @@ async fn main() {
         ..AfpServerConfig::default()
     };
 
-    let _afp_server = AfpServer::spawn(&stack.ddp, &stack.nbp, Some(254), afp_config, stack.token(), stack.services_done_token())
+    let _afp_server = stack.spawn_afp(Some(254), afp_config)
         .await
         .expect("failed to spawn AFP server");
 

--- a/examples/pap-print/main.rs
+++ b/examples/pap-print/main.rs
@@ -1,8 +1,7 @@
 use clap::Parser;
 use tailtalk::{
     TalkStack,
-    atp::{Atp, AtpAddress},
-    pap::PapClient,
+    atp::AtpAddress,
 };
 use tailtalk_packets::nbp::EntityName;
 
@@ -40,10 +39,6 @@ async fn main() -> anyhow::Result<()> {
         .await
         .expect("failed to build AppleTalk stack");
 
-    // Two ATP sockets: one for sending requests, one for receiving printer-initiated ones
-    let (_req_sock, atp_requestor, _) = Atp::spawn(&stack.ddp, None).await;
-    let (_resp_sock, _, atp_responder) = Atp::spawn(&stack.ddp, None).await;
-
     // Locate the printer via NBP
     println!("Looking up printer '{}'...", entity);
     let tuples = stack.nbp.lookup(entity).await?;
@@ -64,8 +59,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Query status
     println!("Querying printer status...");
-    let status_requestor = atp_requestor.clone();
-    match PapClient::get_status(status_requestor, printer_addr).await {
+    match stack.pap_status(printer_addr).await {
         Ok(status) => println!("Printer status: '{}'", status),
         Err(e) => println!("Could not get status: {}", e),
     }
@@ -89,7 +83,7 @@ showpage
     };
 
     println!("Connecting to printer ({} bytes to send)...", data.len());
-    let mut client = PapClient::new(atp_requestor, atp_responder);
+    let mut client = stack.pap_client().await;
     client.connect(printer_addr).await?;
 
     println!("Printing...");

--- a/tailtalk-gui/Cargo.toml
+++ b/tailtalk-gui/Cargo.toml
@@ -15,21 +15,21 @@ ethertalk = ["dep:if-addrs"]
 
 [dependencies]
 anyhow = { workspace = true } #unified
+dirs = "5"
+hfs-reader = { workspace = true } #unified
+if-addrs = { version = "0.13", optional = true }
 rfd = "0.15"
+serde = { version = "1", features = ["derive"] }
+serialport = { version = "4", optional = true }
 slint = "1"
+stuffit = "0.1.4"
 tailtalk = { workspace = true } #unified
 tailtalk-packets = { workspace = true } #unified
 tokio = { workspace = true, features = ["io-util"] } #unified
-tracing = { workspace = true } #unified
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tracing-appender = "0.2"
-dirs = "5"
-serde = { version = "1", features = ["derive"] }
 toml = "0.8"
-if-addrs = { version = "0.13", optional = true }
-serialport = { version = "4", optional = true }
-stuffit = "0.1.4"
-hfs-reader = { path = "../hfs-reader" }
+tracing = { workspace = true } #unified
+tracing-appender = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [build-dependencies]
 slint-build = "1"

--- a/tailtalk-gui/main.rs
+++ b/tailtalk-gui/main.rs
@@ -370,7 +370,7 @@ fn main() -> anyhow::Result<()> {
         });
     });
 
-    ui.on_clamp_ostype(|s| s.chars().take(4).collect::<String>().into());
+    ui.on_clamp_to_one(|s| s.chars().next().map_or(String::new(), |c| c.to_string()).into());
 
     let ui_weak = ui.as_weak();
     let rt_handle_fi = rt_handle.clone();
@@ -404,14 +404,20 @@ fn main() -> anyhow::Result<()> {
                 }
             };
 
-            let type_str = ostype_to_string(&info.file_type);
-            let creator_str = ostype_to_string(&info.creator);
+            let type_chars = ostype_to_chars(&info.file_type);
+            let creator_chars = ostype_to_chars(&info.creator);
             let path_str: SharedString = path.to_string_lossy().into_owned().into();
 
             slint::invoke_from_event_loop(move || {
                 if let Some(ui) = ui_weak.upgrade() {
-                    ui.set_finder_info_type(type_str.into());
-                    ui.set_finder_info_creator(creator_str.into());
+                    ui.set_finder_info_type_0(type_chars[0].clone());
+                    ui.set_finder_info_type_1(type_chars[1].clone());
+                    ui.set_finder_info_type_2(type_chars[2].clone());
+                    ui.set_finder_info_type_3(type_chars[3].clone());
+                    ui.set_finder_info_creator_0(creator_chars[0].clone());
+                    ui.set_finder_info_creator_1(creator_chars[1].clone());
+                    ui.set_finder_info_creator_2(creator_chars[2].clone());
+                    ui.set_finder_info_creator_3(creator_chars[3].clone());
                     ui.set_finder_info_path(path_str);
                     ui.set_finder_info_visible(true);
                 }
@@ -425,8 +431,22 @@ fn main() -> anyhow::Result<()> {
     ui.on_save_finder_info(move || {
         let Some(ui) = ui_weak.upgrade() else { return };
         let path = PathBuf::from(ui.get_finder_info_path().as_str());
-        let file_type = string_to_ostype(&ui.get_finder_info_type());
-        let creator = string_to_ostype(&ui.get_finder_info_creator());
+        let type_str = format!(
+            "{}{}{}{}",
+            ui.get_finder_info_type_0(),
+            ui.get_finder_info_type_1(),
+            ui.get_finder_info_type_2(),
+            ui.get_finder_info_type_3(),
+        );
+        let creator_str = format!(
+            "{}{}{}{}",
+            ui.get_finder_info_creator_0(),
+            ui.get_finder_info_creator_1(),
+            ui.get_finder_info_creator_2(),
+            ui.get_finder_info_creator_3(),
+        );
+        let file_type = string_to_ostype(&type_str);
+        let creator = string_to_ostype(&creator_str);
         let ui_weak = ui_weak.clone();
 
         rt_handle_sfi.spawn(async move {
@@ -683,6 +703,15 @@ fn show_info(ui_weak: slint::Weak<AppWindow>, message: String) {
 }
 
 // ── OSType (4-byte Mac type/creator code) helpers ────────────────────────────
+
+/// Split a 4-byte OSType into 4 individual SharedStrings for the per-character UI boxes.
+fn ostype_to_chars(bytes: &[u8]) -> [SharedString; 4] {
+    let s = ostype_to_string(bytes);
+    let mut chars = s.chars();
+    std::array::from_fn(|_| {
+        chars.next().map_or(SharedString::default(), |c| c.to_string().into())
+    })
+}
 
 /// Convert a 4-byte OSType to a displayable string, replacing non-graphic bytes with spaces.
 fn ostype_to_string(bytes: &[u8]) -> String {
@@ -1311,7 +1340,7 @@ async fn run_server(
 ) {
     use tailtalk::{
         TalkStack,
-        afp::{AfpServer, AfpServerConfig},
+        afp::AfpServerConfig,
     };
 
     let set_stopped = |ui_weak: slint::Weak<AppWindow>| {
@@ -1407,7 +1436,7 @@ async fn run_server(
         ..AfpServerConfig::default()
     };
 
-    let _afp = match AfpServer::spawn(&stack.ddp, &stack.nbp, Some(254), afp_config, stack.token(), stack.services_done_token()).await {
+    let _afp = match stack.spawn_afp(Some(254), afp_config).await {
         Ok(s) => s,
         Err(e) => {
             let msg = format!("Failed to start AFP server:\n{e}");

--- a/tailtalk-gui/ui/app.slint
+++ b/tailtalk-gui/ui/app.slint
@@ -26,8 +26,14 @@ export component AppWindow inherits Window {
 
     in-out property <bool> finder-info-visible: false;
     in-out property <string> finder-info-path: "";
-    in-out property <string> finder-info-type: "";
-    in-out property <string> finder-info-creator: "";
+    in-out property <string> finder-info-type-0: "";
+    in-out property <string> finder-info-type-1: "";
+    in-out property <string> finder-info-type-2: "";
+    in-out property <string> finder-info-type-3: "";
+    in-out property <string> finder-info-creator-0: "";
+    in-out property <string> finder-info-creator-1: "";
+    in-out property <string> finder-info-creator-2: "";
+    in-out property <string> finder-info-creator-3: "";
 
     callback start-stop();
     callback browse-volume();
@@ -36,8 +42,8 @@ export component AppWindow inherits Window {
     callback import-hfs-image();
     callback inspect-finder-info();
     callback save-finder-info();
-    // Returns the input truncated to 4 characters; registered in Rust.
-    callback clamp-ostype(string) -> string;
+    // Returns the input truncated to 1 character; registered in Rust.
+    callback clamp-to-one(string) -> string;
 
     MenuBar {
         Menu {
@@ -290,22 +296,90 @@ export component AppWindow inherits Window {
 
                 HorizontalBox {
                     Text { text: "File Type:"; min-width: 80px; vertical-alignment: center; color: #1a1a1a; }
-                    LineEdit {
-                        text <=> root.finder-info-type;
-                        placeholder-text: "    ";
-                        horizontal-stretch: 1;
-                        edited(t) => { root.finder-info-type = root.clamp-ostype(t); }
+                    HorizontalBox {
+                        spacing: 4px;
+                        padding: 0;
+                        type-edit-0 := LineEdit {
+                            width: 36px;
+                            text <=> root.finder-info-type-0;
+                            horizontal-alignment: center;
+                            edited(t) => {
+                                root.finder-info-type-0 = root.clamp-to-one(t);
+                                if (t != "") { type-edit-1.focus(); }
+                            }
+                        }
+                        type-edit-1 := LineEdit {
+                            width: 36px;
+                            text <=> root.finder-info-type-1;
+                            horizontal-alignment: center;
+                            edited(t) => {
+                                root.finder-info-type-1 = root.clamp-to-one(t);
+                                if (t != "") { type-edit-2.focus(); }
+                            }
+                        }
+                        type-edit-2 := LineEdit {
+                            width: 36px;
+                            text <=> root.finder-info-type-2;
+                            horizontal-alignment: center;
+                            edited(t) => {
+                                root.finder-info-type-2 = root.clamp-to-one(t);
+                                if (t != "") { type-edit-3.focus(); }
+                            }
+                        }
+                        type-edit-3 := LineEdit {
+                            width: 36px;
+                            text <=> root.finder-info-type-3;
+                            horizontal-alignment: center;
+                            edited(t) => {
+                                root.finder-info-type-3 = root.clamp-to-one(t);
+                            }
+                        }
                     }
+                    Rectangle { horizontal-stretch: 1; }
                 }
 
                 HorizontalBox {
                     Text { text: "Creator:"; min-width: 80px; vertical-alignment: center; color: #1a1a1a; }
-                    LineEdit {
-                        text <=> root.finder-info-creator;
-                        placeholder-text: "    ";
-                        horizontal-stretch: 1;
-                        edited(t) => { root.finder-info-creator = root.clamp-ostype(t); }
+                    HorizontalBox {
+                        spacing: 4px;
+                        padding: 0;
+                        creator-edit-0 := LineEdit {
+                            width: 36px;
+                            text <=> root.finder-info-creator-0;
+                            horizontal-alignment: center;
+                            edited(t) => {
+                                root.finder-info-creator-0 = root.clamp-to-one(t);
+                                if (t != "") { creator-edit-1.focus(); }
+                            }
+                        }
+                        creator-edit-1 := LineEdit {
+                            width: 36px;
+                            text <=> root.finder-info-creator-1;
+                            horizontal-alignment: center;
+                            edited(t) => {
+                                root.finder-info-creator-1 = root.clamp-to-one(t);
+                                if (t != "") { creator-edit-2.focus(); }
+                            }
+                        }
+                        creator-edit-2 := LineEdit {
+                            width: 36px;
+                            text <=> root.finder-info-creator-2;
+                            horizontal-alignment: center;
+                            edited(t) => {
+                                root.finder-info-creator-2 = root.clamp-to-one(t);
+                                if (t != "") { creator-edit-3.focus(); }
+                            }
+                        }
+                        creator-edit-3 := LineEdit {
+                            width: 36px;
+                            text <=> root.finder-info-creator-3;
+                            horizontal-alignment: center;
+                            edited(t) => {
+                                root.finder-info-creator-3 = root.clamp-to-one(t);
+                            }
+                        }
                     }
+                    Rectangle { horizontal-stretch: 1; }
                 }
 
                 HorizontalBox {

--- a/tailtalk-packets/Cargo.toml
+++ b/tailtalk-packets/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/feralfirmware/tailtalk"
 bitflags = "2.6"
 byteorder = { workspace = true } #unified
 bytes = { workspace = true } #unified
-encoding_rs = "0.8.33"
+encoding_rs = { workspace = true } #unified
 thiserror = { workspace = true } #unified
 
 [dev-dependencies]

--- a/tailtalk/Cargo.toml
+++ b/tailtalk/Cargo.toml
@@ -17,12 +17,11 @@ anyhow = { workspace = true } #unified
 byteorder = { workspace = true } #unified
 bytes = { workspace = true } #unified
 dashmap = "6.1.0"
-encoding_rs = "0.8.33"
-magic-db = "0.5"
-pure-magic = "0.3"
+encoding_rs = { workspace = true } #unified
 futures = { workspace = true } #unified
 im = "15.1.0"
 mac_address = "1.1"
+magic-db = "0.5"
 pcap = { version = "2", features = ["capture-stream"] }
 rand = "0.9.3"
 sled = "0.34"

--- a/tailtalk/src/afp/desktop.rs
+++ b/tailtalk/src/afp/desktop.rs
@@ -23,7 +23,9 @@ impl IconKey {
 
 pub struct DesktopDatabase {
     pub dt_ref_num: u16,
-    db: sled::Db,
+    icons: sled::Tree,
+    comments: sled::Tree,
+    appls: sled::Tree,
 }
 
 impl DesktopDatabase {
@@ -49,15 +51,27 @@ impl DesktopDatabase {
 
     /// Construct a `DesktopDatabase` from an already-open `sled::Db` handle.
     /// Use this to share a single DB handle across multiple AFP sessions.
-    pub fn from_db(db: sled::Db, dt_ref_num: u16) -> Self {
-        Self { dt_ref_num, db }
+    pub fn from_db(db: sled::Db, dt_ref_num: u16) -> Result<Self, AfpError> {
+        let icons = db.open_tree(b"icons").map_err(|e| {
+            error!("Failed to open 'icons' tree: {}", e);
+            AfpError::AccessDenied
+        })?;
+        let comments = db.open_tree(b"comments").map_err(|e| {
+            error!("Failed to open 'comments' tree: {}", e);
+            AfpError::AccessDenied
+        })?;
+        let appls = db.open_tree(b"appls").map_err(|e| {
+            error!("Failed to open 'appls' tree: {}", e);
+            AfpError::AccessDenied
+        })?;
+        Ok(Self { dt_ref_num, icons, comments, appls })
     }
 
     /// Open (or create) the desktop database at the standard path and wrap it.
     /// Prefer `open_or_create` + `from_db` when sharing across sessions.
     pub fn new(volume_root: &Path, dt_ref_num: u16) -> Result<Self, AfpError> {
         let db = Self::open_or_create(volume_root)?;
-        Ok(Self { dt_ref_num, db })
+        Self::from_db(db, dt_ref_num)
     }
 
     pub fn add_icon(
@@ -73,12 +87,7 @@ impl DesktopDatabase {
             icon_type,
         };
 
-        let tree = self.db.open_tree(b"icons").map_err(|e| {
-            error!("Failed to open 'icons' tree: {}", e);
-            AfpError::AccessDenied
-        })?;
-
-        tree.insert(key.to_bytes(), icon_data).map_err(|e| {
+        self.icons.insert(key.to_bytes(), icon_data).map_err(|e| {
             error!("Failed to insert icon: {}", e);
             AfpError::AccessDenied
         })?;
@@ -90,6 +99,7 @@ impl DesktopDatabase {
         creator: [u8; 4],
         file_type: [u8; 4],
         icon_type: u8,
+        // AFP wire format includes an iconSize field; we store one copy per type and ignore it.
         _size: u16,
     ) -> Result<Vec<u8>, AfpError> {
         let key = IconKey {
@@ -98,12 +108,7 @@ impl DesktopDatabase {
             icon_type,
         };
 
-        let tree = self.db.open_tree(b"icons").map_err(|e| {
-            error!("Failed to open 'icons' tree: {}", e);
-            AfpError::AccessDenied
-        })?;
-
-        if let Some(data) = tree.get(key.to_bytes()).map_err(|e| {
+        if let Some(data) = self.icons.get(key.to_bytes()).map_err(|e| {
             error!("Failed to get icon: {}", e);
             AfpError::AccessDenied
         })? {
@@ -117,12 +122,8 @@ impl DesktopDatabase {
         creator: [u8; 4],
         _icon_type: u16,
     ) -> Result<(u32, u32, u16), AfpError> {
-        // Since sqlite/sled stores the entire icon, we can iterate over the keys matching the creator
+        // Since sled stores the entire icon, we can iterate over the keys matching the creator
         // and find an icon type that matches the request. Or return basic size info.
-        let tree = self.db.open_tree(b"icons").map_err(|e| {
-            error!("Failed to open 'icons' tree: {}", e);
-            AfpError::AccessDenied
-        })?;
 
         // Format is:
         // tag (4 bytes)
@@ -130,7 +131,7 @@ impl DesktopDatabase {
         // icon_type (1 byte, padding, or matching requested size)
         // size (2 bytes)
 
-        for result in tree.iter() {
+        for result in self.icons.iter() {
             if let Ok((key, value)) = result
                 && key.len() == 9
             {
@@ -156,13 +157,8 @@ impl DesktopDatabase {
     }
 
     pub fn set_comment(&self, rel_path: &std::path::Path, comment: &[u8]) -> Result<(), AfpError> {
-        let tree = self.db.open_tree(b"comments").map_err(|e| {
-            error!("Failed to open 'comments' tree: {}", e);
-            AfpError::AccessDenied
-        })?;
-
         let key = rel_path.to_string_lossy();
-        tree.insert(key.as_bytes(), comment).map_err(|e| {
+        self.comments.insert(key.as_bytes(), comment).map_err(|e| {
             error!("Failed to insert comment: {}", e);
             AfpError::AccessDenied
         })?;
@@ -176,14 +172,9 @@ impl DesktopDatabase {
     }
 
     pub fn get_comment(&self, rel_path: &std::path::Path) -> Result<Vec<u8>, AfpError> {
-        let tree = self.db.open_tree(b"comments").map_err(|e| {
-            error!("Failed to open 'comments' tree: {}", e);
-            AfpError::AccessDenied
-        })?;
-
         tracing::info!("Get comment for path {:?}", rel_path);
         let key = rel_path.to_string_lossy();
-        if let Some(data) = tree.get(key.as_bytes()).map_err(|e| {
+        if let Some(data) = self.comments.get(key.as_bytes()).map_err(|e| {
             error!("Failed to get comment: {}", e);
             AfpError::AccessDenied
         })? {
@@ -194,13 +185,8 @@ impl DesktopDatabase {
     }
 
     pub fn remove_comment(&self, rel_path: &std::path::Path) -> Result<(), AfpError> {
-        let tree = self.db.open_tree(b"comments").map_err(|e| {
-            error!("Failed to open 'comments' tree: {}", e);
-            AfpError::AccessDenied
-        })?;
-
         let key = rel_path.to_string_lossy();
-        tree.remove(key.as_bytes()).map_err(|e| {
+        self.comments.remove(key.as_bytes()).map_err(|e| {
             error!("Failed to remove comment: {}", e);
             AfpError::AccessDenied
         })?;
@@ -214,18 +200,13 @@ impl DesktopDatabase {
         old_path: &std::path::Path,
         new_path: &std::path::Path,
     ) -> Result<(), AfpError> {
-        let tree = self.db.open_tree(b"comments").map_err(|e| {
-            error!("Failed to open 'comments' tree: {}", e);
-            AfpError::AccessDenied
-        })?;
-
         let old_key = old_path.to_string_lossy();
-        if let Some(data) = tree.remove(old_key.as_bytes()).map_err(|e| {
+        if let Some(data) = self.comments.remove(old_key.as_bytes()).map_err(|e| {
             error!("Failed to remove old comment key: {}", e);
             AfpError::AccessDenied
         })? {
             let new_key = new_path.to_string_lossy();
-            tree.insert(new_key.as_bytes(), data).map_err(|e| {
+            self.comments.insert(new_key.as_bytes(), data).map_err(|e| {
                 error!("Failed to insert comment at new key: {}", e);
                 AfpError::AccessDenied
             })?;
@@ -240,18 +221,13 @@ impl DesktopDatabase {
         src_path: &std::path::Path,
         dst_path: &std::path::Path,
     ) -> Result<(), AfpError> {
-        let tree = self.db.open_tree(b"comments").map_err(|e| {
-            error!("Failed to open 'comments' tree: {}", e);
-            AfpError::AccessDenied
-        })?;
-
         let src_key = src_path.to_string_lossy();
-        if let Some(data) = tree.get(src_key.as_bytes()).map_err(|e| {
+        if let Some(data) = self.comments.get(src_key.as_bytes()).map_err(|e| {
             error!("Failed to read comment for copy: {}", e);
             AfpError::AccessDenied
         })? {
             let dst_key = dst_path.to_string_lossy();
-            tree.insert(dst_key.as_bytes(), data).map_err(|e| {
+            self.comments.insert(dst_key.as_bytes(), data).map_err(|e| {
                 error!("Failed to insert copied comment: {}", e);
                 AfpError::AccessDenied
             })?;
@@ -268,15 +244,10 @@ impl DesktopDatabase {
         old_dir_id: u32,
         new_dir_id: u32,
     ) -> Result<(), AfpError> {
-        let tree = self.db.open_tree(b"appls").map_err(|e| {
-            error!("Failed to open 'appls' tree: {}", e);
-            AfpError::AccessDenied
-        })?;
-
         let old_dir_bytes = old_dir_id.to_be_bytes();
         let old_path_bytes = old_path.as_bytes();
 
-        let matches: Vec<(sled::IVec, sled::IVec)> = tree
+        let matches: Vec<(sled::IVec, sled::IVec)> = self.appls
             .iter()
             .filter_map(|r| r.ok())
             .filter(|(_, v)| {
@@ -296,7 +267,7 @@ impl DesktopDatabase {
             value.extend_from_slice(&new_dir_bytes);
             value.push(new_path_bytes.len() as u8);
             value.extend_from_slice(new_path_bytes);
-            tree.insert(key, value).map_err(|e| {
+            self.appls.insert(key, value).map_err(|e| {
                 error!("Failed to update APPL path: {}", e);
                 AfpError::AccessDenied
             })?;
@@ -313,15 +284,10 @@ impl DesktopDatabase {
         src_dir_id: u32,
         dst_dir_id: u32,
     ) -> Result<(), AfpError> {
-        let tree = self.db.open_tree(b"appls").map_err(|e| {
-            error!("Failed to open 'appls' tree: {}", e);
-            AfpError::AccessDenied
-        })?;
-
         let src_dir_bytes = src_dir_id.to_be_bytes();
         let src_path_bytes = src_path.as_bytes();
 
-        let matches: Vec<(sled::IVec, sled::IVec)> = tree
+        let matches: Vec<(sled::IVec, sled::IVec)> = self.appls
             .iter()
             .filter_map(|r| r.ok())
             .filter(|(_, v)| {
@@ -341,7 +307,7 @@ impl DesktopDatabase {
             value.extend_from_slice(&dst_dir_bytes);
             value.push(dst_path_bytes.len() as u8);
             value.extend_from_slice(dst_path_bytes);
-            tree.insert(key, value).map_err(|e| {
+            self.appls.insert(key, value).map_err(|e| {
                 error!("Failed to insert copied APPL: {}", e);
                 AfpError::AccessDenied
             })?;
@@ -352,15 +318,10 @@ impl DesktopDatabase {
     /// Remove all APPL entries whose stored path matches `path` and directory ID matches
     /// `dir_id`. Used when a file is deleted. Silently succeeds if no match exists.
     pub fn delete_appls_for_path(&self, dir_id: u32, path: &str) -> Result<(), AfpError> {
-        let tree = self.db.open_tree(b"appls").map_err(|e| {
-            error!("Failed to open 'appls' tree: {}", e);
-            AfpError::AccessDenied
-        })?;
-
         let dir_bytes = dir_id.to_be_bytes();
         let path_bytes = path.as_bytes();
 
-        let keys: Vec<sled::IVec> = tree
+        let keys: Vec<sled::IVec> = self.appls
             .iter()
             .filter_map(|r| r.ok())
             .filter(|(_, v)| {
@@ -375,7 +336,7 @@ impl DesktopDatabase {
             .collect();
 
         for key in keys {
-            tree.remove(key).map_err(|e| {
+            self.appls.remove(key).map_err(|e| {
                 error!("Failed to remove APPL entry: {}", e);
                 AfpError::AccessDenied
             })?;
@@ -394,22 +355,20 @@ impl DesktopDatabase {
         directory_id: u32,
         path: &str,
     ) -> Result<(), AfpError> {
-        let tree = self.db.open_tree(b"appls").map_err(|e| {
-            error!("Failed to open 'appls' tree: {}", e);
-            AfpError::AccessDenied
-        })?;
-
         let mut key = [0u8; 8];
         key[0..4].copy_from_slice(&creator);
         key[4..8].copy_from_slice(&tag.to_be_bytes());
 
         let path_bytes = path.as_bytes();
+        if path_bytes.len() > 255 {
+            return Err(AfpError::ParamError);
+        }
         let mut value = Vec::with_capacity(5 + path_bytes.len());
         value.extend_from_slice(&directory_id.to_be_bytes());
         value.push(path_bytes.len() as u8);
         value.extend_from_slice(path_bytes);
 
-        tree.insert(key, value).map_err(|e| {
+        self.appls.insert(key, value).map_err(|e| {
             error!("Failed to insert APPL: {}", e);
             AfpError::AccessDenied
         })?;
@@ -423,15 +382,10 @@ impl DesktopDatabase {
         directory_id: u32,
         path: &str,
     ) -> Result<(), AfpError> {
-        let tree = self.db.open_tree(b"appls").map_err(|e| {
-            error!("Failed to open 'appls' tree: {}", e);
-            AfpError::AccessDenied
-        })?;
-
         let dir_bytes = directory_id.to_be_bytes();
         let path_bytes = path.as_bytes();
 
-        for result in tree.scan_prefix(creator) {
+        for result in self.appls.scan_prefix(creator) {
             let (key, value) = result.map_err(|e| {
                 error!("Failed to scan APPLs: {}", e);
                 AfpError::AccessDenied
@@ -443,7 +397,7 @@ impl DesktopDatabase {
                     && value.len() >= 5 + path_len
                     && &value[5..5 + path_len] == path_bytes
                 {
-                    tree.remove(&key).map_err(|e| {
+                    self.appls.remove(&key).map_err(|e| {
                         error!("Failed to remove APPL: {}", e);
                         AfpError::AccessDenied
                     })?;
@@ -463,13 +417,8 @@ impl DesktopDatabase {
         creator: [u8; 4],
         index: u16,
     ) -> Result<(u32, u32, String), AfpError> {
-        let tree = self.db.open_tree(b"appls").map_err(|e| {
-            error!("Failed to open 'appls' tree: {}", e);
-            AfpError::AccessDenied
-        })?;
-
         let target = index.saturating_sub(1) as usize;
-        for (i, result) in tree.scan_prefix(creator).enumerate() {
+        for (i, result) in self.appls.scan_prefix(creator).enumerate() {
             let (key, value) = result.map_err(|e| {
                 error!("Failed to scan APPLs: {}", e);
                 AfpError::AccessDenied

--- a/tailtalk/src/afp/volume.rs
+++ b/tailtalk/src/afp/volume.rs
@@ -41,11 +41,29 @@ fn infer_type_creator_from_content(path: &Path) -> Option<TypeCreator> {
         "application/x-stuffit" => Some(TypeCreator { file_type: *b"SIT!", creator: *b"SIT!" }),
         // StuffIt SEA (Self-Extracting Archive): APPL type as it is a standalone executable
         "application/x-stuffit-x" => Some(TypeCreator { file_type: *b"APPL", creator: *b"aust" }),
-        "application/x-apple-diskimage" => Some(TypeCreator { file_type: *b"dImg", creator: *b"dCpy" }),
+        "application/x-dc42-floppy-image" => Some(TypeCreator { file_type: *b"dImg", creator: *b"dCpy" }),
         // PDF: type 'PDF ' (with trailing space), creator 'CARO' (Adobe Acrobat)
         "application/pdf" => Some(TypeCreator { file_type: *b"PDF ", creator: *b"CARO" }),
         // BinHex 4.0: type 'TEXT', creator 'BnHq' (BinHex utility)
         "application/mac-binhex40" => Some(TypeCreator { file_type: *b"TEXT", creator: *b"BnHq" }),
+        // BinHex 1.0/2.0 (pre-4.0): same encoding family, creator 'BNHQ'
+        "application/mac-binhex" => Some(TypeCreator { file_type: *b"TEXT", creator: *b"BNHQ" }),
+        // Apple Disk Image (DMG/HFS raw): type/creator from magic-db !:apple ????devi
+        "application/x-apple-diskimage" => Some(TypeCreator { file_type: *b"devi", creator: *b"????" }),
+        // MacBinary I/II/III wrapper: type/creator from magic-db !:apple PSPTBINA
+        "application/x-macbinary" => Some(TypeCreator { file_type: *b"BINA", creator: *b"PSPT" }),
+        // Datafork TrueType/suitcase font
+        "application/x-dfont" => Some(TypeCreator { file_type: *b"dfil", creator: *b"????" }),
+        // HFS/HFS+ resource fork suitcase
+        "application/x-apple-rsr" => Some(TypeCreator { file_type: *b"rsrc", creator: *b"????" }),
+        // AppleWorks 3 word processor (Apple II/ProDOS)
+        "application/x-appleworks3" => Some(TypeCreator { file_type: *b"AWWP", creator: *b"pdos" }),
+        // JPEG: type/creator from magic-db !:apple 8BIMJPEG
+        "image/jpeg" => Some(TypeCreator { file_type: *b"JPEG", creator: *b"8BIM" }),
+        // PNG: no !:apple in magic-db; PNGf is the conventional Classic Mac type
+        "image/png" => Some(TypeCreator { file_type: *b"PNGf", creator: *b"????" }),
+        // PICT: type/creator from magic-db !:apple ????PICT
+        "image/x-pict" => Some(TypeCreator { file_type: *b"PICT", creator: *b"ttxt" }),
         _ => None,
     }
 }
@@ -53,8 +71,19 @@ fn infer_type_creator_from_content(path: &Path) -> Option<TypeCreator> {
 /// Returns the `TypeCreator` by file extension alone, as a fallback when magic
 /// byte probing fails or returns an unrecognised MIME type.
 fn infer_type_creator_from_extension(path: &Path) -> Option<TypeCreator> {
-    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
-    match ext.as_str() {
+    let stem = path.file_stem().and_then(|s| s.to_str());
+    let ext = path.extension().and_then(|e| e.to_str()).map(|e| e.to_ascii_lowercase());
+
+    // MPW Shell conventions (creator 'MPS ')
+    // .π extension: 68k MPW Tool; π.rsrc: companion resource fork file
+    if ext.as_deref() == Some("π") {
+        return Some(TypeCreator { file_type: *b"MPST", creator: *b"MPS " });
+    }
+    if ext.as_deref() == Some("rsrc") && stem.is_some_and(|s| s.ends_with(".π")) {
+        return Some(TypeCreator { file_type: *b"rsrc", creator: *b"MPS " });
+    }
+
+    match ext.as_deref()? {
         "txt" => Some(TypeCreator { file_type: *b"TEXT", creator: *b"ttxt" }),
         "sit" => Some(TypeCreator { file_type: *b"SIT!", creator: *b"SIT!" }),
         "sea" => Some(TypeCreator { file_type: *b"APPL", creator: *b"aust" }),
@@ -376,7 +405,7 @@ async fn resolve_resource_fork_path(volume_root: &Path, relative_path: &Path) ->
         {
             return (sidecar, meta.len() as u32);
         }
-        return (native, 0);
+        (native, 0)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -1268,7 +1297,7 @@ impl Volume {
             let _ = tokio::fs::create_dir(&apple_desktop).await;
         }
 
-        let desktop_db = crate::afp::DesktopDatabase::from_db(db, 1);
+        let desktop_db = crate::afp::DesktopDatabase::from_db(db, 1)?;
         let ref_num = desktop_db.dt_ref_num;
         self.desktop_database = Some(desktop_db);
         Ok(ref_num)
@@ -3199,7 +3228,7 @@ mod tests {
         // Query the DB directly via the shared handle — the file node is gone so
         // we can't go via resolve_node, and no drop/reopen is needed.
         assert_eq!(
-            crate::afp::DesktopDatabase::from_db(shared_db, 1)
+            crate::afp::DesktopDatabase::from_db(shared_db, 1).unwrap()
                 .get_comment(std::path::Path::new("doomed.txt")),
             Err(AfpError::ItemNotFound),
             "comment should have been deleted with the file"

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -7,7 +7,7 @@ use tailtalk_packets::aarp;
 use tailtalk_packets::ddp::DdpPacket;
 use tailtalk_packets::ethertalk::{EtherTalkPhase2Frame, EtherTalkPhase2Type};
 use tailtalk_packets::llap::{LlapPacket, LlapType};
-use tashtalk::{TashTalk, TashTalkError};
+use tashtalk::TashTalk;
 use tokio::sync::mpsc;
 use tokio_serial::SerialPortBuilderExt;
 use futures::StreamExt;
@@ -286,6 +286,38 @@ fn spawn_pcap_writer(
     Some(tx)
 }
 
+// ── Ethernet framing helpers ──────────────────────────────────────────────────
+
+/// Write a 14-byte EtherTalk Phase 1 Ethernet header into `buf` and return 14.
+fn write_eth1_header(buf: &mut [u8], dst: [u8; 6], src: [u8; 6], ethertype: u16) -> usize {
+    buf[0..6].copy_from_slice(&dst);
+    buf[6..12].copy_from_slice(&src);
+    buf[12..14].copy_from_slice(&ethertype.to_be_bytes());
+    14
+}
+
+/// Write a 22-byte EtherTalk Phase 2 LLC/SNAP header into `buf` and return 22.
+///
+/// `oui` is the 3-byte SNAP OUI: `[0x08, 0x00, 0x07]` for AppleTalk DDP,
+/// `[0x00, 0x00, 0x00]` for AARP.
+fn write_snap_header(
+    buf: &mut [u8],
+    dst: [u8; 6],
+    src: [u8; 6],
+    oui: [u8; 3],
+    ethertype: u16,
+    payload_len: usize,
+) -> usize {
+    buf[0..6].copy_from_slice(&dst);
+    buf[6..12].copy_from_slice(&src);
+    let frame_len = 8 + payload_len; // 3 LLC + 5 SNAP bytes
+    buf[12..14].copy_from_slice(&(frame_len as u16).to_be_bytes());
+    buf[14..17].copy_from_slice(&[0xAA, 0xAA, 0x03]); // LLC DSAP, SSAP, Control
+    buf[17..20].copy_from_slice(&oui);
+    buf[20..22].copy_from_slice(&ethertype.to_be_bytes());
+    22
+}
+
 // ── PacketProcessor ───────────────────────────────────────────────────────────
 
 impl PacketProcessor {
@@ -483,7 +515,6 @@ impl PacketProcessor {
 
                 tracing::info!("Starting TashTalk async loop");
                 let _ = ready.send(true);
-                let mut last_receive_was_error = false;
                 loop {
                     tokio::select! {
                         _ = tash_token.cancelled() => break,
@@ -499,7 +530,6 @@ impl PacketProcessor {
                         res = tashtalk_instance.receive_frame() => {
                             match res {
                                 Ok(Some(data)) => {
-                                    last_receive_was_error = false;
                                     if let Some(ref tx) = pcap_rx_sender {
                                         let _ = tx.try_send((SystemTime::now(), data.clone()));
                                     }
@@ -552,26 +582,10 @@ impl PacketProcessor {
                                         }
                                     }
                                 }
-                                Ok(None) => {
-                                    // tokio-util emits one None after every decode error as a
-                                    // recovery artifact; only treat None as real EOF otherwise.
-                                    if last_receive_was_error {
-                                        last_receive_was_error = false;
-                                        continue;
-                                    }
-                                    break;
-                                }
+                                Ok(None) => break,
                                 Err(e) => {
-                                    last_receive_was_error = true;
-                                    tracing::error!("TashTalk receive error: {:?}", e);
-                                    if !matches!(e,
-                                        TashTalkError::FramingError
-                                        | TashTalkError::FrameAborted
-                                        | TashTalkError::CrcCheckFailed
-                                        | TashTalkError::UnknownEscape(_)
-                                    ) {
-                                        break;
-                                    }
+                                    tracing::error!("TashTalk I/O error: {:?}", e);
+                                    break;
                                 }
                             }
                         }
@@ -608,36 +622,21 @@ impl PacketProcessor {
                 DataLinkProtocol::Ddp => {
                     match pkt.dest_node {
                         addressing::Node::EtherTalkPhase1(mac) => {
-                            output_buf[0..6].copy_from_slice(&mac);
-                            output_buf[6..12].copy_from_slice(&our_mac);
-                            output_buf[12] = 0x80;
-                            output_buf[13] = 0x9B;
-                            let dst_node = if pkt.payload.len() > 8 { pkt.payload[8] } else { 0 };
-                            let src_node = if pkt.payload.len() > 9 { pkt.payload[9] } else { 0 };
-                            output_buf[14] = dst_node;
-                            output_buf[15] = src_node;
-                            output_buf[16] = 2;
                             let payload_len = pkt.payload.len();
-                            output_buf[17..17 + payload_len].copy_from_slice(&pkt.payload);
-                            17 + payload_len
+                            let n = write_eth1_header(&mut output_buf, mac, our_mac, 0x809B);
+                            // Phase 1 DDP: 3-byte LLAP header (dst, src, type=2) precedes the DDP packet.
+                            // Node numbers are extracted from the DDP header bytes 8 and 9.
+                            output_buf[n] = if payload_len > 8 { pkt.payload[8] } else { 0 };
+                            output_buf[n + 1] = if payload_len > 9 { pkt.payload[9] } else { 0 };
+                            output_buf[n + 2] = 2;
+                            output_buf[n + 3..n + 3 + payload_len].copy_from_slice(&pkt.payload);
+                            n + 3 + payload_len
                         }
                         addressing::Node::EtherTalkPhase2(mac) => {
-                            output_buf[0..6].copy_from_slice(&mac);
-                            output_buf[6..12].copy_from_slice(&our_mac);
                             let payload_len = pkt.payload.len();
-                            let total_payload = 8 + payload_len;
-                            output_buf[12] = (total_payload >> 8) as u8;
-                            output_buf[13] = (total_payload & 0xFF) as u8;
-                            output_buf[14] = 0xAA;
-                            output_buf[15] = 0xAA;
-                            output_buf[16] = 0x03;
-                            output_buf[17] = 0x08;
-                            output_buf[18] = 0x00;
-                            output_buf[19] = 0x07;
-                            output_buf[20] = 0x80;
-                            output_buf[21] = 0x9B;
-                            output_buf[22..22 + payload_len].copy_from_slice(&pkt.payload);
-                            14 + total_payload
+                            let n = write_snap_header(&mut output_buf, mac, our_mac, [0x08, 0x00, 0x07], 0x809B, payload_len);
+                            output_buf[n..n + payload_len].copy_from_slice(&pkt.payload);
+                            n + payload_len
                         }
                         addressing::Node::LocalTalk(node_id) => {
                             let llap_pkt = LlapPacket {
@@ -690,29 +689,14 @@ impl PacketProcessor {
                     let payload_len = pkt.payload.len();
                     match pkt.dest_node {
                         addressing::Node::EtherTalkPhase1(mac) => {
-                            output_buf[0..6].copy_from_slice(&mac);
-                            output_buf[6..12].copy_from_slice(&our_mac);
-                            output_buf[12] = 0x80;
-                            output_buf[13] = 0xF3;
-                            output_buf[14..14 + payload_len].copy_from_slice(&pkt.payload);
-                            14 + payload_len
+                            let n = write_eth1_header(&mut output_buf, mac, our_mac, 0x80F3);
+                            output_buf[n..n + payload_len].copy_from_slice(&pkt.payload);
+                            n + payload_len
                         }
                         addressing::Node::EtherTalkPhase2(mac) => {
-                            output_buf[0..6].copy_from_slice(&mac);
-                            output_buf[6..12].copy_from_slice(&our_mac);
-                            let total_payload = 8 + payload_len;
-                            output_buf[12] = (total_payload >> 8) as u8;
-                            output_buf[13] = (total_payload & 0xFF) as u8;
-                            output_buf[14] = 0xAA;
-                            output_buf[15] = 0xAA;
-                            output_buf[16] = 0x03;
-                            output_buf[17] = 0x00;
-                            output_buf[18] = 0x00;
-                            output_buf[19] = 0x00;
-                            output_buf[20] = 0x80;
-                            output_buf[21] = 0xF3;
-                            output_buf[22..22 + payload_len].copy_from_slice(&pkt.payload);
-                            14 + total_payload
+                            let n = write_snap_header(&mut output_buf, mac, our_mac, [0x00, 0x00, 0x00], 0x80F3, payload_len);
+                            output_buf[n..n + payload_len].copy_from_slice(&pkt.payload);
+                            n + payload_len
                         }
                         addressing::Node::LocalTalk(_) => 0,
                     }
@@ -804,14 +788,14 @@ impl ShutdownHandle {
 /// Obtain one via [`TalkStack::builder`]. Once built, spawn services on top:
 ///
 /// ```no_run
-/// # use tailtalk::{TalkStack, afp::{AfpServer, AfpServerConfig}};
+/// # use tailtalk::{TalkStack, afp::AfpServerConfig};
 /// # async fn example() -> anyhow::Result<()> {
 /// let stack = TalkStack::builder()
 ///     .ethernet("eth0")
 ///     .build()
 ///     .await?;
 ///
-/// let _afp = AfpServer::spawn(&stack.ddp, &stack.nbp, Some(254), AfpServerConfig::default(), stack.token(), stack.services_done_token()).await?;
+/// let _afp = stack.spawn_afp(Some(254), AfpServerConfig::default()).await?;
 /// # Ok(()) }
 /// ```
 pub struct TalkStack {
@@ -857,6 +841,44 @@ impl TalkStack {
     /// completion of their shutdown sequence.
     pub fn services_done_token(&self) -> CancellationToken {
         self.services_done.clone()
+    }
+
+    /// Start an AFP file server on this stack.
+    pub async fn spawn_afp(&self, socket: Option<u8>, config: afp::AfpServerConfig) -> anyhow::Result<afp::AfpServer> {
+        afp::AfpServer::spawn(&self.ddp, &self.nbp, socket, config, self.service_token.clone(), self.services_done.clone()).await
+    }
+
+    /// Bind an ASP listener on this stack.
+    pub async fn listen_asp(
+        &self,
+        socket: Option<u8>,
+        entity_name: tailtalk_packets::nbp::EntityName,
+        status_data: Vec<u8>,
+    ) -> anyhow::Result<asp::AspHandle> {
+        asp::Asp::bind(&self.ddp, &self.nbp, socket, entity_name, status_data, self.service_token.clone(), self.services_done.clone()).await
+    }
+
+    /// Bind an ADSP listener.
+    pub async fn listen_adsp(&self, socket: Option<u8>) -> std::io::Result<(u8, adsp::AdspListener)> {
+        adsp::Adsp::bind(&self.ddp, socket).await
+    }
+
+    /// Open an outbound ADSP connection.
+    pub async fn connect_adsp(&self, remote_addr: adsp::AdspAddress) -> std::io::Result<adsp::AdspStream> {
+        adsp::Adsp::connect(&self.ddp, remote_addr).await
+    }
+
+    /// Create a PAP client backed by two fresh ATP sockets.
+    pub async fn pap_client(&self) -> pap::PapClient {
+        let (_, atp_requestor, _) = atp::Atp::spawn(&self.ddp, None).await;
+        let (_, _, atp_responder) = atp::Atp::spawn(&self.ddp, None).await;
+        pap::PapClient::new(atp_requestor, atp_responder)
+    }
+
+    /// Query the status string of a PAP printer without opening a full connection.
+    pub async fn pap_status(&self, address: atp::AtpAddress) -> anyhow::Result<String> {
+        let (_, atp_requestor, _) = atp::Atp::spawn(&self.ddp, None).await;
+        pap::PapClient::get_status(atp_requestor, address).await
     }
 }
 

--- a/tashtalk/Cargo.toml
+++ b/tashtalk/Cargo.toml
@@ -12,3 +12,4 @@ futures = { workspace = true } #unified
 thiserror = { workspace = true } #unified
 tokio = { workspace = true, features = ["full"] } #unified
 tokio-util = { version = "0.7.12", features = ["codec"] }
+tracing = { workspace = true } #unified

--- a/tashtalk/src/codec.rs
+++ b/tashtalk/src/codec.rs
@@ -93,15 +93,16 @@ impl Decoder for TashTalkCodec {
 
                         return match code {
                             0xFD => Ok(Some(unescaped)),
-                            0xFE => Err(TashTalkError::FramingError),
-                            0xFA => Err(TashTalkError::FrameAborted),
-                            0xFC => Err(TashTalkError::CrcCheckFailed),
+                            0xFE => { tracing::warn!("LocalTalk framing error"); Ok(None) }
+                            0xFA => { tracing::warn!("LocalTalk frame aborted"); Ok(None) }
+                            0xFC => { tracing::warn!("LocalTalk CRC check failed"); Ok(None) }
                             _ => unreachable!(),
                         };
                     }
                     unknown => {
                         src.advance(i + 2);
-                        return Err(TashTalkError::UnknownEscape(unknown));
+                        tracing::warn!("LocalTalk unknown escape sequence: {:#04X}", unknown);
+                        return Ok(None);
                     }
                 }
             } else {
@@ -160,15 +161,23 @@ mod tests {
         let res = codec.decode(&mut buf).unwrap().unwrap();
         assert_eq!(res, vec![0xAA, 0x00, 0xBB]);
 
-        // Framing Error
+        // Framing error, frame aborted, CRC failure — all return Ok(None) and consume the frame
         let mut buf = BytesMut::from(&[0x00, 0xFE][..]);
-        let err = codec.decode(&mut buf).unwrap_err();
-        assert!(matches!(err, TashTalkError::FramingError));
+        assert_eq!(codec.decode(&mut buf).unwrap(), None);
+        assert!(buf.is_empty());
 
-        // Unknown escape -> error
+        let mut buf = BytesMut::from(&[0xAA, 0xBB, 0x00, 0xFA][..]);
+        assert_eq!(codec.decode(&mut buf).unwrap(), None);
+        assert!(buf.is_empty());
+
+        let mut buf = BytesMut::from(&[0xAA, 0xBB, 0x00, 0xFC][..]);
+        assert_eq!(codec.decode(&mut buf).unwrap(), None);
+        assert!(buf.is_empty());
+
+        // Unknown escape — returns Ok(None) and advances past the two bytes
         let mut buf = BytesMut::from(&[0x00, 0x01][..]);
-        let err = codec.decode(&mut buf).unwrap_err();
-        assert!(matches!(err, TashTalkError::UnknownEscape(0x01)));
+        assert_eq!(codec.decode(&mut buf).unwrap(), None);
+        assert!(buf.is_empty());
 
         // Incomplete
         let mut buf = BytesMut::from(&[0xAA, 0xBB][..]);


### PR DESCRIPTION
GUI: Per-character OSType input; TalkStack: add service helpers; AFP expand type/creator inference; LocalTalk: handle framing errors in codec

The Finder info type/creator editor now uses four individual single-character boxes that auto-advance focus, matching how OSType codes are entered on a real Mac. TalkStack gains convenience methods for AFP, ASP, ADSP, and PAP so callers no longer need to import internal types and wire up handles directly.

The MIME -> type/creator table gains mappings for JPEG, PNG, PICT, MacBinary, DFont, BinHex 1.0/2.0, AppleWorks 3, DC42 floppies, and MPW π tools, plus a fix for the DC42 MIME type. Recoverable LocalTalk framing errors are now handled inside the codec with a warning log rather than propagating as Err, removing the last_receive_was_error workaround from the receive loop. Sled tree handles in DesktopDatabase are cached at construction instead of reopened per call, and pure-magic is dropped in favour of magic-db.