### PR TITLE
GUI: Add binhex import option, consolidate import methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +630,44 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.2",
  "shlex",
+ "syn",
+]
+
+[[package]]
+name = "binhex-rs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1566c65f8d1a993bb340258f25ff5561dc1cb467d0e9a67ae90ab1c0e9b926b5"
+dependencies = [
+ "binrw",
+ "crc",
+ "fourcc-rs",
+ "log",
+ "macintosh-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "binrw"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53195f985e88ab94d1cc87e80049dd2929fd39e4a772c5ae96a7e5c4aad3642"
+dependencies = [
+ "array-init",
+ "binrw_derive",
+ "bytemuck",
+]
+
+[[package]]
+name = "binrw_derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5910da05ee556b789032c8ff5a61fb99239580aa3fd0bfaa8f4d094b2aee00ad"
+dependencies = [
+ "either",
+ "owo-colors",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -1182,6 +1226,21 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -1857,6 +1916,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fourcc-rs"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6d4455339ea4eaf43266293511b372bdc08351a9f4085dba56b8eb11d588d"
+dependencies = [
+ "binrw",
+ "fourcc-rs-macros",
+ "serde",
+]
+
+[[package]]
+name = "fourcc-rs-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af9c22f4348a9858a604ca2a973444a8b7ce952b59d1c642acfabb5777af974"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3200,6 +3281,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "macintosh-utils"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c38010014f404cb90c5c72132ae3065e59912a090d48f8d30b585cdc397c51"
+dependencies = [
+ "binrw",
+ "bitflags 2.11.0",
+ "chrono",
+ "encoding_rs",
+ "fourcc-rs",
+]
+
+[[package]]
 name = "magic-db"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3978,6 +4072,12 @@ checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser 0.25.1",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "pap-print-example"
@@ -5528,6 +5628,7 @@ name = "tailtalk-gui"
 version = "0.5.2"
 dependencies = [
  "anyhow",
+ "binhex-rs",
  "dirs",
  "hfs-reader",
  "if-addrs",

--- a/tailtalk-gui/Cargo.toml
+++ b/tailtalk-gui/Cargo.toml
@@ -15,6 +15,7 @@ ethertalk = ["dep:if-addrs", "tailtalk/ethertalk"]
 
 [dependencies]
 anyhow = { workspace = true } #unified
+binhex-rs = "0.1.1"
 dirs = "6"
 hfs-reader = { workspace = true } #unified
 if-addrs = { version = "0.15", optional = true }

--- a/tailtalk-gui/main.rs
+++ b/tailtalk-gui/main.rs
@@ -510,10 +510,10 @@ fn main() -> anyhow::Result<()> {
     });
 
     let ui_weak = ui.as_weak();
-    let rt_handle_sit = rt_handle.clone();
-    ui.on_import_stuffit(move || {
+    let rt_handle_imp = rt_handle.clone();
+    ui.on_import_files(move || {
         let ui_weak = ui_weak.clone();
-        let rt_handle_sit = rt_handle_sit.clone();
+        let rt_handle_imp = rt_handle_imp.clone();
 
         let volume_path = {
             let Some(ui) = ui_weak.upgrade() else { return };
@@ -525,100 +525,87 @@ fn main() -> anyhow::Result<()> {
             return;
         }
 
-        rt_handle_sit.spawn(async move {
+        rt_handle_imp.spawn(async move {
             let Some(handle) = rfd::AsyncFileDialog::new()
                 .add_filter("StuffIt Archive", &["sit"])
-                .set_title("Import StuffIt Archive")
+                .add_filter("Floppy Disk Image", &["dsk", "img", "hfs", "image"])
+                .add_filter("BinHex Archive", &["hqx"])
+                .set_title("Import Archive/Disk Image")
                 .pick_file()
                 .await
             else {
                 return;
             };
-            let sit_path = handle.path().to_path_buf();
+            let file_path = handle.path().to_path_buf();
 
-            {
-                let ui_weak = ui_weak.clone();
-                slint::invoke_from_event_loop(move || {
-                    if let Some(ui) = ui_weak.upgrade() {
-                        ui.set_import_progress_value(0.0);
-                        ui.set_import_progress_label("Starting…".into());
-                        ui.set_import_progress_visible(true);
-                    }
-                })
-                .ok();
-            }
+            let ext = file_path
+                .extension()
+                .and_then(|e| e.to_str())
+                .map(|e| e.to_ascii_lowercase());
 
-            let ui_progress = ui_weak.clone();
-            let result = extract_sit(&sit_path, &volume_path, move |done, total| {
-                let ui_weak = ui_progress.clone();
-                slint::invoke_from_event_loop(move || {
-                    if let Some(ui) = ui_weak.upgrade() {
-                        ui.set_import_progress_value(done as f32 / total as f32);
-                        ui.set_import_progress_label(format!("{done} of {total}").into());
-                    }
-                })
-                .ok();
-            })
-            .await;
-
-            match result {
-                Ok(count) => {
-                    let msg =
-                        format!("Extracted {count} file(s) from the archive successfully.");
+            if ext.as_deref() == Some("hqx") {
+                match extract_hqx(&file_path, &volume_path).await {
+                    Ok(()) => show_info(
+                        ui_weak,
+                        "Imported file from BinHex archive successfully.".to_string(),
+                    ),
+                    Err(e) => show_error(ui_weak, e),
+                }
+            } else if ext.as_deref() == Some("sit") {
+                {
+                    let ui_weak = ui_weak.clone();
                     slint::invoke_from_event_loop(move || {
                         if let Some(ui) = ui_weak.upgrade() {
-                            ui.set_import_progress_visible(false);
-                            ui.set_info_message(msg.into());
+                            ui.set_import_progress_value(0.0);
+                            ui.set_import_progress_label("Starting…".into());
+                            ui.set_import_progress_visible(true);
                         }
                     })
                     .ok();
                 }
-                Err(e) => {
+
+                let ui_progress = ui_weak.clone();
+                let result = extract_sit(&file_path, &volume_path, move |done, total| {
+                    let ui_weak = ui_progress.clone();
                     slint::invoke_from_event_loop(move || {
                         if let Some(ui) = ui_weak.upgrade() {
-                            ui.set_import_progress_visible(false);
-                            ui.set_error_message(e.into());
+                            ui.set_import_progress_value(done as f32 / total as f32);
+                            ui.set_import_progress_label(format!("{done} of {total}").into());
                         }
                     })
                     .ok();
+                })
+                .await;
+
+                match result {
+                    Ok(count) => {
+                        let msg = format!("Extracted {count} file(s) from the archive successfully.");
+                        slint::invoke_from_event_loop(move || {
+                            if let Some(ui) = ui_weak.upgrade() {
+                                ui.set_import_progress_visible(false);
+                                ui.set_info_message(msg.into());
+                            }
+                        })
+                        .ok();
+                    }
+                    Err(e) => {
+                        slint::invoke_from_event_loop(move || {
+                            if let Some(ui) = ui_weak.upgrade() {
+                                ui.set_import_progress_visible(false);
+                                ui.set_error_message(e.into());
+                            }
+                        })
+                        .ok();
+                    }
                 }
-            }
-        });
-    });
-
-    let ui_weak = ui.as_weak();
-    let rt_handle_hfs = rt_handle.clone();
-    ui.on_import_hfs_image(move || {
-        let ui_weak = ui_weak.clone();
-        let rt_handle_hfs = rt_handle_hfs.clone();
-
-        let volume_path = {
-            let Some(ui) = ui_weak.upgrade() else { return };
-            PathBuf::from(ui.get_volume_path().as_str())
-        };
-
-        if volume_path.as_os_str().is_empty() {
-            show_error(ui_weak, "Please set a volume path before importing.".to_string());
-            return;
-        }
-
-        rt_handle_hfs.spawn(async move {
-            let Some(handle) = rfd::AsyncFileDialog::new()
-                .add_filter("HFS Disk Image", &["dsk", "img", "hfs", "image"])
-                .set_title("Import HFS Disk Image")
-                .pick_file()
-                .await
-            else {
-                return;
-            };
-            let img_path = handle.path().to_path_buf();
-
-            match extract_hfs_image(&img_path, &volume_path).await {
-                Ok(count) => show_info(
-                    ui_weak,
-                    format!("Imported {count} file(s) from the HFS image successfully."),
-                ),
-                Err(e) => show_error(ui_weak, e),
+            } else {
+                match extract_hfs_image(&file_path, &volume_path).await {
+                    Ok(count) => show_info(
+                        ui_weak,
+                        format!("Imported {count} file(s) from the HFS image successfully."),
+                    ),
+                    Err(e) => show_error(ui_weak, e),
+                }
             }
         });
     });
@@ -1263,6 +1250,84 @@ async fn extract_sit(
     }
 
     Ok(file_count)
+}
+
+// ── BinHex extraction ─────────────────────────────────────────────────────────
+
+/// Extracts a BinHex 4.0 (.hqx) file into the volume. BinHex always wraps a
+/// single file, so we just drop it straight into `volume_path` using whatever
+/// name the archive says it should have. The resource fork (if any) goes into
+/// the usual TailTalk sidecar location, and we write the type/creator to xattr
+/// so the Mac sees the right Finder info.
+async fn extract_hqx(hqx_path: &Path, volume_path: &Path) -> Result<(), String> {
+    let bytes = tokio::fs::read(hqx_path).await
+        .map_err(|e| format!("Failed to read BinHex archive: {e}"))?;
+
+    let mut archive = binhex::Archive::try_from(std::io::Cursor::new(bytes))
+        .map_err(|e| format!("Failed to parse BinHex archive: {e}"))?;
+
+    let name = archive.name().to_string();
+    let file_type: [u8; 4] = u32::from(archive.file_code()).to_be_bytes();
+    let creator: [u8; 4] = u32::from(archive.creator_code()).to_be_bytes();
+
+    let mut data_fork = Vec::with_capacity(archive.data_len());
+    std::io::copy(
+        &mut archive.data_fork().map_err(|e| format!("Failed to read data fork: {e}"))?,
+        &mut data_fork,
+    )
+    .map_err(|e| format!("Failed to read data fork: {e}"))?;
+
+    let mut rsrc_fork = Vec::with_capacity(archive.resource_len());
+    std::io::copy(
+        &mut archive.resource_fork().map_err(|e| format!("Failed to read resource fork: {e}"))?,
+        &mut rsrc_fork,
+    )
+    .map_err(|e| format!("Failed to read resource fork: {e}"))?;
+
+    let safe_name: PathBuf = name
+        .split(['/', ':'])
+        .filter(|c| !c.is_empty() && *c != "." && *c != "..")
+        .collect();
+
+    if safe_name.as_os_str().is_empty() {
+        return Err("BinHex archive contains no usable file name".to_string());
+    }
+
+    let dest = volume_path.join(&safe_name);
+    if let Some(parent) = dest.parent()
+        && parent != volume_path
+    {
+        tokio::fs::create_dir_all(parent).await
+            .map_err(|e| format!("Failed to create parent directory: {e}"))?;
+    }
+
+    tokio::fs::write(&dest, &data_fork).await
+        .map_err(|e| format!("Failed to write '{}': {e}", dest.display()))?;
+
+    let finder_info = tailtalk::afp::FinderInfo {
+        file_type,
+        creator,
+        ..Default::default()
+    };
+    if let Err(e) = tailtalk::afp::write_finder_info(&dest, &finder_info).await {
+        tracing::warn!("Could not set FinderInfo for '{}': {e}", dest.display());
+    }
+
+    if !rsrc_fork.is_empty() {
+        let rsrc_dest = volume_path.join(".tailtalk").join("rsrc").join(&safe_name);
+        if let Some(parent) = rsrc_dest.parent() {
+            tokio::fs::create_dir_all(parent).await
+                .map_err(|e| format!("Failed to create rsrc dir: {e}"))?;
+        }
+        tokio::fs::write(&rsrc_dest, &rsrc_fork).await
+            .map_err(|e| format!("Failed to write resource fork for '{}': {e}", dest.display()))?;
+
+        if let Err(e) = register_appl_from_resource_fork(&rsrc_fork, &safe_name, volume_path) {
+            tracing::warn!("Could not register APPL for '{}': {e}", dest.display());
+        }
+    }
+
+    Ok(())
 }
 
 // ── HFS disk image extraction ─────────────────────────────────────────────────

--- a/tailtalk-gui/ui/app.slint
+++ b/tailtalk-gui/ui/app.slint
@@ -42,8 +42,7 @@ export component AppWindow inherits Window {
     callback start-stop();
     callback browse-volume();
     callback browse-pcap();
-    callback import-stuffit();
-    callback import-hfs-image();
+    callback import-files();
     callback inspect-finder-info();
     callback save-finder-info();
     callback open-log-dir();
@@ -54,12 +53,8 @@ export component AppWindow inherits Window {
         Menu {
             title: "File";
             MenuItem {
-                title: "Import StuffIt Archive…";
-                activated => { root.import-stuffit(); }
-            }
-            MenuItem {
-                title: "Import HFS Disk Image…";
-                activated => { root.import-hfs-image(); }
+                title: "Import Archive/Disk Image…";
+                activated => { root.import-files(); }
             }
             MenuItem {
                 title: "Inspect Finder Info…";


### PR DESCRIPTION
Pulls in binhex-rs so we can import binhex'd files just like Netatalk. As part of this we also consolidate all the import buttons in to a single one that offers changing the archive type in the file picker.