### PR TITLE
PAP: Fix protocol bugs and add pap-print query subcommands

### DIFF
--- a/examples/pap-print/main.rs
+++ b/examples/pap-print/main.rs
@@ -1,24 +1,50 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use tailtalk::{
     TalkStack,
     atp::AtpAddress,
 };
 use tailtalk_packets::nbp::EntityName;
+use tokio::time::Duration;
 
 #[derive(Parser, Debug)]
-#[command(about = "Print a PostScript file to a PAP-capable AppleTalk printer")]
+#[command(about = "Print and query PAP-capable AppleTalk printers")]
 struct Args {
-    /// Network interface to bind to
-    #[arg(short, long)]
-    interface: String,
+    /// Network interface to bind to (EtherTalk)
+    #[arg(short, long, global = true)]
+    interface: Option<String>,
+
+    /// TashTalk serial port path (LocalTalk)
+    #[arg(short, long, global = true)]
+    tashtalk: Option<String>,
 
     /// Printer entity name to look up, e.g. "LaserWriter 4/600:LaserWriter@*"
-    #[arg(short, long, default_value = "=:LaserWriter@*")]
+    #[arg(short, long, global = true, default_value = "=:LaserWriter@*")]
     printer: String,
 
-    /// PostScript file to print (omit for a built-in test page)
-    #[arg(short, long)]
-    file: Option<String>,
+    /// Write a LocalTalk pcap capture to this file
+    #[arg(long, global = true)]
+    pcap: Option<String>,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Print a PostScript file (omit --file for a built-in test page)
+    Print {
+        /// PostScript file to send
+        #[arg(short, long)]
+        file: Option<String>,
+    },
+    /// Query the printer's PAP status string
+    Status,
+    /// Query printer settings via the PostScript Query Protocol (PQP)
+    Query,
+    /// Dump the entire statusdict (all keys and values) for diagnostics
+    DumpStatusdict,
+    /// Connect to the printer and immediately close the connection (for diagnostics)
+    TestClose,
 }
 
 #[tokio::main]
@@ -27,27 +53,38 @@ async fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
 
+    if args.interface.is_none() && args.tashtalk.is_none() {
+        anyhow::bail!("at least one of --interface or --tashtalk is required");
+    }
+
     let entity: EntityName = args
         .printer
         .as_str()
         .try_into()
         .map_err(|e| anyhow::anyhow!("Invalid printer name: {}", e))?;
 
-    let stack = TalkStack::builder()
-        .ethernet(&args.interface)
+    let mut builder = TalkStack::builder();
+    if let Some(ref intf) = args.interface {
+        builder = builder.ethernet(intf);
+    }
+    if let Some(ref tty) = args.tashtalk {
+        builder = builder.localtalk(tty);
+    }
+    if let Some(ref path) = args.pcap {
+        builder = builder.pcap_capture(path);
+    }
+    let stack = builder
         .build()
         .await
         .expect("failed to build AppleTalk stack");
 
-    // Locate the printer via NBP
-    println!("Looking up printer '{}'...", entity);
     let tuples = stack.nbp.lookup(entity).await?;
     let printer = tuples
         .first()
         .ok_or_else(|| anyhow::anyhow!("Printer not found on network"))?;
 
     println!(
-        "Found printer {} at {}.{} socket {}",
+        "Found {} at {}.{} socket {}",
         printer.entity_name, printer.network_number, printer.node_id, printer.socket_number
     );
 
@@ -57,20 +94,77 @@ async fn main() -> anyhow::Result<()> {
         socket_number: printer.socket_number,
     };
 
