### PR TITLE
Fix protocol correctness bugs in NBP, DDP, ATP, and ASP

### DIFF
--- a/tailtalk-packets/src/ddp.rs
+++ b/tailtalk-packets/src/ddp.rs
@@ -147,7 +147,8 @@ impl DdpPacket {
             });
         }
 
-        BigEndian::write_u16(buf, ((self.hop_count as u16 & 0xF) << 2) | self.len as u16);
+        // Bits 13-10: hop_count (4 bits); bits 9-0: DDP length (10 bits).
+        BigEndian::write_u16(buf, ((self.hop_count as u16 & 0xF) << 10) | (self.len as u16 & 0x3FF));
         BigEndian::write_u16(&mut buf[2..], self.chksum);
         BigEndian::write_u16(&mut buf[4..], self.dest_network_num);
         BigEndian::write_u16(&mut buf[6..], self.src_network_num);

--- a/tailtalk-packets/src/nbp.rs
+++ b/tailtalk-packets/src/nbp.rs
@@ -155,14 +155,14 @@ impl TryFrom<&str> for EntityName {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         let first_index = value
-            .find(":")
+            .find(':')
             .ok_or("malformed entity name - missing : separator")?;
         let second_index = value
-            .find("@")
+            .find('@')
             .ok_or("malformed entity name - missing @ separator")?;
 
         if first_index > second_index {
-            return Err("malformed entity name - : was found before @");
+            return Err("malformed entity name - : was found after @");
         }
 
         let object = &value[..first_index];
@@ -292,14 +292,12 @@ impl EntityName {
 
     pub fn fully_qualified(&self) -> bool {
         const LOOKUP_FLAGS: [char; 3] = ['*', '=', '≈'];
-
-        for flag in LOOKUP_FLAGS {
-            if self.object.contains(flag) || self.entity_type.contains(flag) || self.zone != "*" {
-                return false;
-            }
-        }
-
-        true
+        // Object and type must not contain wildcard characters.
+        // Zone is allowed to be "*" (meaning "my current zone") since that is the standard
+        // AppleTalk convention for service registration; the router resolves the real zone.
+        !LOOKUP_FLAGS
+            .iter()
+            .any(|&f| self.object.contains(f) || self.entity_type.contains(f))
     }
 }
 

--- a/tailtalk-packets/src/pap.rs
+++ b/tailtalk-packets/src/pap.rs
@@ -53,8 +53,10 @@ impl TryFrom<u8> for PapFunction {
 pub struct PapPacket {
     pub connection_id: u8,
     pub function: PapFunction,
+    /// Sequence number. Meaningful only for `SendData` (ATP user bytes 2-3, big-endian).
+    /// Ignored on serialization for all other functions; always decoded as 0.
     pub sequence_num: u16,
-    /// End-of-file flag; only meaningful for Data packets.
+    /// End-of-file flag; only meaningful for `Data` packets.
     pub eof: bool,
     pub data: Vec<u8>,
 }

--- a/tailtalk/src/asp.rs
+++ b/tailtalk/src/asp.rs
@@ -360,17 +360,21 @@ impl Asp {
                                     };
 
                                     if sess.command_tx.send(command).await.is_ok() {
-                                        // Wait for reply from application
-                                        if let Ok(reply_data) = reply_rx.await {
-                                            let _ = req
-                                                .send_response(reply_data.data, reply_data.result)
-                                                .await;
-                                        } else {
-                                            tracing::warn!(
-                                                "ASP Command for session {}: application dropped reply channel",
-                                                session_id
-                                            );
-                                        }
+                                        // Spawn the reply wait so the select! loop stays
+                                        // responsive to other sessions while AFP processes
+                                        // this command (which may involve disk I/O).
+                                        tokio::spawn(async move {
+                                            if let Ok(reply_data) = reply_rx.await {
+                                                let _ = req
+                                                    .send_response(reply_data.data, reply_data.result)
+                                                    .await;
+                                            } else {
+                                                tracing::warn!(
+                                                    "ASP Command for session {}: application dropped reply channel",
+                                                    session_id
+                                                );
+                                            }
+                                        });
                                     } else {
                                         tracing::warn!(
                                             "ASP Command for session {}: session channel closed",

--- a/tailtalk/src/atp.rs
+++ b/tailtalk/src/atp.rs
@@ -23,6 +23,8 @@ pub struct PendingRequestState {
     pub eom_seq: Option<u8>,
     pub raw_packet: Vec<u8>,
     pub destination: AtpAddress,
+    /// Number of retransmissions sent so far (not counting the initial send).
+    pub retry_count: u8,
 }
 
 type AtpTransactionMap = HashMap<u16, PendingRequestState>;
@@ -345,12 +347,32 @@ impl Atp {
             return;
         }
 
-        let retransmits: Vec<(u16, Vec<u8>, AtpAddress)> = self.pending_transactions
-            .iter()
-            .map(|(tid, state)| (*tid, state.raw_packet.clone(), state.destination))
-            .collect();
+        // ATP spec: give up after 8 retransmits (9 total attempts).
+        const MAX_RETRIES: u8 = 8;
 
-        for (tid, packet, dest_addr) in retransmits {
+        let mut to_evict: Vec<u16> = Vec::new();
+        let mut to_resend: Vec<(u16, Vec<u8>, AtpAddress)> = Vec::new();
+
+        for (tid, state) in &mut self.pending_transactions {
+            state.retry_count += 1;
+            if state.retry_count > MAX_RETRIES {
+                to_evict.push(*tid);
+            } else {
+                to_resend.push((*tid, state.raw_packet.clone(), state.destination));
+            }
+        }
+
+        for tid in to_evict {
+            if let Some(state) = self.pending_transactions.remove(&tid) {
+                tracing::warn!("ATP: TID {} got no response after {} retransmits, giving up", tid, MAX_RETRIES);
+                let _ = state.chan.send(Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "ATP: no response after maximum retransmits",
+                )));
+            }
+        }
+
+        for (tid, packet, dest_addr) in to_resend {
             let dest = crate::ddp::DdpAddress::new(
                 tailtalk_packets::aarp::AppleTalkAddress {
                     network_number: dest_addr.network_number,
@@ -367,8 +389,25 @@ impl Atp {
     }
 
     async fn handle_send_request(&mut self, req: AtpSendRequest) {
-        let tid = self.next_tid;
-        self.next_tid = self.next_tid.wrapping_add(1);
+        // Skip any TID that is still in pending_transactions to prevent aliasing a live
+        // transaction on wrapping. A freed TID is naturally eligible for reuse.
+        let tid = {
+            let start = self.next_tid;
+            loop {
+                let candidate = self.next_tid;
+                self.next_tid = self.next_tid.wrapping_add(1);
+                if !self.pending_transactions.contains_key(&candidate) {
+                    break candidate;
+                }
+                if self.next_tid == start {
+                    let _ = req.chan.send(Err(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        "ATP: all transaction IDs in use",
+                    )));
+                    return;
+                }
+            }
+        };
 
         let packet = AtpPacket {
             function: AtpFunction::Request,
@@ -426,6 +465,7 @@ impl Atp {
                     eom_seq: None,
                     raw_packet,
                     destination: req.address,
+                    retry_count: 0,
                 },
             );
         }


### PR DESCRIPTION
NBP's fully_qualified() was rejecting zone "*", which is the standard AppleTalk registration convention for "my current zone" (resolved by the router). The check now only validates object and type for wildcard characters. The associated error message for a misplaced ':' was also backwards — it said "before @" when the condition fires when ':' is found after '@'.

DDP's to_bytes was shifting hop_count left by 2 bits instead of 10, placing it in the wrong nibble relative to parse. TailTalk is not a router so hop_count is always 0, but it was wrong per spec.

ATP had no upper bound on retransmission, so a non-responsive peer would cause send_request to hang forever. It now evicts pending transactions after 8 retransmits per spec and returns a TimedOut error. TID allocation also had a gap where wrapping could hand out a TID still in use; the allocator now scans past any live TIDs before issuing a new one.

In ASP, the reply wait for a Command or Write was blocking inline in the select! loop, which starved all other sessions of tickles and new connections while AFP processed a command. The wait is now spawned so the loop stays responsive.