### PR TITLE
TailTalk: Gate Pcap usage behind ethertalk flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,28 +341,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ashpd"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
-dependencies = [
- "async-fs",
- "async-net",
- "enumflags2",
- "futures-channel",
- "futures-util",
- "rand",
- "raw-window-handle",
- "serde",
- "serde_repr",
- "url",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "zbus",
-]
-
-[[package]]
 name = "assert_hex"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,17 +385,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-fs"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,17 +411,6 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-net"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
-dependencies = [
- "async-io",
- "blocking",
- "futures-lite",
 ]
 
 [[package]]
@@ -921,6 +877,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1395,23 +1362,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2104,6 +2071,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2722,12 +2690,12 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.13.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4499,6 +4467,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4522,6 +4501,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xoshiro"
@@ -4559,7 +4544,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand",
+ "rand 0.9.3",
  "rand_chacha",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -4679,13 +4664,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4736,26 +4721,29 @@ dependencies = [
 
 [[package]]
 name = "rfd"
-version = "0.15.4"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
 dependencies = [
- "ashpd",
  "block2 0.6.2",
  "dispatch2",
  "js-sys",
+ "libc",
  "log",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
+ "percent-encoding",
  "pollster",
  "raw-window-handle",
- "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "web-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4976,15 +4964,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -5530,7 +5509,7 @@ dependencies = [
  "mac_address",
  "magic-db",
  "pcap",
- "rand",
+ "rand 0.10.1",
  "sled",
  "tailtalk-packets",
  "tashtalk",
@@ -5560,7 +5539,7 @@ dependencies = [
  "tailtalk",
  "tailtalk-packets",
  "tokio",
- "toml 0.8.23",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -5837,25 +5816,13 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
+ "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -5863,12 +5830,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.11"
+name = "toml"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -5887,20 +5860,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -5936,12 +5895,6 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.1",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -6181,14 +6134,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usvg"
@@ -7690,7 +7636,6 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "url",
  "winnow 0.7.15",
  "zvariant_derive",
  "zvariant_utils",

--- a/examples/adsp-stylewriter/Cargo.toml
+++ b/examples/adsp-stylewriter/Cargo.toml
@@ -11,7 +11,7 @@ path = "main.rs"
 [dependencies]
 anyhow = { workspace = true } #unified
 clap = { workspace = true } #unified
-tailtalk = { workspace = true } #unified
+tailtalk = { workspace = true, features = ["ethertalk"] } #unified
 tailtalk-packets = { workspace = true } #unified
 tokio = { workspace = true, features = ["io-util"] } #unified
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/aep-echo/Cargo.toml
+++ b/examples/aep-echo/Cargo.toml
@@ -11,7 +11,7 @@ path = "main.rs"
 [dependencies]
 anyhow = { workspace = true } #unified
 clap = { workspace = true } #unified
-tailtalk = { workspace = true } #unified
+tailtalk = { workspace = true, features = ["ethertalk"] } #unified
 tailtalk-packets = { workspace = true } #unified
 tokio = { workspace = true, features = ["io-util"] } #unified
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/afp-server/Cargo.toml
+++ b/examples/afp-server/Cargo.toml
@@ -10,7 +10,7 @@ path = "main.rs"
 
 [dependencies]
 clap = { workspace = true } #unified
-tailtalk = { workspace = true } #unified
+tailtalk = { workspace = true, features = ["ethertalk"] } #unified
 tailtalk-packets = { workspace = true } #unified
 tokio = { workspace = true, features = ["io-util"] } #unified
 tracing = { workspace = true } #unified

--- a/examples/nbp-lookup/Cargo.toml
+++ b/examples/nbp-lookup/Cargo.toml
@@ -11,7 +11,7 @@ path = "main.rs"
 [dependencies]
 anyhow = { workspace = true } #unified
 clap = { workspace = true } #unified
-tailtalk = { workspace = true } #unified
+tailtalk = { workspace = true, features = ["ethertalk"] } #unified
 tailtalk-packets = { workspace = true } #unified
 tokio = { workspace = true, features = ["io-util"] } #unified
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/pap-print/Cargo.toml
+++ b/examples/pap-print/Cargo.toml
@@ -11,7 +11,7 @@ path = "main.rs"
 [dependencies]
 anyhow = { workspace = true } #unified
 clap = { workspace = true } #unified
-tailtalk = { workspace = true } #unified
+tailtalk = { workspace = true, features = ["ethertalk"] } #unified
 tailtalk-packets = { workspace = true } #unified
 tokio = { workspace = true, features = ["io-util"] } #unified
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/tailtalk-gui/Cargo.toml
+++ b/tailtalk-gui/Cargo.toml
@@ -11,14 +11,14 @@ path = "main.rs"
 [features]
 default = ["tashtalk"]
 tashtalk = ["dep:serialport"]
-ethertalk = ["dep:if-addrs"]
+ethertalk = ["dep:if-addrs", "tailtalk/ethertalk"]
 
 [dependencies]
 anyhow = { workspace = true } #unified
-dirs = "5"
+dirs = "6"
 hfs-reader = { workspace = true } #unified
-if-addrs = { version = "0.13", optional = true }
-rfd = "0.15"
+if-addrs = { version = "0.15", optional = true }
+rfd = "0.17"
 serde = { version = "1", features = ["derive"] }
 serialport = { version = "4", optional = true }
 slint = "1"
@@ -26,7 +26,7 @@ stuffit = { git = "https://github.com/Arctessa/stuffit-rs", branch = "huffman-me
 tailtalk = { workspace = true } #unified
 tailtalk-packets = { workspace = true } #unified
 tokio = { workspace = true, features = ["io-util"] } #unified
-toml = "0.8"
+toml = "^1.1"
 tracing = { workspace = true } #unified
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/tailtalk-gui/main.rs
+++ b/tailtalk-gui/main.rs
@@ -247,10 +247,10 @@ fn main() -> anyhow::Result<()> {
             ui.set_volume_path(v.as_str().into());
         }
         #[cfg(feature = "ethertalk")]
-        if let Some(ref iface) = config.ethernet_interface {
-            if let Some(idx) = ethernet_names.iter().position(|n| n == iface) {
-                ui.set_selected_ethernet(idx as i32);
-            }
+        if let Some(ref iface) = config.ethernet_interface
+            && let Some(idx) = ethernet_names.iter().position(|n| n == iface)
+        {
+            ui.set_selected_ethernet(idx as i32);
         }
         #[cfg(feature = "tashtalk")]
         if let Some(ref port) = config.tashtalk_port {

--- a/tailtalk/Cargo.toml
+++ b/tailtalk/Cargo.toml
@@ -20,10 +20,10 @@ dashmap = "6.1.0"
 encoding_rs = { workspace = true } #unified
 futures = { workspace = true } #unified
 im = "15.1.0"
-mac_address = "1.1"
+mac_address = { version = "1.1", optional = true }
 magic-db = "0.5"
-pcap = { version = "2", features = ["capture-stream"] }
-rand = "0.9.3"
+pcap = { version = "2", features = ["capture-stream"], optional = true }
+rand = "0.10"
 sled = "0.34"
 tailtalk-packets = { workspace = true } #unified
 tashtalk = { workspace = true } #unified
@@ -31,12 +31,13 @@ tokio = { workspace = true, features = ["io-util"] } #unified
 tokio-serial = "5.4.4"
 tokio-util = { version = "0.7.12", features = ["codec"] }
 tracing = { workspace = true } #unified
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-subscriber = { version = "^0.3", features = ["env-filter"] }
 
 [target.'cfg(unix)'.dependencies]
 xattr = "1.3.1"
 
 [features]
+ethertalk = ["dep:pcap", "dep:mac_address"]
 
 [dev-dependencies]
 tempfile = "3.13"

--- a/tailtalk/src/addressing.rs
+++ b/tailtalk/src/addressing.rs
@@ -1,6 +1,6 @@
 use dashmap::DashMap;
 use im::hashmap::HashMap;
-use rand::Rng;
+use rand::RngExt;
 use std::sync::Arc;
 use std::{io::Error, time::Duration};
 use tailtalk_packets::aarp::*;

--- a/tailtalk/src/afp/volume.rs
+++ b/tailtalk/src/afp/volume.rs
@@ -61,7 +61,7 @@ fn infer_type_creator_from_content(path: &Path) -> Option<TypeCreator> {
         // JPEG: type/creator from magic-db !:apple 8BIMJPEG
         "image/jpeg" => Some(TypeCreator { file_type: *b"JPEG", creator: *b"8BIM" }),
         // PNG: no !:apple in magic-db; PNGf is the conventional Classic Mac type
-        "image/png" => Some(TypeCreator { file_type: *b"PNGf", creator: *b"????" }),
+        "image/png" => Some(TypeCreator { file_type: *b"PNGf", creator: *b"ogle" }),
         // PICT: type/creator from magic-db !:apple ????PICT
         "image/x-pict" => Some(TypeCreator { file_type: *b"PICT", creator: *b"ttxt" }),
         _ => None,

--- a/tailtalk/src/ddp.rs
+++ b/tailtalk/src/ddp.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 use std::{
     collections::HashMap,
     io::{self, Error},

--- a/tailtalk/src/ethertalk.rs
+++ b/tailtalk/src/ethertalk.rs
@@ -1,0 +1,267 @@
+use futures::StreamExt;
+use mac_address::mac_address_by_name;
+use tailtalk_packets::aarp;
+use tailtalk_packets::ddp::DdpPacket;
+use tailtalk_packets::ethertalk::{EtherTalkPhase2Frame, EtherTalkPhase2Type};
+use tailtalk_packets::llap::{LlapPacket, LlapType};
+
+use crate::{addressing, ddp, CancellationToken};
+
+struct EtherTalkCodec;
+
+impl pcap::PacketCodec for EtherTalkCodec {
+    type Item = Box<[u8]>;
+    fn decode(&mut self, packet: pcap::Packet) -> Self::Item {
+        packet.data.into()
+    }
+}
+
+fn write_eth1_header(buf: &mut [u8], dst: [u8; 6], src: [u8; 6], ethertype: u16) -> usize {
+    buf[0..6].copy_from_slice(&dst);
+    buf[6..12].copy_from_slice(&src);
+    buf[12..14].copy_from_slice(&ethertype.to_be_bytes());
+    14
+}
+
+fn write_snap_header(
+    buf: &mut [u8],
+    dst: [u8; 6],
+    src: [u8; 6],
+    oui: [u8; 3],
+    ethertype: u16,
+    payload_len: usize,
+) -> usize {
+    buf[0..6].copy_from_slice(&dst);
+    buf[6..12].copy_from_slice(&src);
+    let frame_len = 8 + payload_len; // 3 LLC + 5 SNAP bytes
+    buf[12..14].copy_from_slice(&(frame_len as u16).to_be_bytes());
+    buf[14..17].copy_from_slice(&[0xAA, 0xAA, 0x03]); // LLC DSAP, SSAP, Control
+    buf[17..20].copy_from_slice(&oui);
+    buf[20..22].copy_from_slice(&ethertype.to_be_bytes());
+    22
+}
+
+pub struct EtherTalkTransport {
+    pcap_rx: Option<pcap::Capture<pcap::Active>>,
+    pcap_tx: Option<pcap::Capture<pcap::Active>>,
+    pub our_mac: [u8; 6],
+}
+
+pub struct EtherTalkTx {
+    pcap_tx: Option<pcap::Capture<pcap::Active>>,
+    our_mac: [u8; 6],
+}
+
+impl EtherTalkTransport {
+    pub fn open(intf: &str) -> anyhow::Result<Self> {
+        let mac = mac_address_by_name(intf)?
+            .ok_or_else(|| anyhow::anyhow!("no MAC address found for interface {}", intf))?;
+        let our_mac = mac.bytes();
+
+        let filter = format!(
+            "(ether proto 0x809B or ether proto 0x80F3 or (ether[12:2] <= 1500)) and not ether src {mac}"
+        );
+        tracing::info!("filter string: {filter}");
+
+        let mut rx = pcap::Capture::from_device(intf)?
+            .promisc(true)
+            .immediate_mode(true)
+            .open()?;
+        rx.filter(&filter, true)?;
+
+        let tx = pcap::Capture::from_device(intf)?
+            .promisc(true)
+            .open()?;
+
+        tracing::info!("EtherTalk pcap captures opened on {}", intf);
+
+        Ok(Self { pcap_rx: Some(rx), pcap_tx: Some(tx), our_mac })
+    }
+
+    /// Returns `None` if pcap stream setup fails; the caller should abort the run loop.
+    pub fn spawn_rx_task(
+        self,
+        ddp: ddp::DdpHandle,
+        addressing: addressing::AddressingHandle,
+        token: CancellationToken,
+    ) -> Option<EtherTalkTx> {
+        let EtherTalkTransport { pcap_rx, pcap_tx, our_mac } = self;
+
+        if let Some(rx_cap) = pcap_rx {
+            let rx_cap = match rx_cap.setnonblock() {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::error!("Failed to set pcap nonblocking: {e}");
+                    return None;
+                }
+            };
+            let stream = match rx_cap.stream(EtherTalkCodec) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::error!("Failed to create pcap stream: {e}");
+                    return None;
+                }
+            };
+
+            tokio::spawn(async move {
+                tracing::info!("EtherTalk RX task started");
+                tokio::pin!(stream);
+                loop {
+                    let data: Box<[u8]> = tokio::select! {
+                        _ = token.cancelled() => break,
+                        result = stream.next() => match result {
+                            Some(Ok(d)) => d,
+                            Some(Err(e)) => { tracing::error!("pcap rx error: {e}"); break; }
+                            None => break,
+                        },
+                    };
+
+                    let ethertype_or_len = u16::from_be_bytes([data[12], data[13]]);
+
+                    if ethertype_or_len <= 1500 {
+                        // EtherTalk Phase 2 – IEEE 802.2 LLC/SNAP encapsulation.
+                        match EtherTalkPhase2Frame::parse(&data) {
+                            Err(e) => tracing::debug!("Phase 2 parse failed: {:?}", e),
+                            Ok(header) => {
+                                let payload = &data[EtherTalkPhase2Frame::len()..];
+                                match header.protocol {
+                                    EtherTalkPhase2Type::Ddp => {
+                                        ddp.received_pkt(
+                                            payload,
+                                            aarp::AddressSource::EtherTalkPhase2,
+                                            header.src_mac,
+                                        );
+                                    }
+                                    EtherTalkPhase2Type::Aarp => {
+                                        if let Err(e) = addressing.received_pkt(
+                                            payload,
+                                            aarp::AddressSource::EtherTalkPhase2,
+                                        ) {
+                                            tracing::error!("failed to relay Phase 2 AARP: {e}");
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } else if ethertype_or_len == 0x80F3 {
+                        // EtherTalk Phase 1 AARP.
+                        if data.len() > 14
+                            && let Err(e) = addressing.received_pkt(
+                                &data[14..],
+                                aarp::AddressSource::EtherTalkPhase1,
+                            )
+                        {
+                            tracing::error!("failed to relay Phase 1 AARP: {e}");
+                        }
+                    } else if ethertype_or_len == 0x809B {
+                        // EtherTalk Phase 1 – LLAP encapsulated in Ethernet.
+                        if data.len() > 14 + LlapPacket::LEN
+                            && let Ok(llap) = LlapPacket::parse(&data[14..])
+                        {
+                            match llap.type_ {
+                                LlapType::DdpShort => {
+                                    let payload = &data[(14 + LlapPacket::LEN)..];
+                                    if payload.len() >= 5
+                                        && let Ok(headers) = DdpPacket::parse_short(
+                                            payload,
+                                            llap.dst_node,
+                                            llap.src_node,
+                                        )
+                                    {
+                                        let ddp_payload = payload[5..headers.len.min(payload.len())].into();
+                                        let source_mac: [u8; 6] = data[6..12].try_into().unwrap();
+                                        ddp.received_parsed_pkt(
+                                            headers,
+                                            ddp_payload,
+                                            aarp::AddressSource::EtherTalkPhase1,
+                                            source_mac,
+                                        );
+                                    }
+                                }
+                                LlapType::DdpLong => {
+                                    let payload = &data[(14 + LlapPacket::LEN)..];
+                                    if payload.len() >= DdpPacket::LEN
+                                        && let Ok(headers) = DdpPacket::parse(payload)
+                                    {
+                                        let ddp_payload =
+                                            payload[DdpPacket::LEN..headers.len.min(payload.len())].into();
+                                        let source_mac: [u8; 6] = data[6..12].try_into().unwrap();
+                                        ddp.received_parsed_pkt(
+                                            headers,
+                                            ddp_payload,
+                                            aarp::AddressSource::EtherTalkPhase1,
+                                            source_mac,
+                                        );
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        Some(EtherTalkTx { pcap_tx, our_mac })
+    }
+}
+
+impl EtherTalkTx {
+    pub fn build_ddp_frame(
+        &self,
+        dest: addressing::Node,
+        payload: &[u8],
+        output_buf: &mut [u8],
+    ) -> usize {
+        let payload_len = payload.len();
+        match dest {
+            addressing::Node::EtherTalkPhase1(mac) => {
+                let n = write_eth1_header(output_buf, mac, self.our_mac, 0x809B);
+                // Phase 1 DDP: 3-byte LLAP header (dst, src, type=2) precedes the DDP packet.
+                // Node numbers are extracted from the DDP header bytes 8 and 9.
+                output_buf[n] = if payload_len > 8 { payload[8] } else { 0 };
+                output_buf[n + 1] = if payload_len > 9 { payload[9] } else { 0 };
+                output_buf[n + 2] = 2;
+                output_buf[n + 3..n + 3 + payload_len].copy_from_slice(payload);
+                n + 3 + payload_len
+            }
+            addressing::Node::EtherTalkPhase2(mac) => {
+                let n = write_snap_header(output_buf, mac, self.our_mac, [0x08, 0x00, 0x07], 0x809B, payload_len);
+                output_buf[n..n + payload_len].copy_from_slice(payload);
+                n + payload_len
+            }
+            _ => 0,
+        }
+    }
+
+    pub fn build_aarp_frame(
+        &self,
+        dest: addressing::Node,
+        payload: &[u8],
+        output_buf: &mut [u8],
+    ) -> usize {
+        let payload_len = payload.len();
+        match dest {
+            addressing::Node::EtherTalkPhase1(mac) => {
+                let n = write_eth1_header(output_buf, mac, self.our_mac, 0x80F3);
+                output_buf[n..n + payload_len].copy_from_slice(payload);
+                n + payload_len
+            }
+            addressing::Node::EtherTalkPhase2(mac) => {
+                let n = write_snap_header(output_buf, mac, self.our_mac, [0x00, 0x00, 0x00], 0x80F3, payload_len);
+                output_buf[n..n + payload_len].copy_from_slice(payload);
+                n + payload_len
+            }
+            _ => 0,
+        }
+    }
+
+    pub fn sendpacket(&mut self, output_buf: &[u8], final_size: usize) {
+        if let Some(ref mut tx) = self.pcap_tx {
+            let padded_size = final_size.max(60); // Ethernet minimum frame size
+            if let Err(e) = tx.sendpacket(&output_buf[..padded_size]) {
+                tracing::error!("failed to send packet: {e}");
+            }
+        }
+    }
+}

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -1,16 +1,16 @@
 use anyhow::Error;
-use mac_address::mac_address_by_name;
 use std::path::PathBuf;
 use std::time::SystemTime;
 use tailtalk_packets::aarp;
 use tailtalk_packets::ddp::DdpPacket;
-use tailtalk_packets::ethertalk::{EtherTalkPhase2Frame, EtherTalkPhase2Type};
 use tailtalk_packets::llap::{LlapPacket, LlapType};
 use tashtalk::TashTalk;
 use tokio::sync::mpsc;
 use tokio_serial::SerialPortBuilderExt;
-use futures::StreamExt;
 pub use tokio_util::sync::CancellationToken;
+
+#[cfg(feature = "ethertalk")]
+mod ethertalk;
 
 pub use tashtalk::TashTalkFeatures;
 
@@ -44,24 +44,10 @@ pub struct DataLinkPacket {
     pub src_node_id: u8,
 }
 
-/// Trivial pcap codec that boxes the raw Ethernet frame bytes.
-struct EtherTalkCodec;
-
-impl pcap::PacketCodec for EtherTalkCodec {
-    type Item = Box<[u8]>;
-
-    fn decode(&mut self, packet: pcap::Packet) -> Self::Item {
-        packet.data.into()
-    }
-}
-
 pub struct PacketProcessor {
-    /// RX capture, consumed into an async stream in `run()`.
-    pcap_rx: Option<pcap::Capture<pcap::Active>>,
-    /// TX capture, used for packet injection in the outbound loop.
-    pcap_tx: Option<pcap::Capture<pcap::Active>>,
+    #[cfg(feature = "ethertalk")]
+    transport: Option<ethertalk::EtherTalkTransport>,
     outbound_rx: mpsc::Receiver<DataLinkPacket>,
-    our_mac: Option<[u8; 6]>,
     /// Serial port path for LocalTalk / TashTalk. The port is opened (and
     /// reopened on disconnect) inside the async task spawned by `run()`.
     localtalk_serial_path: Option<String>,
@@ -77,15 +63,6 @@ pub struct PacketProcessor {
 ///
 /// At least one transport must be configured before calling [`build`](PacketProcessorBuilder::build).
 ///
-/// # Example – EtherTalk only
-/// ```no_run
-/// # use tailtalk::PacketProcessor;
-/// let (processor, handle) = PacketProcessor::builder()
-///     .ethernet("eth0")
-///     .build()?;
-/// # Ok::<(), Box<dyn std::error::Error>>(())
-/// ```
-///
 /// # Example – LocalTalk only
 /// ```no_run
 /// # use tailtalk::PacketProcessor;
@@ -95,8 +72,17 @@ pub struct PacketProcessor {
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///
-/// # Example – both transports
-/// ```no_run
+/// # Example – EtherTalk only (requires the `ethertalk` feature)
+/// ```ignore
+/// # use tailtalk::PacketProcessor;
+/// let (processor, handle) = PacketProcessor::builder()
+///     .ethernet("eth0")
+///     .build()?;
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// # Example – both transports (requires the `ethertalk` feature)
+/// ```ignore
 /// # use tailtalk::PacketProcessor;
 /// let (processor, handle) = PacketProcessor::builder()
 ///     .ethernet("eth0")
@@ -105,6 +91,7 @@ pub struct PacketProcessor {
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct PacketProcessorBuilder {
+    #[cfg(feature = "ethertalk")]
     ethernet_intf: Option<String>,
     localtalk_serial_path: Option<String>,
     tashtalk_features: tashtalk::TashTalkFeatures,
@@ -114,6 +101,7 @@ pub struct PacketProcessorBuilder {
 impl PacketProcessorBuilder {
     fn new() -> Self {
         Self {
+            #[cfg(feature = "ethertalk")]
             ethernet_intf: None,
             localtalk_serial_path: None,
             tashtalk_features: tashtalk::TashTalkFeatures::new(),
@@ -122,6 +110,7 @@ impl PacketProcessorBuilder {
     }
 
     /// Configure an EtherTalk transport on the given network interface.
+    #[cfg(feature = "ethertalk")]
     pub fn ethernet(mut self, intf: &str) -> Self {
         self.ethernet_intf = Some(intf.to_string());
         self
@@ -159,39 +148,13 @@ impl PacketProcessorBuilder {
 
     /// Finalise the builder: open pcap captures and the serial port as configured.
     pub fn build(self) -> Result<(PacketProcessor, OutboundHandle), Error> {
-        let mut pcap_rx: Option<pcap::Capture<pcap::Active>> = None;
-        let mut pcap_tx: Option<pcap::Capture<pcap::Active>> = None;
-        let mut our_mac: Option<[u8; 6]> = None;
-
         // ── EtherTalk setup ──────────────────────────────────────────────────
-        if let Some(ref intf) = self.ethernet_intf {
-            // Retrieve the interface MAC address cross-platform.
-            let mac = mac_address_by_name(intf)?
-                .ok_or_else(|| anyhow::anyhow!("no MAC address found for interface {}", intf))?;
-            our_mac = Some(mac.bytes());
-
-            // BPF filter: Phase 1 AppleTalk (0x809B), Phase 1 AARP (0x80F3),
-            // and any IEEE 802.2 LLC/SNAP frame (length field ≤ 1500) for Phase 2.
-            let filter = format!("(ether proto 0x809B or ether proto 0x80F3 or (ether[12:2] <= 1500)) and not ether src {mac}");
-
-            tracing::info!("filter string: {filter}");
-            // RX capture – promiscuous mode, filter applied.
-            let mut rx = pcap::Capture::from_device(intf.as_str())?
-                .promisc(true)
-                .immediate_mode(true)
-                .open()?;
-            rx.filter(&filter, true)?;
-
-            pcap_rx = Some(rx);
-
-            // TX capture – separate handle used solely for packet injection.
-            let tx = pcap::Capture::from_device(intf.as_str())?
-                .promisc(true)
-                .open()?;
-            pcap_tx = Some(tx);
-
-            tracing::info!("EtherTalk pcap captures opened on {}", intf);
-        }
+        #[cfg(feature = "ethertalk")]
+        let transport = if let Some(ref intf) = self.ethernet_intf {
+            Some(ethertalk::EtherTalkTransport::open(intf)?)
+        } else {
+            None
+        };
 
         // ── LocalTalk / TashTalk setup ───────────────────────────────────────
         // Serial port is opened lazily inside the async task (hot-pluggable).
@@ -202,10 +165,9 @@ impl PacketProcessorBuilder {
         let pcap_sender = self.pcap_path.and_then(spawn_pcap_writer);
 
         let processor = PacketProcessor {
-            pcap_rx,
-            pcap_tx,
+            #[cfg(feature = "ethertalk")]
+            transport,
             outbound_rx,
-            our_mac,
             localtalk_serial_path: self.localtalk_serial_path,
             tashtalk_features: self.tashtalk_features,
             pcap_sender,
@@ -277,38 +239,6 @@ fn spawn_pcap_writer(
     Some(tx)
 }
 
-// ── Ethernet framing helpers ──────────────────────────────────────────────────
-
-/// Write a 14-byte EtherTalk Phase 1 Ethernet header into `buf` and return 14.
-fn write_eth1_header(buf: &mut [u8], dst: [u8; 6], src: [u8; 6], ethertype: u16) -> usize {
-    buf[0..6].copy_from_slice(&dst);
-    buf[6..12].copy_from_slice(&src);
-    buf[12..14].copy_from_slice(&ethertype.to_be_bytes());
-    14
-}
-
-/// Write a 22-byte EtherTalk Phase 2 LLC/SNAP header into `buf` and return 22.
-///
-/// `oui` is the 3-byte SNAP OUI: `[0x08, 0x00, 0x07]` for AppleTalk DDP,
-/// `[0x00, 0x00, 0x00]` for AARP.
-fn write_snap_header(
-    buf: &mut [u8],
-    dst: [u8; 6],
-    src: [u8; 6],
-    oui: [u8; 3],
-    ethertype: u16,
-    payload_len: usize,
-) -> usize {
-    buf[0..6].copy_from_slice(&dst);
-    buf[6..12].copy_from_slice(&src);
-    let frame_len = 8 + payload_len; // 3 LLC + 5 SNAP bytes
-    buf[12..14].copy_from_slice(&(frame_len as u16).to_be_bytes());
-    buf[14..17].copy_from_slice(&[0xAA, 0xAA, 0x03]); // LLC DSAP, SSAP, Control
-    buf[17..20].copy_from_slice(&oui);
-    buf[20..22].copy_from_slice(&ethertype.to_be_bytes());
-    22
-}
-
 // ── PacketProcessor ───────────────────────────────────────────────────────────
 
 impl PacketProcessor {
@@ -319,7 +249,10 @@ impl PacketProcessor {
     /// Returns the Ethernet MAC address of the configured interface, or `None`
     /// if no EtherTalk transport was added.
     pub fn get_mac(&self) -> Option<[u8; 6]> {
-        self.our_mac
+        #[cfg(feature = "ethertalk")]
+        return self.transport.as_ref().map(|t| t.our_mac);
+        #[cfg(not(feature = "ethertalk"))]
+        None
     }
 
     pub async fn run(
@@ -329,132 +262,26 @@ impl PacketProcessor {
         ddp: ddp::DdpHandle,
         token: CancellationToken,
     ) {
+        #[cfg(not(feature = "ethertalk"))]
+        let _ = et_addressing;
+
         // Extract pcap senders before any other field moves.
         // pcap_rx_sender goes into the TashTalk receive task; pcap_tx_sender stays in the outbound loop.
         let pcap_rx_sender = self.pcap_sender.clone();
         let pcap_tx_sender = self.pcap_sender;
 
-        // ── EtherTalk RX task ────────────────────────────────────────────────
-        if let Some(rx_cap) = self.pcap_rx {
-            let ddp_rx = ddp.clone();
-            let addressing_rx = et_addressing.clone().expect("EtherTalk RX task requires ET addressing");
-            let rx_token = token.clone();
-
-            let rx_cap = match rx_cap.setnonblock() {
-                Ok(c) => c,
-                Err(e) => {
-                    tracing::error!("Failed to set pcap nonblocking: {e}");
-                    return;
-                }
-            };
-            let stream = match rx_cap.stream(EtherTalkCodec) {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::error!("Failed to create pcap stream: {e}");
-                    return;
-                }
-            };
-
-            tokio::spawn(async move {
-                tracing::info!("EtherTalk RX task started");
-                tokio::pin!(stream);
-                loop {
-                    let data: Box<[u8]> = tokio::select! {
-                        _ = rx_token.cancelled() => break,
-                        result = stream.next() => match result {
-                            Some(Ok(d)) => d,
-                            Some(Err(e)) => { tracing::error!("pcap rx error: {e}"); break; }
-                            None => break,
-                        },
-                    };
-
-                    let ethertype_or_len = u16::from_be_bytes([data[12], data[13]]);
-
-                    if ethertype_or_len <= 1500 {
-                        // EtherTalk Phase 2 – IEEE 802.2 LLC/SNAP encapsulation.
-                        match EtherTalkPhase2Frame::parse(&data) {
-                            Err(e) => tracing::debug!("Phase 2 parse failed: {:?}", e),
-                            Ok(header) => {
-                                let payload = &data[EtherTalkPhase2Frame::len()..];
-                                match header.protocol {
-                                    EtherTalkPhase2Type::Ddp => {
-                                        ddp_rx.received_pkt(
-                                            payload,
-                                            aarp::AddressSource::EtherTalkPhase2,
-                                            header.src_mac,
-                                        );
-                                    }
-                                    EtherTalkPhase2Type::Aarp => {
-                                        if let Err(e) = addressing_rx.received_pkt(
-                                            payload,
-                                            aarp::AddressSource::EtherTalkPhase2,
-                                        ) {
-                                            tracing::error!("failed to relay Phase 2 AARP: {e}");
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    } else if ethertype_or_len == 0x80F3 {
-                        // EtherTalk Phase 1 AARP.
-                        if data.len() > 14
-                            && let Err(e) = addressing_rx.received_pkt(
-                                &data[14..],
-                                aarp::AddressSource::EtherTalkPhase1,
-                            )
-                        {
-                            tracing::error!("failed to relay Phase 1 AARP: {e}");
-                        }
-                    } else if ethertype_or_len == 0x809B {
-                        // EtherTalk Phase 1 – LLAP encapsulated in Ethernet.
-                        if data.len() > 14 + LlapPacket::LEN
-                            && let Ok(llap) = LlapPacket::parse(&data[14..])
-                        {
-                            match llap.type_ {
-                                LlapType::DdpShort => {
-                                    let payload = &data[(14 + LlapPacket::LEN)..];
-                                    if payload.len() >= 5
-                                        && let Ok(headers) = DdpPacket::parse_short(
-                                            payload,
-                                            llap.dst_node,
-                                            llap.src_node,
-                                        )
-                                    {
-                                        let ddp_payload = payload[5..headers.len.min(payload.len())].into();
-                                        let source_mac: [u8; 6] =
-                                            data[6..12].try_into().unwrap();
-                                        ddp_rx.received_parsed_pkt(
-                                            headers,
-                                            ddp_payload,
-                                            aarp::AddressSource::EtherTalkPhase1,
-                                            source_mac,
-                                        );
-                                    }
-                                }
-                                LlapType::DdpLong => {
-                                    let payload = &data[(14 + LlapPacket::LEN)..];
-                                    if payload.len() >= DdpPacket::LEN
-                                        && let Ok(headers) = DdpPacket::parse(payload)
-                                    {
-                                        let ddp_payload =
-                                            payload[DdpPacket::LEN..headers.len.min(payload.len())].into();
-                                        let source_mac: [u8; 6] =
-                                            data[6..12].try_into().unwrap();
-                                        ddp_rx.received_parsed_pkt(
-                                            headers,
-                                            ddp_payload,
-                                            aarp::AddressSource::EtherTalkPhase1,
-                                            source_mac,
-                                        );
-                                    }
-                                }
-                                _ => {}
-                            }
-                        }
-                    }
-                }
-            });
-        }
+        // ── EtherTalk: spawn RX task, obtain TX handle ──────────────────────
+        #[cfg(feature = "ethertalk")]
+        let mut et_tx = if let Some(transport) = self.transport {
+            let addressing = et_addressing.clone()
+                .expect("EtherTalk transport requires ET addressing");
+            match transport.spawn_rx_task(ddp.clone(), addressing, token.clone()) {
+                None => return,
+                Some(tx) => Some(tx),
+            }
+        } else {
+            None
+        };
 
         // ── TashTalk async task ──────────────────────────────────────────────
         // Spawned here rather than in the builder because it needs the addressing
@@ -629,9 +456,7 @@ impl PacketProcessor {
         };
 
         // ── Outbound TX loop ─────────────────────────────────────────────────
-        let our_mac = self.our_mac.unwrap_or([0; 6]);
         let mut rx = self.outbound_rx;
-        let mut pcap_tx = self.pcap_tx;
 
         // Wait for TashTalk init unless no LocalTalk is configured.
         // If the device isn't present yet, proceed — outbound frames to
@@ -655,22 +480,9 @@ impl PacketProcessor {
             let final_size = match pkt.protocol {
                 DataLinkProtocol::Ddp => {
                     match pkt.dest_node {
-                        addressing::Node::EtherTalkPhase1(mac) => {
-                            let payload_len = pkt.payload.len();
-                            let n = write_eth1_header(&mut output_buf, mac, our_mac, 0x809B);
-                            // Phase 1 DDP: 3-byte LLAP header (dst, src, type=2) precedes the DDP packet.
-                            // Node numbers are extracted from the DDP header bytes 8 and 9.
-                            output_buf[n] = if payload_len > 8 { pkt.payload[8] } else { 0 };
-                            output_buf[n + 1] = if payload_len > 9 { pkt.payload[9] } else { 0 };
-                            output_buf[n + 2] = 2;
-                            output_buf[n + 3..n + 3 + payload_len].copy_from_slice(&pkt.payload);
-                            n + 3 + payload_len
-                        }
-                        addressing::Node::EtherTalkPhase2(mac) => {
-                            let payload_len = pkt.payload.len();
-                            let n = write_snap_header(&mut output_buf, mac, our_mac, [0x08, 0x00, 0x07], 0x809B, payload_len);
-                            output_buf[n..n + payload_len].copy_from_slice(&pkt.payload);
-                            n + payload_len
+                        #[cfg(feature = "ethertalk")]
+                        addressing::Node::EtherTalkPhase1(_) | addressing::Node::EtherTalkPhase2(_) => {
+                            et_tx.as_ref().map_or(0, |t| t.build_ddp_frame(pkt.dest_node, &pkt.payload, &mut output_buf))
                         }
                         addressing::Node::LocalTalk(node_id) => {
                             let llap_pkt = LlapPacket {
@@ -693,6 +505,8 @@ impl PacketProcessor {
 
                             frame_end + 2
                         }
+                        #[cfg(not(feature = "ethertalk"))]
+                        _ => 0,
                     }
                 }
                 DataLinkProtocol::LlapEnq | DataLinkProtocol::LlapAck => {
@@ -720,19 +534,14 @@ impl PacketProcessor {
                     }
                 }
                 DataLinkProtocol::Aarp => {
-                    let payload_len = pkt.payload.len();
                     match pkt.dest_node {
-                        addressing::Node::EtherTalkPhase1(mac) => {
-                            let n = write_eth1_header(&mut output_buf, mac, our_mac, 0x80F3);
-                            output_buf[n..n + payload_len].copy_from_slice(&pkt.payload);
-                            n + payload_len
-                        }
-                        addressing::Node::EtherTalkPhase2(mac) => {
-                            let n = write_snap_header(&mut output_buf, mac, our_mac, [0x00, 0x00, 0x00], 0x80F3, payload_len);
-                            output_buf[n..n + payload_len].copy_from_slice(&pkt.payload);
-                            n + payload_len
+                        #[cfg(feature = "ethertalk")]
+                        addressing::Node::EtherTalkPhase1(_) | addressing::Node::EtherTalkPhase2(_) => {
+                            et_tx.as_ref().map_or(0, |t| t.build_aarp_frame(pkt.dest_node, &pkt.payload, &mut output_buf))
                         }
                         addressing::Node::LocalTalk(_) => 0,
+                        #[cfg(not(feature = "ethertalk"))]
+                        _ => 0,
                     }
                 }
             };
@@ -742,12 +551,10 @@ impl PacketProcessor {
             }
 
             match pkt.dest_node {
+                #[cfg(feature = "ethertalk")]
                 addressing::Node::EtherTalkPhase1(_) | addressing::Node::EtherTalkPhase2(_) => {
-                    if let Some(ref mut tx) = pcap_tx {
-                        let padded_size = final_size.max(60);
-                        if let Err(e) = tx.sendpacket(&output_buf[..padded_size]) {
-                            tracing::error!("failed to send packet: {e}");
-                        }
+                    if let Some(ref mut t) = et_tx {
+                        t.sendpacket(&output_buf, final_size);
                     }
                 }
                 addressing::Node::LocalTalk(_) => {
@@ -764,6 +571,8 @@ impl PacketProcessor {
                         let _ = tx.try_send((SystemTime::now(), output_buf[..frame_len].to_vec()));
                     }
                 }
+                #[cfg(not(feature = "ethertalk"))]
+                _ => {}
             }
         }
     }
@@ -832,7 +641,7 @@ impl ShutdownHandle {
 /// # use tailtalk::{TalkStack, afp::AfpServerConfig};
 /// # async fn example() -> anyhow::Result<()> {
 /// let stack = TalkStack::builder()
-///     .ethernet("eth0")
+///     .localtalk("/dev/ttyUSB0")
 ///     .build()
 ///     .await?;
 ///
@@ -925,9 +734,11 @@ impl TalkStack {
 
 /// Builder for [`TalkStack`].
 pub struct TalkStackBuilder {
+    #[cfg(feature = "ethertalk")]
     ethernet_intf: Option<String>,
     localtalk_serial_path: Option<String>,
     tashtalk_features: tashtalk::TashTalkFeatures,
+    #[cfg(feature = "ethertalk")]
     fixed_addr: Option<tailtalk_packets::aarp::AppleTalkAddress>,
     lt_fixed_node: Option<u8>,
     pcap_path: Option<PathBuf>,
@@ -936,9 +747,11 @@ pub struct TalkStackBuilder {
 impl TalkStack {
     pub fn builder() -> TalkStackBuilder {
         TalkStackBuilder {
+            #[cfg(feature = "ethertalk")]
             ethernet_intf: None,
             localtalk_serial_path: None,
             tashtalk_features: tashtalk::TashTalkFeatures::new(),
+            #[cfg(feature = "ethertalk")]
             fixed_addr: None,
             lt_fixed_node: None,
             pcap_path: None,
@@ -948,6 +761,7 @@ impl TalkStack {
 
 impl TalkStackBuilder {
     /// Configure an EtherTalk transport on the given network interface.
+    #[cfg(feature = "ethertalk")]
     pub fn ethernet(mut self, intf: &str) -> Self {
         self.ethernet_intf = Some(intf.to_string());
         self
@@ -982,6 +796,7 @@ impl TalkStackBuilder {
     }
 
     /// Use a fixed AppleTalk address on EtherTalk instead of probing via AARP.
+    #[cfg(feature = "ethertalk")]
     pub fn fixed_address(mut self, network: u16, node: u8) -> Self {
         self.fixed_addr = Some(tailtalk_packets::aarp::AppleTalkAddress {
             network_number: network,
@@ -996,6 +811,7 @@ impl TalkStackBuilder {
     /// order, then starts the [`PacketProcessor`] background task.
     pub async fn build(self) -> Result<TalkStack, Error> {
         let mut pp = PacketProcessor::builder().tashtalk_features(self.tashtalk_features);
+        #[cfg(feature = "ethertalk")]
         if let Some(ref intf) = self.ethernet_intf {
             pp = pp.ethernet(intf);
         }
@@ -1008,6 +824,7 @@ impl TalkStackBuilder {
         let (processor, outbound) = pp.build()?;
 
         // EtherTalk addressing: AARP probe (or fixed address if caller specified one).
+        #[cfg(feature = "ethertalk")]
         let et_addressing = if self.ethernet_intf.is_some() {
             Some(addressing::Addressing::spawn(
                 processor.get_mac(),
@@ -1018,6 +835,8 @@ impl TalkStackBuilder {
         } else {
             None
         };
+        #[cfg(not(feature = "ethertalk"))]
+        let et_addressing: Option<addressing::AddressingHandle> = None;
 
         let lt_addressing = if self.localtalk_serial_path.is_some() {
             let lt_fixed = self.lt_fixed_node.map(|node| tailtalk_packets::aarp::AppleTalkAddress {


### PR DESCRIPTION
Refactors our code base so only if the "ethertalk" feature flag is set do we actually pull in the pcap crate. This makes it so our packages published on GitHub which has this feature disabled does not actually require libpcap to be bundled (for macOS / Linux) or installed (for Windows).

Additionally bumps our deps to the latest versions and some minor changes associated with the crate bumps.