-    // Query status
-    println!("Querying printer status...");
-    match stack.pap_status(printer_addr).await {
-        Ok(status) => println!("Printer status: '{}'", status),
-        Err(e) => println!("Could not get status: {}", e),
-    }
+    match args.command {
+        Command::Status => {
+            let status = stack.pap_status(printer_addr).await?;
+            println!("{}", status);
+        }
 
-    // Prepare data
-    let data = if let Some(path) = &args.file {
-        println!("Reading file '{}'...", path);
-        std::fs::read(path)?
-    } else {
-        println!("Using built-in test page...");
-        b"%!PS-Adobe-2.0
+        Command::Query => {
+            let labels = &[
+                "Product", "PS Version", "Firmware Rev", "Resolution",
+                "RAM (bytes)", "Page count", "Page size (pts)", "AppleTalk type",
+            ];
+
+            // All queries in one job. `stopped` isolates failures per entry; `printval`
+            // handles arrays (e.g. PageSize). Procedure entries need `begin/end` to call them.
+            let job =
+                "%!PS-Adobe-3.0\n\
+                 %%EndComments\n\
+                 errordict /handleerror {} put\n\
+                 /printval {\n\
+                   dup type /arraytype eq {\n\
+                     { dup type /stringtype eq { print } { 20 string cvs print } ifelse ( ) print } forall\n\
+                     (\\n) print\n\
+                   } { = } ifelse\n\
+                 } def\n\
+                 { statusdict /product get printval } stopped { (error) = } if\n\
+                 { version printval } stopped { (error) = } if\n\
+                 { statusdict /revision get printval } stopped { (error) = } if\n\
+                 { statusdict /resolution get printval } stopped { currentpagedevice /HWResolution get 0 get printval } if\n\
+                 { statusdict begin ramsize end printval } stopped { (error) = } if\n\
+                 { statusdict begin pagecount end printval } stopped { (error) = } if\n\
+                 { currentpagedevice /PageSize get printval } stopped { (error) = } if\n\
+                 { statusdict /appletalktype get printval } stopped { (error) = } if\n\
+                 flush\n\
+                 %%EOF\n";
+
+            let mut client = stack.pap_client().await;
+            client.connect(printer_addr).await?;
+            client.print_stream(std::io::Cursor::new(job.as_bytes())).await?;
+
+            let response_bytes = tokio::time::timeout(
+                Duration::from_secs(15),
+                client.read_response(),
+            ).await.unwrap_or_else(|_| Ok(vec![]))?;
+
+            client.close().await?;
+
+            let response = String::from_utf8_lossy(&response_bytes);
+            let mut lines = response.lines();
+            for label in labels {
+                let value = lines.next().unwrap_or("no response");
+                println!("{label}: {}", if value.is_empty() { "no response" } else { value });
+            }
+        }
+
+        Command::Print { file } => {
+            println!("Querying status...");
+            match stack.pap_status(printer_addr).await {
+                Ok(status) => println!("Status: {}", status),
+                Err(e) => println!("Could not get status: {}", e),
+            }
+
+            let mut client = stack.pap_client().await;
+            client.connect(printer_addr).await?;
+
+            if let Some(path) = file {
+                println!("Sending '{}'...", path);
+                let f = tokio::fs::File::open(&path).await?;
+                client.print_stream(f).await?;
+            } else {
+                println!("Sending built-in test page...");
+                let data: &[u8] = b"%!PS-Adobe-2.0
 %%Title: TailTalk Test Page
 %%Creator: TailTalk pap-print
 %%EndComments
@@ -78,18 +172,45 @@ async fn main() -> anyhow::Result<()> {
 72 720 moveto
 (TailTalk PAP Test) show
 showpage
-"
-        .to_vec()
-    };
+";
+                client.print_stream(std::io::Cursor::new(data)).await?;
+            }
 
-    println!("Connecting to printer ({} bytes to send)...", data.len());
-    let mut client = stack.pap_client().await;
-    client.connect(printer_addr).await?;
+            println!("Done.");
+        }
 
-    println!("Printing...");
-    client.print(&data).await?;
+        Command::DumpStatusdict => {
+            let job =
+                "%!PS-Adobe-3.0\n\
+                 %%EndComments\n\
+                 errordict /handleerror {} put\n\
+                 statusdict { exch = = } forall\n\
+                 flush\n\
+                 %%EOF\n";
 
-    println!("Print job finished successfully!");
+            let mut client = stack.pap_client().await;
+            client.connect(printer_addr).await?;
+            client.print_stream(std::io::Cursor::new(job.as_bytes())).await?;
+
+            let response_bytes = tokio::time::timeout(
+                Duration::from_secs(15),
+                client.read_response(),
+            ).await.unwrap_or_else(|_| Ok(vec![]))?;
+
+            client.close().await?;
+
+            print!("{}", String::from_utf8_lossy(&response_bytes));
+        }
+
+        Command::TestClose => {
+            println!("Connecting...");
+            let mut client = stack.pap_client().await;
+            client.connect(printer_addr).await?;
+            println!("Connected. Sending CloseConn...");
+            client.close().await?;
+            println!("CloseConn acknowledged.");
+        }
+    }
 
     Ok(())
 }

