### PR TITLE
Cancel token when TashTalk transport closes

### DIFF
--- a/examples/afp-server/main.rs
+++ b/examples/afp-server/main.rs
@@ -59,10 +59,14 @@ async fn main() {
     tracing::info!("AFP server serving {:?} on {}", args.path, transport);
     tracing::info!("Press Ctrl+C to exit");
 
-    tokio::signal::ctrl_c()
-        .await
-        .expect("failed to listen for ctrl+c");
-
-    tracing::info!("Shutting down");
-    stack.shutdown_handle().graceful_shutdown().await;
+    let shutdown = stack.shutdown_handle();
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            tracing::info!("Ctrl+C received, shutting down");
+        }
+        _ = shutdown.transport_closed() => {
+            tracing::info!("Transport closed, shutting down");
+        }
+    }
+    shutdown.graceful_shutdown().await;
 }

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -591,6 +591,10 @@ impl PacketProcessor {
                         }
                     }
                 }
+                // TashTalk transport lost (device disconnected / reset).
+                // Cancel all tasks so the process shuts down cleanly.
+                tracing::warn!("TashTalk transport closed, shutting down");
+                tash_token.cancel();
             });
 
             Some(tx)

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -774,6 +774,12 @@ impl ShutdownHandle {
         self.transport_token.cancel();
     }
 
+    /// Wait until the transport layer shuts down (e.g. serial device
+    /// disconnected). Useful for detecting when the stack is no longer viable.
+    pub async fn transport_closed(&self) {
+        self.transport_token.cancelled().await;
+    }
+
     /// Close sessions gracefully (e.g. send ASP CloseSess), then stop the
     /// transport once all services confirm they are done, or after 5 seconds.
     pub async fn graceful_shutdown(&self) {


### PR DESCRIPTION
## Summary
- When the TashTalk serial device disconnects (USB reset, cable unplug), the TashTalk task now cancels its `CancellationToken`, causing all other tasks to shut down cleanly
- Previously the task exited silently while AFP server, DDP, NBP etc. kept running with a dead transport

## Test plan
- [ ] Start `afp-server --tashtalk /dev/tashtalk-data-...`
- [ ] Connect from Mac, mount share
- [ ] Reset the Pico (`usbreset` or power cycle)
- [ ] Verify `afp-server` process exits cleanly with "TashTalk transport closed" log message

🤖 Generated with [Claude Code](https://claude.com/claude-code)