### PR TITLE
EtherTalk: Fix broadcast addressing for Phase 2 EtherTalk and NBP

### DIFF
--- a/tailtalk/src/addressing.rs
+++ b/tailtalk/src/addressing.rs
@@ -39,11 +39,31 @@ pub struct Addressing {
     cache: Arc<DashMap<AppleTalkAddress, Node>>,
     outbound: OutboundHandle,
     our_mac: Option<EthernetMac>,
+    phase: AddressSource,
     cancel: CancellationToken,
 }
 
 impl Addressing {
     const BROADCAST_MAC: [u8; 6] = [0xFF; 6];
+    pub const APPLETALK_BROADCAST_MULTICAST: [u8; 6] = [0x09, 0x00, 0x07, 0xFF, 0xFF, 0xFF];
+
+    fn broadcast_mac(phase: AddressSource) -> EthernetMac {
+        match phase {
+            AddressSource::EtherTalkPhase2 => Self::APPLETALK_BROADCAST_MULTICAST,
+            _ => Self::BROADCAST_MAC,
+        }
+    }
+
+    /// Returns `true` if `mac` is the correct broadcast address for the given
+    /// EtherTalk phase: `FF:FF:FF:FF:FF:FF` for Phase 1,
+    /// `09:00:07:FF:FF:FF` for Phase 2.
+    pub fn is_broadcast_mac(mac: EthernetMac, phase: AddressSource) -> bool {
+        match phase {
+            AddressSource::EtherTalkPhase1 => mac == Self::BROADCAST_MAC,
+            AddressSource::EtherTalkPhase2 => mac == Self::APPLETALK_BROADCAST_MULTICAST,
+            AddressSource::LocalTalk => false,
+        }
+    }
 
     /// Spawn the addressing actor.
     ///
@@ -54,6 +74,7 @@ impl Addressing {
         our_mac: Option<EthernetMac>,
         outbound: OutboundHandle,
         fixed_addr: Option<AppleTalkAddress>,
+        phase: AddressSource,
     ) -> AddressingHandle {
         let (request_send, request_recv) = mpsc::channel(100);
         let (packet_send, packet_recv) = mpsc::channel(100);
@@ -72,6 +93,7 @@ impl Addressing {
             lt_ack_recv,
             lt_enq_recv,
             our_mac,
+            phase,
             outbound,
         };
 
@@ -84,6 +106,7 @@ impl Addressing {
             lt_ack_send,
             lt_enq_send,
             cache,
+            phase,
         }
     }
 
@@ -181,10 +204,10 @@ impl Addressing {
 
                 let probe = self.create_packet(
                     addr,
-                    Self::BROADCAST_MAC,
+                    Self::broadcast_mac(self.phase),
                     addr,
                     AarpOpcode::Probe,
-                    AddressSource::EtherTalkPhase2,
+                    self.phase,
                 );
                 self.outbound
                     .send(probe)
@@ -258,7 +281,7 @@ impl Addressing {
                     if let Some(command) = req {
                         match command {
                             AarpCommand::Lookup(lookup) => {
-                                let packet = self.create_packet(lookup.addr, Self::BROADCAST_MAC, our_addr, AarpOpcode::Request, AddressSource::EtherTalkPhase2);
+                                let packet = self.create_packet(lookup.addr, Self::broadcast_mac(self.phase), our_addr, AarpOpcode::Request, self.phase);
                                 self.outbound.send(packet).await.expect("failed to dispatch request");
                                 self.pending.entry(lookup.addr).or_default().push(Arc::new(lookup));
                             },
@@ -318,6 +341,7 @@ pub struct AddressingHandle {
     lt_ack_send: mpsc::Sender<u8>,
     lt_enq_send: mpsc::Sender<u8>,
     cache: Arc<DashMap<AppleTalkAddress, Node>>,
+    pub phase: AddressSource,
     _cancel: Arc<DropGuard>,
 }
 
@@ -335,14 +359,23 @@ impl AddressingHandle {
     }
 
     pub fn try_lookup(&self, addr: &AppleTalkAddress) -> Option<Node> {
-        // Network 0 is LocalTalk — node number is the link-layer address directly.
+        // Node 255 is always the cable-wide broadcast for this handle's phase,
+        // regardless of network number (network 0 = network-wide broadcast).
+        if addr.node_number == 255 {
+            return Some(match self.phase {
+                AddressSource::EtherTalkPhase2 => {
+                    Node::EtherTalkPhase2(Addressing::APPLETALK_BROADCAST_MULTICAST)
+                }
+                AddressSource::EtherTalkPhase1 => Node::EtherTalkPhase1(Addressing::BROADCAST_MAC),
+                AddressSource::LocalTalk => Node::LocalTalk(255),
+            });
+        }
+
+        // Network 0 unicast: LocalTalk — node number is the link-layer address directly.
         if addr.network_number == 0 {
             return Some(Node::LocalTalk(addr.node_number));
         }
 
-        if addr.node_number == 255 {
-            return Some(Node::EtherTalkPhase2(Addressing::BROADCAST_MAC));
-        }
         self.cache.get(addr).map(|v| *v)
     }
 

--- a/tailtalk/src/ddp.rs
+++ b/tailtalk/src/ddp.rs
@@ -14,7 +14,7 @@ use tokio::sync::{
 
 use crate::{
     DataLinkPacket, DataLinkProtocol, OutboundHandle,
-    addressing::{AddressingHandle, Node},
+    addressing::{Addressing, AddressingHandle, Node},
 };
 
 pub struct Packet {
@@ -246,6 +246,31 @@ impl DdpProcessor {
     }
 
     async fn handle_outbound(&mut self, packet: OutboundPacket) {
+        // Network-wide broadcast {0, 255}: send on every configured interface so
+        // all nodes on each cable receive it, regardless of their network number.
+        if packet.dest.addr.network_number == 0 && packet.dest.addr.node_number == 255 {
+            let mut sent = false;
+            if let Some(et) = &self.et_addressing {
+                let et_addr = et.addr().await.unwrap();
+                let dest_node = Node::EtherTalkPhase2(Addressing::APPLETALK_BROADCAST_MULTICAST);
+                self.send_ddp_to_node(&packet, dest_node, et_addr).await;
+                sent = true;
+            }
+            if let Some(lt) = &self.lt_addressing {
+                let lt_addr = lt.addr().await.unwrap();
+                self.send_ddp_to_node(&packet, Node::LocalTalk(255), lt_addr).await;
+                sent = true;
+            }
+            if !sent {
+                tracing::error!(
+                    "DDP: dropping packet to {}.{} — no interfaces configured",
+                    packet.dest.addr.network_number,
+                    packet.dest.addr.node_number,
+                );
+            }
+            return;
+        }
+
         let dest_node = if packet.dest.addr.network_number == 0 {
             if self.lt_addressing.is_none() {
                 tracing::error!(
@@ -273,6 +298,15 @@ impl DdpProcessor {
             _ => self.et_addressing.as_ref().unwrap().addr().await.unwrap(),
         };
 
+        self.send_ddp_to_node(&packet, dest_node, our_addr).await;
+    }
+
+    async fn send_ddp_to_node(
+        &self,
+        packet: &OutboundPacket,
+        dest_node: Node,
+        our_addr: AppleTalkAddress,
+    ) {
         // Short DDP (DDP-S, 5-byte header) is LocalTalk only.
         let use_short = matches!(dest_node, Node::LocalTalk(_));
 

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -962,6 +962,7 @@ impl TalkStackBuilder {
                 processor.get_mac(),
                 outbound.clone(),
                 self.fixed_addr,
+                aarp::AddressSource::EtherTalkPhase2,
             ))
         } else {
             None
@@ -975,7 +976,12 @@ impl TalkStackBuilder {
                 network_number: 0,
                 node_number: rand::rng().random_range(1..=253u8),
             });
-            Some(addressing::Addressing::spawn(None, outbound.clone(), lt_fixed))
+            Some(addressing::Addressing::spawn(
+                None,
+                outbound.clone(),
+                lt_fixed,
+                aarp::AddressSource::LocalTalk,
+            ))
         } else {
             None
         };

--- a/tailtalk/src/nbp.rs
+++ b/tailtalk/src/nbp.rs
@@ -130,49 +130,27 @@ impl Nbp {
                                 let mut buf = [0u8; 1024];
                                 let size = packet.to_bytes(&mut buf).expect("failed to serialize");
 
-                                let mut send_ok = true;
+                                // Network-wide broadcast {0, 255}: the DDP layer will send this
+                                // on every configured interface (EtherTalk and/or LocalTalk).
+                                let dest = crate::ddp::DdpAddress::new(
+                                    tailtalk_packets::aarp::AppleTalkAddress {
+                                        network_number: 0,
+                                        node_number: 255,
+                                    },
+                                    2,
+                                );
 
-                                // Send over LocalTalk (network 0 = this LocalTalk cable).
-                                if self.lt_addressing.is_some() {
-                                    let dest = crate::ddp::DdpAddress::new(
-                                        tailtalk_packets::aarp::AppleTalkAddress {
-                                            network_number: 0,
-                                            node_number: 255,
-                                        },
-                                        2,
-                                    );
-                                    if let Err(e) = self.sock.send_to(&buf[..size], dest).await {
-                                        tracing::error!("NBP LkUp: failed to send on LocalTalk: {e}");
-                                        send_ok = false;
-                                    }
-                                }
-
-                                // Send over EtherTalk (our assigned network, node 255 = cable broadcast).
-                                if let Some(et) = &self.et_addressing {
-                                    let et_addr = et.addr().await.expect("failed to get ET addr");
-                                    let dest = crate::ddp::DdpAddress::new(
-                                        tailtalk_packets::aarp::AppleTalkAddress {
-                                            network_number: et_addr.network_number,
-                                            node_number: 255,
-                                        },
-                                        2,
-                                    );
-                                    if let Err(e) = self.sock.send_to(&buf[..size], dest).await {
-                                        tracing::error!("NBP LkUp: failed to send on EtherTalk: {e}");
-                                        send_ok = false;
-                                    }
-                                }
-
-                                if send_ok {
+                                if let Err(e) = self.sock.send_to(&buf[..size], dest).await {
+                                    tracing::error!("NBP LkUp: failed to send: {e}");
+                                    let _ = lookup.chan.send(Err(io::Error::other(
+                                        "failed to send NBP lookup",
+                                    )));
+                                } else {
                                     self.pending_lookups.insert(tid, PendingLookup {
                                         chan: lookup.chan,
                                         start_time: Instant::now(),
                                         results: Vec::new(),
                                     });
-                                } else {
-                                    let _ = lookup.chan.send(Err(io::Error::other(
-                                        "failed to send NBP lookup on all transports",
-                                    )));
                                 }
                             },
                         }

--- a/tailtalk/tests/adsp_test.rs
+++ b/tailtalk/tests/adsp_test.rs
@@ -65,7 +65,7 @@ impl TestClient {
             }
         });
 
-        let addressing = Addressing::spawn(Some(mac), outbound_handle.clone(), None);
+        let addressing = Addressing::spawn(Some(mac), outbound_handle.clone(), None, AddressSource::EtherTalkPhase2);
         let ddp = DdpProcessor::spawn(Some(addressing.clone()), None, outbound_handle.clone());
 
         let mut rx = hub_rx;
@@ -82,11 +82,8 @@ impl TestClient {
                         continue;
                     }
 
-                    let is_for_us = if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac } else { [0; 6] } == mac;
-                    let is_broadcast_std = if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac == [0xff, 0xff, 0xff, 0xff, 0xff, 0xff] } else { false };
-                    let is_zeros = if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac } else { [0; 6] } == [0, 0, 0, 0, 0, 0];
-
-                    if is_for_us || is_broadcast_std || is_zeros {
+                    let dest_mac = if let tailtalk::addressing::Node::EtherTalkPhase2(m) = pkt.dest_node { m } else { [0; 6] };
+                    if dest_mac == mac || tailtalk::addressing::Addressing::is_broadcast_mac(dest_mac, AddressSource::EtherTalkPhase2) {
                         match pkt.protocol {
                             DataLinkProtocol::Ddp => ddp_handle.received_pkt(
                                 &pkt.payload,

--- a/tailtalk/tests/asp_session_test.rs
+++ b/tailtalk/tests/asp_session_test.rs
@@ -73,7 +73,7 @@ impl TestClient {
             }
         });
 
-        let addressing = Addressing::spawn(Some(mac), outbound_handle.clone(), None);
+        let addressing = Addressing::spawn(Some(mac), outbound_handle.clone(), None, AddressSource::EtherTalkPhase2);
         let ddp = DdpProcessor::spawn(Some(addressing.clone()), None, outbound_handle.clone());
 
         let echo = Echo::spawn(&ddp).await;
@@ -103,11 +103,8 @@ impl TestClient {
                     }
 
                     // Accept packets for us, broadcast, or [0; 6]
-                    let is_for_us = if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac } else { [0; 6] } == mac;
-                    let is_broadcast_std = if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac == [0xff, 0xff, 0xff, 0xff, 0xff, 0xff] } else { false };
-                    let is_zeros = if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac } else { [0; 6] } == [0, 0, 0, 0, 0, 0];
-
-                    if is_for_us || is_broadcast_std || is_zeros {
+                    let dest_mac = if let tailtalk::addressing::Node::EtherTalkPhase2(m) = pkt.dest_node { m } else { [0; 6] };
+                    if dest_mac == mac || tailtalk::addressing::Addressing::is_broadcast_mac(dest_mac, AddressSource::EtherTalkPhase2) {
                         match pkt.protocol {
                             DataLinkProtocol::Ddp => ddp_handle.received_pkt(
                                 &pkt.payload,
@@ -167,7 +164,7 @@ async fn test_asp_session_workflow() {
         }
     });
 
-    let addr_server = Addressing::spawn(Some(mac_server), outbound_server.clone(), None);
+    let addr_server = Addressing::spawn(Some(mac_server), outbound_server.clone(), None, AddressSource::EtherTalkPhase2);
     let ddp_server = DdpProcessor::spawn(Some(addr_server.clone()), None, outbound_server.clone());
     // Start NBP for server
     let nbp_server = Nbp::spawn(&ddp_server, Some(addr_server.clone()), None).await;
@@ -185,7 +182,8 @@ async fn test_asp_session_workflow() {
                     continue;
                 }
                 let pkt = &wire_pkt.packet;
-                if if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac } else { [0; 6] } == mac_server || if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac } else { [0; 6] } == [0xff; 6] || if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac } else { [0; 6] } == [0; 6] {
+                let dest_mac = if let tailtalk::addressing::Node::EtherTalkPhase2(m) = pkt.dest_node { m } else { [0; 6] };
+                if dest_mac == mac_server || tailtalk::addressing::Addressing::is_broadcast_mac(dest_mac, AddressSource::EtherTalkPhase2) {
                     match pkt.protocol {
                         DataLinkProtocol::Ddp => {
                             ddp_handle_s.received_pkt(&pkt.payload, AddressSource::EtherTalkPhase2, src)

--- a/tailtalk/tests/asp_status_test.rs
+++ b/tailtalk/tests/asp_status_test.rs
@@ -72,7 +72,7 @@ impl TestClient {
             }
         });
 
-        let addressing = Addressing::spawn(Some(mac), outbound_handle.clone(), None);
+        let addressing = Addressing::spawn(Some(mac), outbound_handle.clone(), None, AddressSource::EtherTalkPhase2);
         let ddp = DdpProcessor::spawn(Some(addressing.clone()), None, outbound_handle.clone());
 
         let echo = Echo::spawn(&ddp).await;
@@ -102,11 +102,8 @@ impl TestClient {
                     }
 
                     // Accept packets for us, broadcast, or [0; 6]
-                    let is_for_us = if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac } else { [0; 6] } == mac;
-                    let is_broadcast_std = if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac == [0xff, 0xff, 0xff, 0xff, 0xff, 0xff] } else { false };
-                    let is_zeros = if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac } else { [0; 6] } == [0, 0, 0, 0, 0, 0];
-
-                    if is_for_us || is_broadcast_std || is_zeros {
+                    let dest_mac = if let tailtalk::addressing::Node::EtherTalkPhase2(m) = pkt.dest_node { m } else { [0; 6] };
+                    if dest_mac == mac || tailtalk::addressing::Addressing::is_broadcast_mac(dest_mac, AddressSource::EtherTalkPhase2) {
                         match pkt.protocol {
                             DataLinkProtocol::Ddp => ddp_handle.received_pkt(
                                 &pkt.payload,
@@ -168,7 +165,7 @@ async fn test_asp_get_status() {
         }
     });
 
-    let addr_server = Addressing::spawn(Some(mac_server), outbound_server.clone(), None);
+    let addr_server = Addressing::spawn(Some(mac_server), outbound_server.clone(), None, AddressSource::EtherTalkPhase2);
     let ddp_server = DdpProcessor::spawn(Some(addr_server.clone()), None, outbound_server.clone());
     // Start NBP for server
     let nbp_server = Nbp::spawn(&ddp_server, Some(addr_server.clone()), None).await;
@@ -176,7 +173,7 @@ async fn test_asp_get_status() {
     // Start incoming packet loop for server
     let mut rx_server = hub_ref.subscribe();
     let ddp_handle_s = ddp_server.clone();
-    let addr_handle_s = addr_server.clone(); // Fix: use handle, not actor/struct if separate? Addressing::spawn returns handle.
+    let addr_handle_s = addr_server.clone();
 
     tokio::spawn(async move {
         loop {
@@ -186,7 +183,8 @@ async fn test_asp_get_status() {
                     continue;
                 }
                 let pkt = &wire_pkt.packet;
-                if if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac } else { [0; 6] } == mac_server || if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac } else { [0; 6] } == [0xff; 6] || if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac } else { [0; 6] } == [0; 6] {
+                let dest_mac = if let tailtalk::addressing::Node::EtherTalkPhase2(m) = pkt.dest_node { m } else { [0; 6] };
+                if dest_mac == mac_server || tailtalk::addressing::Addressing::is_broadcast_mac(dest_mac, AddressSource::EtherTalkPhase2) {
                     match pkt.protocol {
                         DataLinkProtocol::Ddp => {
                             ddp_handle_s.received_pkt(&pkt.payload, AddressSource::EtherTalkPhase2, src)

--- a/tailtalk/tests/client_exchange.rs
+++ b/tailtalk/tests/client_exchange.rs
@@ -73,7 +73,7 @@ impl TestClient {
             }
         });
 
-        let addressing = Addressing::spawn(Some(mac), outbound_handle.clone(), None);
+        let addressing = Addressing::spawn(Some(mac), outbound_handle.clone(), None, AddressSource::EtherTalkPhase2);
         let ddp = DdpProcessor::spawn(Some(addressing.clone()), None, outbound_handle.clone());
 
         let echo = Echo::spawn(&ddp).await;
@@ -109,12 +109,8 @@ impl TestClient {
                         continue;
                     }
 
-                    // Accept packets for us, broadcast, or [0; 6] (addressing module bug - should be 09:00:07:FF:FF:FF)
-                    let is_for_us = if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac } else { [0; 6] } == mac;
-                    let is_broadcast_std = if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac == [0xff, 0xff, 0xff, 0xff, 0xff, 0xff] } else { false };
-                    let is_zeros = if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac } else { [0; 6] } == [0, 0, 0, 0, 0, 0];
-
-                    if is_for_us || is_broadcast_std || is_zeros {
+                    let dest_mac = if let tailtalk::addressing::Node::EtherTalkPhase2(m) = pkt.dest_node { m } else { [0; 6] };
+                    if dest_mac == mac || tailtalk::addressing::Addressing::is_broadcast_mac(dest_mac, AddressSource::EtherTalkPhase2) {
                         tracing::info!(
                             "TestClient {:?} processing pkt (dst_mac: {:?})",
                             mac,

--- a/tailtalk/tests/pap_test.rs
+++ b/tailtalk/tests/pap_test.rs
@@ -80,7 +80,7 @@ impl TestClient {
             }
         });
 
-        let addressing = Addressing::spawn(Some(mac), outbound_handle.clone(), None);
+        let addressing = Addressing::spawn(Some(mac), outbound_handle.clone(), None, AddressSource::EtherTalkPhase2);
         let ddp = DdpProcessor::spawn(Some(addressing.clone()), None, outbound_handle.clone());
 
         let echo = Echo::spawn(&ddp).await;
@@ -104,11 +104,8 @@ impl TestClient {
                     }
 
                     // Accept packets for us, broadcast, or [0; 6]
-                    let is_for_us = if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac } else { [0; 6] } == mac;
-                    let is_broadcast_std = if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac == [0xff, 0xff, 0xff, 0xff, 0xff, 0xff] } else { false };
-                    let is_zeros = if let tailtalk::addressing::Node::EtherTalkPhase2(mac) = pkt.dest_node { mac } else { [0; 6] } == [0, 0, 0, 0, 0, 0];
-
-                    if is_for_us || is_broadcast_std || is_zeros {
+                    let dest_mac = if let tailtalk::addressing::Node::EtherTalkPhase2(m) = pkt.dest_node { m } else { [0; 6] };
+                    if dest_mac == mac || tailtalk::addressing::Addressing::is_broadcast_mac(dest_mac, AddressSource::EtherTalkPhase2) {
                         match pkt.protocol {
                             DataLinkProtocol::Ddp => ddp_handle.received_pkt(
                                 &pkt.payload,


### PR DESCRIPTION
    We were using FF:FF:FF:FF:FF:FF for all AppleTalk broadcast traffic
    regardless of phase. EtherTalk Phase 2 requires 09:00:07:FF:FF:FF for
    both AARP and DDP broadcasts.
    
    Addressing::spawn now takes an explicit phase, used to select the
    correct broadcast MAC for AARP probes and requests. try_lookup now
    resolves node 255 before checking network 0, so {0, 255} resolves
    correctly on EtherTalk handles.
    
    NBP lookups now use {0, 255} (network-wide broadcast) instead of
    {our_network, 255} (network-specific). The DDP layer handles {0, 255}
    by dispatching on all configured interfaces, each with the correct
    source address and frame format.