--- a/tailtalk-packets/src/nbp.rs
+++ b/tailtalk-packets/src/nbp.rs
@@ -56,7 +56,7 @@ pub struct NbpTuple {
 }
 
 /// Represents an entity name in NBP.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct EntityName {
     pub object: String,      // Object name
     pub entity_type: String, // Type of the entity (e.g., service type)

--- a/tailtalk-packets/src/pap.rs
+++ b/tailtalk-packets/src/pap.rs
@@ -1,4 +1,3 @@
-use byteorder::{BigEndian, ByteOrder};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -45,16 +44,18 @@ impl TryFrom<u8> for PapFunction {
 
 /// PAP packet structure
 ///
-/// PAP packets are sent over ATP and have the following format:
+/// PAP packets are sent over ATP. For Data/SendData the ATP user bytes are:
 /// - Byte 0: Connection ID
 /// - Byte 1: Function code
-/// - Bytes 2-3: Sequence number (for some functions)
-/// - Remaining bytes: Function-specific data
+/// - Byte 2: EOF flag (Data only; 0 = more data, non-zero = end of job)
+/// - Byte 3: Sequence number (Data and SendData; wraps mod 256)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PapPacket {
     pub connection_id: u8,
     pub function: PapFunction,
     pub sequence_num: u16,
+    /// End-of-file flag; only meaningful for Data packets.
+    pub eof: bool,
     pub data: Vec<u8>,
 }
 
@@ -74,8 +75,8 @@ impl PapPacket {
         let connection_id = buf[0];
         let function = PapFunction::try_from(buf[1])?;
 
-        // Some functions include a sequence number, others don't
-        let (sequence_num, data_start) = match function {
+        // Data and SendData carry a sequence number in byte 3; Data also has an EOF flag in byte 2.
+        let (sequence_num, eof, data_start) = match function {
             PapFunction::SendData | PapFunction::Data => {
                 if buf.len() < 4 {
                     return Err(PapError::InvalidSize {
@@ -83,9 +84,10 @@ impl PapPacket {
                         found: buf.len(),
                     });
                 }
-                (BigEndian::read_u16(&buf[2..4]), 4)
+                let eof = function == PapFunction::Data && buf[2] != 0;
+                (buf[3] as u16, eof, 4)
             }
-            _ => (0, 2),
+            _ => (0, false, 2),
         };
 
         let data = buf[data_start..].to_vec();
@@ -94,6 +96,7 @@ impl PapPacket {
             connection_id,
             function,
             sequence_num,
+            eof,
             data,
         })
     }
@@ -116,7 +119,9 @@ impl PapPacket {
         buf[1] = self.function as u8;
 
         if has_seq_num {
-            BigEndian::write_u16(&mut buf[2..4], self.sequence_num);
+            // Byte 2: EOF flag (Data only), byte 3: sequence number (mod 256).
+            buf[2] = if self.function == PapFunction::Data { self.eof as u8 } else { 0 };
+            buf[3] = self.sequence_num as u8;
             buf[4..total_len].copy_from_slice(&self.data);
         } else {
             buf[2..total_len].copy_from_slice(&self.data);
@@ -150,10 +155,18 @@ impl PapPacket {
         user_bytes[0] = self.connection_id;
         user_bytes[1] = self.function as u8;
 
-        if matches!(self.function, PapFunction::SendData | PapFunction::Data) {
-            BigEndian::write_u16(&mut user_bytes[2..4], self.sequence_num);
+        match self.function {
+            PapFunction::Data => {
+                // Byte 2: EOF flag, byte 3: sequence number (mod 256).
+                user_bytes[2] = self.eof as u8;
+                user_bytes[3] = self.sequence_num as u8;
+            }
+            PapFunction::SendData => {
+                // Byte 2: reserved (0), byte 3: sequence number (mod 256).
+                user_bytes[3] = self.sequence_num as u8;
+            }
+            _ => {}
         }
-        // All other PAP functions: bytes 2-3 in user_bytes remain zero
 
         (user_bytes, &self.data)
     }
@@ -163,15 +176,17 @@ impl PapPacket {
         let connection_id = user_bytes[0];
         let function = PapFunction::try_from(user_bytes[1])?;
 
-        let sequence_num = match function {
-            PapFunction::SendData | PapFunction::Data => BigEndian::read_u16(&user_bytes[2..4]),
-            _ => 0,
+        let (sequence_num, eof) = match function {
+            PapFunction::Data => (user_bytes[3] as u16, user_bytes[2] != 0),
+            PapFunction::SendData => (user_bytes[3] as u16, false),
+            _ => (0, false),
         };
 
         Ok(Self {
             connection_id,
             function,
             sequence_num,
+            eof,
             data: data.to_vec(),
         })
     }
@@ -212,7 +227,8 @@ mod tests {
         let packet = PapPacket {
             connection_id: 7,
             function: PapFunction::OpenConnReply,
-            sequence_num: 0,                          // Not used for OpenConnReply
+            sequence_num: 0,
+            eof: false,
             data: vec![0x42, 0x00, 0x08, 0x00, 0x01], // socket, flow_quantum, result
         };
 
@@ -229,6 +245,7 @@ mod tests {
             connection_id: 3,
             function: PapFunction::Data,
             sequence_num: 42,
+            eof: false,
             data: b"PostScript data".to_vec(),
         };
 
@@ -238,7 +255,8 @@ mod tests {
         assert_eq!(len, 4 + 15); // 4 byte header + 15 bytes data
         assert_eq!(buf[0], 3); // connection_id
         assert_eq!(buf[1], 4); // function code for Data
-        assert_eq!(BigEndian::read_u16(&buf[2..4]), 42); // sequence_num
+        assert_eq!(buf[2], 0); // EOF flag (false)
+        assert_eq!(buf[3], 42); // sequence_num
         assert_eq!(&buf[4..len], b"PostScript data");
     }
 
@@ -248,6 +266,7 @@ mod tests {
             connection_id: 10,
             function: PapFunction::Tickle,
             sequence_num: 0,
+            eof: false,
             data: vec![],
         };
 
@@ -265,6 +284,7 @@ mod tests {
             connection_id: 15,
             function: PapFunction::SendData,
             sequence_num: 100,
+            eof: false,
             data: b"Test print job data".to_vec(),
         };
 
@@ -293,6 +313,7 @@ mod tests {
             connection_id: 1,
             function: PapFunction::Status,
             sequence_num: 0,
+            eof: false,
             data: vec![1, 2, 3, 4, 5],
         };
 
@@ -306,14 +327,16 @@ mod tests {
         let original = PapPacket {
             connection_id: 10,
             function: PapFunction::SendData,
-            sequence_num: 12345,
+            sequence_num: 57,
+            eof: false,
             data: b"Data Payload".to_vec(),
         };
 
         let (user_bytes, data) = original.to_atp_parts();
         assert_eq!(user_bytes[0], 10);
         assert_eq!(user_bytes[1], 3); // SendData
-        assert_eq!(BigEndian::read_u16(&user_bytes[2..4]), 12345);
+        assert_eq!(user_bytes[2], 0); // reserved
+        assert_eq!(user_bytes[3], 57); // sequence_num
         assert_eq!(data, b"Data Payload");
 
         let parsed = PapPacket::parse_from_atp(user_bytes, data).expect("failed to parse from atp");

--- a/tailtalk/src/atp.rs
+++ b/tailtalk/src/atp.rs
@@ -140,15 +140,38 @@ impl AtpReceivedRequest {
             })
             .collect();
 
-        // Always send at least one packet (e.g. empty ASP OpenSession replies)
+        // ATP requires at least one TResp even for zero-length data.
         if packets.is_empty() {
-            packets.push(AtpResponse {
-                data: vec![],
-                user_bytes,
-            });
+            packets.push(AtpResponse { data: vec![], user_bytes });
         }
 
-        // Send via internal method
+        self.send_response_internal(packets).await
+    }
+
+    /// Send a response fragmented at `chunk_size` bytes per ATP packet.
+    ///
+    /// Use this when the protocol layer imposes a stricter per-packet limit than
+    /// `ATP_MAX_DATA_PER_PACKET`. PAP, for example, caps each packet at 512 bytes.
+    pub async fn send_response_chunked(
+        &self,
+        data: Vec<u8>,
+        user_bytes: [u8; 4],
+        chunk_size: usize,
+    ) -> Result<(), io::Error> {
+        assert!(chunk_size > 0, "chunk_size must be positive");
+        let effective_bitmap = if self.bitmap == 0x00 { 0xFF } else { self.bitmap };
+        let max_packets = (effective_bitmap.count_ones() as usize).clamp(1, 8);
+        let max_data = max_packets * chunk_size;
+
+        let mut packets: Vec<AtpResponse> = data[..data.len().min(max_data)]
+            .chunks(chunk_size)
+            .map(|chunk| AtpResponse { data: chunk.to_vec(), user_bytes })
+            .collect();
+
+        if packets.is_empty() {
+            packets.push(AtpResponse { data: vec![], user_bytes });
+        }
+
         self.send_response_internal(packets).await
     }
 

--- a/tailtalk/src/ddp.rs
+++ b/tailtalk/src/ddp.rs
@@ -52,6 +52,12 @@ pub struct DdpSocket {
     sender: mpsc::Sender<DdpCommand>,
 }
 
+impl Drop for DdpSocket {
+    fn drop(&mut self) {
+        let _ = self.sender.try_send(DdpCommand::Deregister(self.sock_num));
+    }
+}
+
 impl DdpSocket {
     pub async fn recv(&mut self) -> Result<Packet, io::Error> {
         let res = self
@@ -146,6 +152,9 @@ impl DdpProcessor {
                 DdpCommand::SendPkt(pkt) => {
                     self.handle_outbound(pkt).await;
                 }
+                DdpCommand::Deregister(sock_num) => {
+                    self.sockets.remove(&sock_num);
+                }
             }
         }
     }
@@ -155,13 +164,25 @@ impl DdpProcessor {
         protocol: DdpProtocolType,
         sock_num: Option<SockNum>,
     ) -> Result<DdpSocket, io::Error> {
-        let sock_num = sock_num.unwrap_or_else(|| {
-            rand::rng().random_range(64..=255)
-        });
-
-        if self.sockets.contains_key(&sock_num) {
-            return Err(io::Error::from(io::ErrorKind::AddrInUse));
-        }
+        let sock_num = if let Some(n) = sock_num {
+            if self.sockets.contains_key(&n) {
+                return Err(io::Error::from(io::ErrorKind::AddrInUse));
+            }
+            n
+        } else {
+            let mut rng = rand::rng();
+            let mut candidate = rng.random_range(64u8..=255);
+            for _ in 0..192u16 {
+                if !self.sockets.contains_key(&candidate) {
+                    break;
+                }
+                candidate = rng.random_range(64..=255);
+            }
+            if self.sockets.contains_key(&candidate) {
+                return Err(io::Error::from(io::ErrorKind::AddrInUse));
+            }
+            candidate
+        };
 
         let (tx, rx) = mpsc::channel(100);
         let sock = DdpSocket {
@@ -387,6 +408,7 @@ enum DdpCommand {
     NewSocket(SockArgs),
     ReceivedPkt(DdpPacket),
     SendPkt(OutboundPacket),
+    Deregister(SockNum),
 }
 
 #[derive(Clone)]

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -718,10 +718,9 @@ impl TalkStack {
         adsp::Adsp::connect(&self.ddp, remote_addr).await
     }
 
-    /// Create a PAP client backed by two fresh ATP sockets.
+    /// Create a PAP client backed by a single ATP socket.
     pub async fn pap_client(&self) -> pap::PapClient {
-        let (_, atp_requestor, _) = atp::Atp::spawn(&self.ddp, None).await;
-        let (_, _, atp_responder) = atp::Atp::spawn(&self.ddp, None).await;
+        let (_, atp_requestor, atp_responder) = atp::Atp::spawn(&self.ddp, None).await;
         pap::PapClient::new(atp_requestor, atp_responder)
     }
 

--- a/tailtalk/src/pap.rs
+++ b/tailtalk/src/pap.rs
@@ -2,6 +2,12 @@ use crate::atp::{AtpAddress, AtpRequestor, AtpResponder};
 use anyhow::{Result, anyhow};
 use tailtalk_packets::pap::{PapFunction, PapPacket};
 use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::time::{Duration, interval};
+
+/// My LaserWriter seems to get very upset over LocalTalk if the individual ATP packets
+/// are any larger than 512 bytes. Not quite sure why, but if kept to 512 this then allows
+/// us to respond with 8 (i.e quantum size) ATP fragments per SendData request.
+pub const PAP_MAX_DATA_PER_PACKET: usize = 512;
 
 #[derive(Debug)]
 pub struct PapClient {
@@ -10,6 +16,11 @@ pub struct PapClient {
     connection_id: u8,
     flow_quantum: u8,
     remote_addr: AtpAddress,
+    /// The printer's connection socket from OpenConnReply — used for all post-connect traffic.
+    server_addr: AtpAddress,
+    /// Override the read buffer size per SendData cycle. When `None`, capacity is
+    /// `bitmap_count × PAP_MAX_DATA_PER_PACKET` derived from the printer's per-request bitmap.
+    pub chunk_size: Option<usize>,
 }
 
 impl PapClient {
@@ -24,130 +35,215 @@ impl PapClient {
                 node_number: 0,
                 socket_number: 0,
             },
+            server_addr: AtpAddress {
+                network_number: 0,
+                node_number: 0,
+                socket_number: 0,
+            },
+            chunk_size: None,
         }
     }
 
-    /// Open a PAP connection to the specified address
     pub async fn connect(&mut self, address: AtpAddress) -> Result<()> {
+        self.connect_with_timeout(address, Duration::from_secs(60)).await
+    }
+
+    /// Per PAP spec, retry every 2 seconds on a non-zero result code (server busy).
+    pub async fn connect_with_timeout(&mut self, address: AtpAddress, timeout: Duration) -> Result<()> {
         self.remote_addr = address;
 
-        // Send OpenConn request
         let open_packet = PapPacket {
             connection_id: self.atp_requestor.socket_number,
             function: PapFunction::OpenConn,
             sequence_num: 0,
-            // OpenConn data: [Socket(1), FlowQuantum(1), WaitTime(2)]
-            // We request flow quantum of 8.
+            eof: false,
             data: vec![self.atp_requestor.socket_number, 0x08, 0x00, 0x00],
         };
-
         let (user_bytes, data) = open_packet.to_atp_parts();
+        let deadline = tokio::time::Instant::now() + timeout;
 
-        tracing::info!("PAP: Sending OpenConn to {:?}", address);
-        let (resp_data, resp_user_bytes) = self
-            .atp_requestor
-            .send_request(address, user_bytes, data.to_vec())
-            .await?;
+        loop {
+            tracing::info!("PAP: Sending OpenConn to {:?}", address);
+            let (resp_data, resp_user_bytes) = self
+                .atp_requestor
+                .send_request(address, user_bytes, data.to_vec())
+                .await?;
 
-        // Parse response
-        let reply = PapPacket::parse_from_atp(resp_user_bytes, &resp_data)?;
+            let reply = PapPacket::parse_from_atp(resp_user_bytes, &resp_data)?;
 
-        if reply.function != PapFunction::OpenConnReply {
-            return Err(anyhow!(
-                "Unexpected response function: {:?}",
-                reply.function
-            ));
-        }
+            if reply.function != PapFunction::OpenConnReply {
+                return Err(anyhow!("Unexpected response function: {:?}", reply.function));
+            }
 
-        self.connection_id = reply.connection_id;
+            self.connection_id = reply.connection_id;
 
-        if reply.data.len() >= 4 {
-            let _server_socket = reply.data[0];
+            if reply.data.len() < 4 {
+                return Err(anyhow!("PAP OpenConnReply too short ({} bytes)", reply.data.len()));
+            }
+
+            let server_socket = reply.data[0];
             self.flow_quantum = reply.data[1];
             let result = ((reply.data[2] as u16) << 8) | (reply.data[3] as u16);
+
             if result != 0 {
-                return Err(anyhow!("PAP OpenConn failed with result code: {}", result));
+                if tokio::time::Instant::now() >= deadline {
+                    return Err(anyhow!("PAP OpenConn failed with result code: {} (server busy)", result));
+                }
+                tracing::info!("PAP: Server busy (result={}), retrying in 2s", result);
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                continue;
             }
+
+            self.server_addr = AtpAddress {
+                network_number: address.network_number,
+                node_number: address.node_number,
+                socket_number: server_socket,
+            };
+
+            tracing::info!("PAP connected! ID={}, Quantum={}", self.connection_id, self.flow_quantum);
+            return Ok(());
         }
-
-        tracing::info!(
-            "PAP connected! ID={}, Quantum={}",
-            self.connection_id,
-            self.flow_quantum
-        );
-
-        Ok(())
     }
 
-    /// Send data (print job) to the connected printer
     pub async fn print(&mut self, data: &[u8]) -> Result<()> {
         self.print_stream(std::io::Cursor::new(data)).await
     }
 
-    /// Send a print job from an async reader, pulling chunks on demand as the printer requests them.
-    /// Each SendData cycle reads up to `flow_quantum * 574` bytes from the source in one shot.
     pub async fn print_stream<R: AsyncRead + Unpin>(&mut self, mut source: R) -> Result<()> {
         tracing::info!("PAP: Starting streaming print job");
 
-        let mut eof = false;
+        let mut last_activity = tokio::time::Instant::now();
+        let mut tickle_interval = interval(Duration::from_secs(30));
+        tickle_interval.tick().await; // skip the immediate first tick
+        let mut eof_sent = false;
 
         loop {
-            let Some(req) = self.atp_responder.next().await else {
-                return Err(anyhow!("ATP responder closed unexpectedly"));
-            };
-
-            let pap_req = PapPacket::parse_from_atp(req.user_bytes, &req.data)?;
-
-            if pap_req.connection_id != self.connection_id {
-                tracing::warn!(
-                    "Ignored PAP packet with mismatched ID: {}",
-                    pap_req.connection_id
-                );
-                continue;
-            }
-
-            match pap_req.function {
-                PapFunction::SendData => {
-                    let seq_num = pap_req.sequence_num;
-                    tracing::debug!("PAP received SendData seq={}", seq_num);
-
-                    let mut buf = vec![0u8; self.flow_quantum as usize * 574];
-                    let n = source.read(&mut buf).await?;
-                    buf.truncate(n);
-
-                    if n == 0 {
-                        eof = true;
-                    }
-
-                    let pap_resp = PapPacket {
-                        connection_id: self.connection_id,
-                        function: PapFunction::Data,
-                        sequence_num: seq_num,
-                        data: buf,
+            tokio::select! {
+                maybe_req = self.atp_responder.next() => {
+                    let Some(req) = maybe_req else {
+                        return Err(anyhow!("ATP responder closed unexpectedly"));
                     };
-                    let (user_bytes, chunk_data) = pap_resp.to_atp_parts();
-                    req.send_response(chunk_data.to_vec(), user_bytes).await?;
 
-                    if let Some(rx) = req.release_rx {
-                        tracing::debug!("PAP: Waiting for ATP Release");
-                        let _ = rx.await;
-                        tracing::debug!("PAP: Received ATP Release");
+                    let pap_req = PapPacket::parse_from_atp(req.user_bytes, &req.data)?;
+
+                    if pap_req.connection_id != self.connection_id {
+                        tracing::warn!("Ignored PAP packet with mismatched ID: {}", pap_req.connection_id);
+                        continue;
                     }
 
-                    if eof {
-                        break;
+                    last_activity = tokio::time::Instant::now();
+
+                    match pap_req.function {
+                        PapFunction::SendData => {
+                            let seq_num = pap_req.sequence_num;
+
+                            let max_packets = if req.bitmap == 0x00 { 8 } else { req.bitmap.count_ones() as usize }.clamp(1, 8);
+                            let capacity = self.chunk_size.unwrap_or(max_packets * PAP_MAX_DATA_PER_PACKET);
+
+                            let (n, buf) = if eof_sent {
+                                // Each ATP SendData is an XO transaction; the printer's slot stays
+                                // locked until it gets a response, so drain in-flight ones with EOF.
+                                (0, vec![])
+                            } else {
+                                tracing::info!("PAP received SendData seq={}", seq_num);
+                                let mut buf = vec![0u8; capacity];
+                                let n = source.read(&mut buf).await?;
+                                buf.truncate(n);
+                                (n, buf)
+                            };
+
+                            let pap_resp = PapPacket {
+                                connection_id: self.connection_id,
+                                function: PapFunction::Data,
+                                sequence_num: seq_num,
+                                eof: n == 0,
+                                data: buf,
+                            };
+                            let (user_bytes, chunk_data) = pap_resp.to_atp_parts();
+                            req.send_response_chunked(chunk_data.to_vec(), user_bytes, PAP_MAX_DATA_PER_PACKET).await?;
+
+                            if n == 0 && !eof_sent {
+                                tracing::info!("PAP: EOF sent");
+                                eof_sent = true;
+                            }
+                        }
+                        PapFunction::Tickle => {
+                            tracing::debug!("PAP: Received Tickle from printer");
+                            if eof_sent {
+                                return Ok(());
+                            }
+                        }
+                        PapFunction::CloseConn => {
+                            let reply = PapPacket {
+                                connection_id: self.connection_id,
+                                function: PapFunction::CloseConnReply,
+                                sequence_num: 0,
+                                eof: false,
+                                data: vec![],
+                            };
+                            let (ub, d) = reply.to_atp_parts();
+                            let _ = req.send_response(d.to_vec(), ub).await;
+                            if eof_sent {
+                                return Ok(());
+                            }
+                            return Err(anyhow!("Printer closed the connection before the job completed"));
+                        }
+                        _ => {}
                     }
                 }
-                PapFunction::CloseConn => {
-                    tracing::info!("PAP: Printer closed connection");
-                    return Ok(());
+
+                _ = tickle_interval.tick() => {
+                    if last_activity.elapsed() > Duration::from_secs(120) {
+                        return Err(anyhow!("PAP session timed out after 120 seconds of inactivity"));
+                    }
+                    tracing::debug!("PAP: Sending Tickle to printer");
+                    let tickle = PapPacket {
+                        connection_id: self.connection_id,
+                        function: PapFunction::Tickle,
+                        sequence_num: 0,
+                        eof: false,
+                        data: vec![],
+                    };
+                    let (ub, _) = tickle.to_atp_parts();
+                    let _ = self.atp_requestor.send_alo(self.server_addr, ub).await;
                 }
-                _ => {}
             }
         }
+    }
 
-        tracing::info!("PAP: Streaming print job finished, closing connection");
-        self.close().await
+    /// Pull the printer's PS stdout by issuing SendData requests until the printer sends EOF.
+    pub async fn read_response(&mut self) -> Result<Vec<u8>> {
+        let mut response = Vec::new();
+        let mut seq: u8 = 1;
+
+        loop {
+            let pkt = PapPacket {
+                connection_id: self.connection_id,
+                function: PapFunction::SendData,
+                sequence_num: seq as u16,
+                eof: false,
+                data: vec![],
+            };
+            let (ub, d) = pkt.to_atp_parts();
+            let (resp_data, resp_ub) = self.atp_requestor
+                .send_request(self.server_addr, ub, d.to_vec())
+                .await?;
+            let data_pkt = PapPacket::parse_from_atp(resp_ub, &resp_data)?;
+
+            if data_pkt.function != PapFunction::Data {
+                return Err(anyhow!("Expected PAP Data response, got {:?}", data_pkt.function));
+            }
+
+            response.extend_from_slice(&data_pkt.data);
+
+            if data_pkt.eof {
+                break;
+            }
+
+            seq = seq.wrapping_add(1);
+        }
+
+        Ok(response)
     }
 
     pub async fn close(&mut self) -> Result<()> {
@@ -155,11 +251,13 @@ impl PapClient {
             connection_id: self.connection_id,
             function: PapFunction::CloseConn,
             sequence_num: 0,
+            eof: false,
             data: vec![],
         };
         let (ub, d) = close_pkt.to_atp_parts();
+        // Must go to server_addr (per-connection socket), not remote_addr (NBP listening socket).
         self.atp_requestor
-            .send_request(self.remote_addr, ub, d.to_vec())
+            .send_request(self.server_addr, ub, d.to_vec())
             .await?;
         Ok(())
     }
@@ -169,6 +267,7 @@ impl PapClient {
             connection_id: 0,
             function: PapFunction::SendStatus,
             sequence_num: 0,
+            eof: false,
             data: vec![],
         };
         let (ub, d) = pkt.to_atp_parts();

--- a/tailtalk/tests/pap_test.rs
+++ b/tailtalk/tests/pap_test.rs
@@ -237,6 +237,7 @@ async fn test_pap_print_job() {
             connection_id: conn_id,
             function: PapFunction::OpenConnReply,
             sequence_num: 0,
+            eof: false,
             data: vec![130, 8, 0, 0], // Socket=130, Flow=8, Result=0
         };
         let (ub, d) = reply.to_atp_parts();
@@ -272,6 +273,7 @@ async fn test_pap_print_job() {
         connection_id: conn_id,
         function: PapFunction::SendData,
         sequence_num: 1,
+        eof: false,
         data: vec![],
     };
     let (ub, d) = send_data_pkt.to_atp_parts();


### PR DESCRIPTION
Fixes several correctness issues found while getting printing working: the Data (TResp) packet had sequence number echoed into byte 3 when the spec says byte 3 is always 0. This caused us to tell the printer we were EOF when its sequence number hit 256, halting the print job.

SendData (TReq) had the sequence number in only byte 3 when it is a big-endian u16 spanning bytes 2–3. CloseConn was being sent to the NBP listening socket instead of the per-connection socket from OpenConnReply. The PAP client was also spawning two separate ATP sockets, so the printer's SendData packets arrived at the requestor socket while the responder never saw them.

After sending EOF the printer may still have in-flight SendData requests; these are now drained so the printer's ATP transaction slots don't stay locked.

Also extends pap-print with subcommands: print, status, query (sends a PostScript job to read back printer settings), and dump-statusdict.

TL;DR - pap-print can now query my LaserWriter 4/600 over LocalTalk with TashTalk USB, send a postscript file to it, and dump its full dict.