### PR TITLE
GUI: Add LaserWriter printing bridge mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,6 +588,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1088,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1531,6 +1614,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,6 +1651,29 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359ee92f81184d7985519e474bda2a5738476334edd3746c9b1265c067afe70"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enum-primitive-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
+dependencies = [
+ "num-traits",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "enumflags2"
@@ -1801,6 +1913,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1958,6 +2081,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -2127,8 +2256,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2138,9 +2269,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2354,6 +2487,110 @@ name = "htmlparser"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48ce8546b993eaf241d69ded33b1be6d205dd9857ec879d9d18bd05d3676e144"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "i-slint-backend-linuxkms"
@@ -2921,6 +3158,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "ipp"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c50f52bbd6cf4cdaac254c696a8a479e3962b0f5858d3b659c7658ea728a94f"
+dependencies = [
+ "base64",
+ "bytes",
+ "enum-as-inner",
+ "enum-primitive-derive",
+ "futures-executor",
+ "futures-util",
+ "http",
+ "log",
+ "num-traits",
+ "reqwest",
+ "thiserror 2.0.18",
+ "tokio-util",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3221,6 +3484,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lyon_algorithms"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3326,6 +3595,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,6 +3615,21 @@ name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
+name = "mdns-sd"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "892f96f6d2ebe1ea641279f986ac52a2a6bac71e8f743bb258315cfe2bd7e88e"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket-pktinfo",
+ "socket2",
+]
 
 [[package]]
 name = "memchr"
@@ -3364,6 +3654,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -4039,6 +4335,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4536,6 +4838,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.3",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4803,6 +5161,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "resvg"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4853,6 +5249,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4937,6 +5347,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4976,6 +5461,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5004,6 +5498,29 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit 0.19.2",
  "tiny-skia",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5056,6 +5573,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5073,6 +5601,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -5422,6 +5962,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket-pktinfo"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927136cc2ae6a1b0e66ac6b1210902b75c3f726db004a73bc18686dcd0dcd22f"
+dependencies = [
+ "libc",
+ "socket2",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5460,6 +6011,15 @@ dependencies = [
  "web-sys",
  "windows-sys 0.61.2",
  "x11rb",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -5536,6 +6096,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "svgtypes"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5571,6 +6137,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -5628,10 +6203,13 @@ name = "tailtalk-gui"
 version = "0.6.0"
 dependencies = [
  "anyhow",
+ "axum",
  "binhex-rs",
  "dirs",
  "hfs-reader",
  "if-addrs",
+ "ipp",
+ "mdns-sd",
  "rfd",
  "serde",
  "serialport",
@@ -5890,6 +6468,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-serial"
 version = "5.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5911,6 +6499,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -6005,6 +6594,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6078,6 +6713,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
@@ -6221,6 +6862,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6351,6 +6998,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6449,6 +7105,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -6616,6 +7285,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -7664,6 +8342,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/examples/pap-print/main.rs
+++ b/examples/pap-print/main.rs
@@ -1,10 +1,40 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use tailtalk::{
     TalkStack,
     atp::AtpAddress,
 };
 use tailtalk_packets::nbp::EntityName;
 use tokio::time::Duration;
+
+#[derive(ValueEnum, Debug, Clone, Copy)]
+enum PaperSize {
+    Letter,
+    A4,
+    Legal,
+    Executive,
+    B5,
+}
+
+impl PaperSize {
+    fn points(self) -> (u32, u32) {
+        match self {
+            PaperSize::Letter    => (612, 792),
+            PaperSize::A4        => (595, 842),
+            PaperSize::Legal     => (612, 1008),
+            PaperSize::Executive => (522, 756),
+            PaperSize::B5        => (516, 729),
+        }
+    }
+    fn label(self) -> &'static str {
+        match self {
+            PaperSize::Letter    => "Letter",
+            PaperSize::A4        => "A4",
+            PaperSize::Legal     => "Legal",
+            PaperSize::Executive => "Executive",
+            PaperSize::B5        => "B5",
+        }
+    }
+}
 
 #[derive(Parser, Debug)]
 #[command(about = "Print and query PAP-capable AppleTalk printers")]
@@ -45,6 +75,12 @@ enum Command {
     DumpStatusdict,
     /// Connect to the printer and immediately close the connection (for diagnostics)
     TestClose,
+    /// Permanently set the default paper size for the cassette tray (writes to NVRAM)
+    SetPaper {
+        /// Paper size to set
+        #[arg(value_enum)]
+        size: PaperSize,
+    },
 }
 
 #[tokio::main]
@@ -104,6 +140,7 @@ async fn main() -> anyhow::Result<()> {
             let labels = &[
                 "Product", "PS Version", "Firmware Rev", "Resolution",
                 "RAM (bytes)", "Page count", "Page size (pts)", "AppleTalk type",
+                "Input trays", "Tray 0 paper (pts)", "Has manual feed",
             ];
 
             // All queries in one job. `stopped` isolates failures per entry; `printval`
@@ -126,6 +163,9 @@ async fn main() -> anyhow::Result<()> {
                  { statusdict begin pagecount end printval } stopped { (error) = } if\n\
                  { currentpagedevice /PageSize get printval } stopped { (error) = } if\n\
                  { statusdict /appletalktype get printval } stopped { (error) = } if\n\
+                 { currentpagedevice /InputAttributes get length = } stopped { (error) = } if\n\
+                 { currentpagedevice /InputAttributes get 0 get /PageSize get printval } stopped { (error) = } if\n\
+                 { currentpagedevice /ManualFeed known = } stopped { (error) = } if\n\
                  flush\n\
                  %%EOF\n";
 
@@ -141,7 +181,8 @@ async fn main() -> anyhow::Result<()> {
             client.close().await?;
 
             let response = String::from_utf8_lossy(&response_bytes);
-            let mut lines = response.lines();
+            // Filter PS status messages (%%[ ... ]%%) that shift line offsets.
+            let mut lines = response.lines().filter(|l| !l.trim_start().starts_with("%%["));
             for label in labels {
                 let value = lines.next().unwrap_or("no response");
                 println!("{label}: {}", if value.is_empty() { "no response" } else { value });
@@ -200,6 +241,44 @@ showpage
             client.close().await?;
 
             print!("{}", String::from_utf8_lossy(&response_bytes));
+        }
+
+        Command::SetPaper { size } => {
+            let (w, h) = size.points();
+            println!("Setting default paper size to {} ({}×{} pts)...", size.label(), w, h);
+
+            // Per developer note p.13: must set both /PageSize and /InputAttributes slot 0.
+            // exitserver (password 0) makes setpagedevice write to NVRAM.
+            let job = format!(
+                "%!PS-Adobe-3.0\n\
+                 %%EndComments\n\
+                 serverdict begin 0 exitserver\n\
+                 << /PageSize [{w} {h}] /InputAttributes << 0 << /PageSize [{w} {h}] >> >> >> setpagedevice\n\
+                 flush\n\
+                 %%EOF\n"
+            );
+
+            let mut client = stack.pap_client().await;
+            client.connect(printer_addr).await?;
+            client.print_stream(std::io::Cursor::new(job.as_bytes())).await?;
+
+            let response_bytes = tokio::time::timeout(
+                Duration::from_secs(15),
+                client.read_response(),
+            ).await.unwrap_or_else(|_| Ok(vec![]))?;
+
+            client.close().await?;
+
+            let response = String::from_utf8_lossy(&response_bytes);
+            let output: Vec<&str> = response.lines()
+                .filter(|l| !l.trim_start().starts_with("%%["))
+                .filter(|l| !l.trim().is_empty())
+                .collect();
+            if output.is_empty() {
+                println!("Done.");
+            } else {
+                println!("Printer responded:\n{}", output.join("\n"));
+            }
         }
 
         Command::TestClose => {

--- a/tailtalk-gui/Cargo.toml
+++ b/tailtalk-gui/Cargo.toml
@@ -11,14 +11,17 @@ path = "main.rs"
 [features]
 default = ["tashtalk"]
 tashtalk = ["dep:serialport"]
-ethertalk = ["dep:if-addrs", "tailtalk/ethertalk"]
+ethertalk = ["tailtalk/ethertalk"]
 
 [dependencies]
 anyhow = { workspace = true } #unified
+axum = "0.8.9"
 binhex-rs = "0.1.1"
 dirs = "6"
 hfs-reader = { workspace = true } #unified
-if-addrs = { version = "0.15", optional = true }
+if-addrs = "0.15"
+ipp = "6.0.1"
+mdns-sd = "0.20.0"
 rfd = "0.17"
 serde = { version = "1", features = ["derive"] }
 serialport = { version = "4", optional = true }

--- a/tailtalk-gui/ipp_bridge.rs
+++ b/tailtalk-gui/ipp_bridge.rs
@@ -1,0 +1,1249 @@
+/// A super hacky IPP bridge that exposes LaserWriter printers on the local network via
+/// mDNS/Bonjour and accepts IPP print jobs from macOS/iOS. I built this around making my
+/// LaserWriter 4/600 PS accessible via my Mac, and iOS devices for printing. Pretty sure
+/// it should work on other systems as it exposes a standard IPP interface and uses PostScript
+/// queries to figure out printer capabilities, but I haven't tested beyond the single one I have.
+///
+/// The other part of this I found is that modern prints tend to generate _enormous_ PostScript files,
+/// and these are both slow to send to the printer and take significant time ot process (on the order of 5-10 minutes).
+/// With this we now pre-rasterize the PostScript to a smaller PostScript file (with rasterized pages) before sending
+/// to the printer, which is much faster - it typically starts printing as soon as the job is fully sent.
+/// The rasterization is done via Ghostscript, which must be installed on the system for this to work.
+use std::{
+    collections::{HashMap, HashSet},
+    io::{Cursor, Read as _, Write as _},
+    net::IpAddr,
+    sync::{Arc, atomic::{AtomicU32, Ordering}},
+    time::{Duration, Instant},
+};
+
+use axum::{Router, body::Bytes, extract::{Path, State}, routing::post};
+use ipp::{parser::IppParser, prelude::*, reader::IppReader};
+use mdns_sd::{ServiceDaemon, ServiceInfo};
+use tailtalk::{atp::{Atp, AtpAddress}, ddp::DdpHandle, nbp::NbpHandle, pap::PapClient, CancellationToken};
+use tailtalk_packets::nbp::EntityName;
+use tokio::sync::{Mutex, RwLock};
+
+// Standard media sizes supported by all LaserWriters.
+const STANDARD_MEDIA: &[&str] = &[
+    "na_letter_8.5x11in",
+    "na_legal_8.5x14in",
+    "iso_a4_210x297mm",
+    "iso_b5_176x250mm",
+    "na_executive_7.25x10.5in",
+    "na_number-10_4.125x9.5in",
+    "na_monarch_3.875x7.5in",
+    "iso_c5_162x229mm",
+    "iso_dl_110x220mm",
+];
+
+#[derive(Clone, Debug, PartialEq)]
+enum JobState {
+    Processing,
+    Completed,
+    Aborted,
+}
+
+impl JobState {
+    fn ipp_enum(&self) -> i32 {
+        match self { Self::Processing => 5, Self::Completed => 9, Self::Aborted => 8 }
+    }
+    fn ipp_reason(&self) -> &'static str {
+        match self { Self::Processing => "job-printing", Self::Completed => "none", Self::Aborted => "aborted-by-system" }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct JobRecord {
+    id: u32,
+    printer_key: String,
+    uri: String,
+    state: JobState,
+    state_message: String,
+    impressions_completed: i32,
+    created_at: u32,
+}
+
+#[derive(Clone)]
+struct PrinterCaps {
+    dpi: u32,
+    color: bool,
+    model: String,
+    /// IPP PWG media name for the paper currently loaded.
+    media_default: String,
+    /// IPP `media-source` keywords for each input tray.
+    tray_sources: Vec<String>,
+}
+
+impl Default for PrinterCaps {
+    fn default() -> Self {
+        PrinterCaps {
+            dpi: 600,
+            color: false,
+            model: "Apple LaserWriter 4/600 PS".to_string(),
+            media_default: "na_letter_8.5x11in".to_string(),
+            tray_sources: vec!["main".into(), "manual".into()],
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Printer {
+    name: String,
+    addr: AtpAddress,
+    key: String,
+    mdns_fullname: String,
+    caps: PrinterCaps,
+}
+
+struct BridgeState {
+    printers: Arc<RwLock<Vec<Printer>>>,
+    ddp: DdpHandle,
+    jobs: RwLock<HashMap<u32, Arc<Mutex<JobRecord>>>>,
+    next_job_id: AtomicU32,
+    start_time: Instant,
+}
+
+pub async fn run(nbp: NbpHandle, ddp: DdpHandle, token: CancellationToken) {
+    let printers: Arc<RwLock<Vec<Printer>>> = Arc::new(RwLock::new(Vec::new()));
+
+    let mdns = match ServiceDaemon::new() {
+        Ok(d) => d,
+        Err(e) => {
+            tracing::error!("IPP bridge: failed to create mDNS daemon: {e}");
+            return;
+        }
+    };
+
+    let ddp2 = ddp.clone();
+    let nbp2 = nbp.clone();
+    let printers2 = printers.clone();
+    let mdns2 = mdns.clone();
+    let token2 = token.clone();
+
+    discover(&nbp, &ddp, &printers, &mdns).await;
+
+    let state = Arc::new(BridgeState {
+        printers: printers.clone(),
+        ddp,
+        jobs: RwLock::new(HashMap::new()),
+        next_job_id: AtomicU32::new(1),
+        start_time: Instant::now(),
+    });
+
+    let app = Router::new()
+        .route("/ipp/{key}", post(handle_ipp))
+        .fallback(|uri: axum::http::Uri, method: axum::http::Method, body: Bytes| async move {
+            tracing::warn!("IPP: unmatched request {method} {uri} ({} bytes)", body.len());
+            axum::response::Response::builder().status(404).body(axum::body::Body::empty()).unwrap()
+        })
+        .layer(axum::extract::DefaultBodyLimit::disable())
+        .with_state(state);
+
+    let listener = match tokio::net::TcpListener::bind("0.0.0.0:8631").await {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!("IPP bridge: failed to bind port 8631: {e}");
+            return;
+        }
+    };
+
+    tracing::info!("IPP bridge: listening on port 8631");
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(30));
+        interval.tick().await;
+        loop {
+            tokio::select! {
+                _ = token2.cancelled() => break,
+                _ = interval.tick() => discover(&nbp2, &ddp2, &printers2, &mdns2).await,
+            }
+        }
+    });
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move { token.cancelled().await })
+        .await
+        .ok();
+
+    let lock = printers.read().await;
+    for p in lock.iter() {
+        if let Ok(rx) = mdns.unregister(&p.mdns_fullname) {
+            drop(rx);
+        }
+    }
+}
+
+/// Non-loopback IPv4 addresses; avoids 127.0.0.1 appearing in mDNS advertisements.
+fn local_ipv4_addrs() -> Vec<IpAddr> {
+    if_addrs::get_if_addrs()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|iface| !iface.is_loopback())
+        .filter_map(|iface| {
+            if let if_addrs::IfAddr::V4(ref v4) = iface.addr {
+                Some(IpAddr::V4(v4.ip))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn make_key(name: &str) -> String {
+    name.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c.to_ascii_lowercase() } else { '-' })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
+}
+
+fn urf_string(caps: &PrinterCaps) -> String {
+    // CP1 = sRGB profile 1 (required by AirPrint spec; CP255 is not valid).
+    // We always advertise SRGB24 so iOS sends colour jobs; ghostscript converts to mono.
+    format!("W8,SRGB24,CP1,RS{}", caps.dpi)
+}
+
+async fn discover(
+    nbp: &NbpHandle,
+    ddp: &DdpHandle,
+    printers: &Arc<RwLock<Vec<Printer>>>,
+    mdns: &ServiceDaemon,
+) {
+    let entity: EntityName = match "=:LaserWriter@*".try_into() {
+        Ok(e) => e,
+        Err(e) => { tracing::error!("IPP bridge: bad entity name: {e}"); return; }
+    };
+
+    let tuples = match nbp.lookup(entity).await {
+        Ok(t) => t,
+        Err(e) => { tracing::warn!("IPP bridge: NBP lookup failed: {e}"); return; }
+    };
+
+    tracing::info!("IPP bridge: found {} LaserWriter(s)", tuples.len());
+
+    let new_keys: HashSet<String> = tuples.iter()
+        .map(|t| make_key(&t.entity_name.object))
+        .filter(|k| !k.is_empty())
+        .collect();
+
+    let mut current = printers.write().await;
+
+    current.retain(|p| {
+        if new_keys.contains(&p.key) {
+            true
+        } else {
+            if let Ok(rx) = mdns.unregister(&p.mdns_fullname) { drop(rx); }
+            false
+        }
+    });
+
+    for tuple in &tuples {
+        let name = tuple.entity_name.object.clone();
+        let key = make_key(&name);
+        if key.is_empty() || current.iter().any(|p| p.key == key) {
+            continue;
+        }
+
+        let addr = AtpAddress {
+            network_number: tuple.network_number,
+            node_number: tuple.node_id,
+            socket_number: tuple.socket_number,
+        };
+
+        let caps = query_printer_caps(ddp, addr).await;
+
+        let hostname = format!("tailtalk-{key}.local.");
+        let rp = format!("ipp/{key}");
+        let product = format!("({})", caps.model);
+
+        #[cfg(not(target_os = "windows"))]
+        let urf = urf_string(&caps);
+
+        let mut props: Vec<(&str, &str)> = vec![
+            ("rp", rp.as_str()),
+            ("ty", name.as_str()),
+            ("product", product.as_str()),
+            ("Color", if caps.color { "T" } else { "F" }),
+            ("qtotal", "1"),
+            ("txtvers", "1"),
+        ];
+        #[cfg(not(target_os = "windows"))]
+        {
+            props.push(("pdl", "image/urf,application/pdf,application/postscript"));
+            props.push(("URF", urf.as_str()));
+        }
+        #[cfg(target_os = "windows")]
+        props.push(("pdl", "application/pdf,application/postscript"));
+
+        let addrs = local_ipv4_addrs();
+        let service_info = match ServiceInfo::new("_universal._sub._ipp._tcp.local.", &name, &hostname, addrs.as_slice(), 8631u16, &props[..]) {
+            Ok(si) => si,
+            Err(e) => { tracing::warn!("IPP bridge: ServiceInfo error for '{name}': {e}"); continue; }
+        };
+
+        let mdns_fullname = service_info.get_fullname().to_string();
+
+        if let Err(e) = mdns.register(service_info) {
+            tracing::warn!("IPP bridge: mDNS register failed for '{name}': {e}");
+            continue;
+        }
+
+        tracing::info!(
+            "IPP bridge: registered '{name}' → /ipp/{key} ({}dpi, color={}, default={})",
+            caps.dpi, caps.color, caps.media_default,
+        );
+        current.push(Printer { name, addr, key, mdns_fullname, caps });
+    }
+
+}
+
+/// Query printer capabilities via the PostScript Query Protocol.
+async fn query_printer_caps(ddp: &DdpHandle, addr: AtpAddress) -> PrinterCaps {
+    let job =
+        "%!PS-Adobe-3.0\n\
+         %%EndComments\n\
+         errordict /handleerror {} put\n\
+         /printval {\n\
+           dup type /arraytype eq {\n\
+             { dup type /stringtype eq { print } { 20 string cvs print } ifelse ( ) print } forall\n\
+             (\\n) print\n\
+           } { = } ifelse\n\
+         } def\n\
+         { statusdict /product get printval } stopped { (error) = } if\n\
+         { version printval } stopped { (error) = } if\n\
+         { statusdict /revision get printval } stopped { (error) = } if\n\
+         { statusdict /resolution get printval } stopped { currentpagedevice /HWResolution get 0 get printval } if\n\
+         { statusdict begin ramsize end printval } stopped { (error) = } if\n\
+         { statusdict begin pagecount end printval } stopped { (error) = } if\n\
+         { currentpagedevice /PageSize get printval } stopped { (error) = } if\n\
+         { statusdict /appletalktype get printval } stopped { (error) = } if\n\
+         { currentpagedevice /ColorDevice get = } stopped { false = } if\n\
+         { currentpagedevice /InputAttributes get length = } stopped { 1 = } if\n\
+         { currentpagedevice /ManualFeed known = } stopped { false = } if\n\
+         flush\n\
+         %%EOF\n";
+
+    let result: anyhow::Result<PrinterCaps> = async {
+        let (_, req, resp) = Atp::spawn(ddp, None).await;
+        let mut client = PapClient::new(req, resp);
+        client.connect(addr).await?;
+        client.print_stream(Cursor::new(job.as_bytes())).await?;
+        let response_bytes = tokio::time::timeout(
+            Duration::from_secs(15),
+            client.read_response(),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("PAP query timed out"))??;
+        client.close().await?;
+
+        let response = String::from_utf8_lossy(&response_bytes);
+        let mut lines = response.lines().filter(|l| !l.trim_start().starts_with("%%["));
+
+        // Line 0: product name
+        let raw_model = lines.next().unwrap_or("").trim().to_string();
+        let model = raw_model.trim_matches(|c| c == '(' || c == ')').to_string();
+
+        let _ = lines.next(); // Line 1: PS version
+        let _ = lines.next(); // Line 2: firmware revision
+
+        // Line 3: resolution (integer, or "w h" array)
+        let resolution_line = lines.next().unwrap_or("300").trim().to_string();
+        let dpi = resolution_line.split_whitespace()
+            .next()
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or(300);
+
+        let _ = lines.next(); // Line 4: RAM
+        let _ = lines.next(); // Line 5: page count
+
+        // Line 6: page size in points
+        let page_size_line = lines.next().unwrap_or("").trim().to_string();
+        let media_default = parse_pts_to_media(&page_size_line)
+            .to_string();
+
+        let _ = lines.next(); // Line 7: AppleTalk type
+
+        // Line 8: ColorDevice
+        let color = lines.next().unwrap_or("false").trim() == "true";
+
+        // Line 9: InputAttributes length (cassette count)
+        let cassette_count = lines.next().unwrap_or("1").trim()
+            .parse::<u32>().unwrap_or(1);
+
+        // Line 10: ManualFeed supported
+        let has_manual = lines.next().unwrap_or("false").trim() == "true";
+
+        let mut tray_sources: Vec<String> = Vec::new();
+        if cassette_count >= 1 { tray_sources.push("main".into()); }
+        if cassette_count >= 2 { tray_sources.push("alternate".into()); }
+        if has_manual           { tray_sources.push("manual".into()); }
+        if tray_sources.is_empty() { tray_sources.push("main".into()); }
+
+        Ok(PrinterCaps {
+            dpi,
+            color,
+            model: if model.is_empty() || model == "error" {
+                "LaserWriter".to_string()
+            } else {
+                model
+            },
+            media_default,
+            tray_sources,
+        })
+    }
+    .await;
+
+    result.unwrap_or_else(|e| {
+        tracing::warn!("IPP bridge: caps query failed ({e}), using defaults");
+        PrinterCaps::default()
+    })
+}
+
+/// Map a PostScript page-size string ("w h ") to the closest IPP PWG media name.
+fn parse_pts_to_media(pts: &str) -> &'static str {
+    let mut nums = pts.split_whitespace().filter_map(|s| s.parse::<f32>().ok());
+    let (Some(w), Some(h)) = (nums.next(), nums.next()) else {
+        return "na_letter_8.5x11in";
+    };
+    // Tolerance of 5 points covers rounding in printer firmware.
+    let known: &[(f32, f32, &str)] = &[
+        (612.0, 792.0,  "na_letter_8.5x11in"),
+        (612.0, 1008.0, "na_legal_8.5x14in"),
+        (595.0, 842.0,  "iso_a4_210x297mm"),
+        (516.0, 729.0,  "iso_b5_176x250mm"),
+        (522.0, 756.0,  "na_executive_7.25x10.5in"),
+        (297.0, 684.0,  "na_number-10_4.125x9.5in"),
+        (279.0, 540.0,  "na_monarch_3.875x7.5in"),
+        (459.0, 649.0,  "iso_c5_162x229mm"),
+        (312.0, 624.0,  "iso_dl_110x220mm"),
+    ];
+    for &(pw, ph, name) in known {
+        if (w - pw).abs() < 5.0 && (h - ph).abs() < 5.0 {
+            return name;
+        }
+    }
+    "na_letter_8.5x11in"
+}
+
+fn ipp_bytes(resp: IppRequestResponse) -> axum::response::Response {
+    let bytes = resp.to_bytes();
+    axum::response::Response::builder()
+        .header("content-type", "application/ipp")
+        .body(axum::body::Body::from(bytes))
+        .unwrap()
+}
+
+fn ipp_status(req_id: u32, status: StatusCode) -> axum::response::Response {
+    match IppRequestResponse::new_response(IppVersion::v1_1(), status, req_id) {
+        Ok(r) => ipp_bytes(r),
+        Err(_) => axum::response::Response::new(axum::body::Body::empty()),
+    }
+}
+
+fn ipp_ok(req_id: u32) -> axum::response::Response {
+    ipp_status(req_id, StatusCode::SuccessfulOk)
+}
+
+fn job_created_response(job_id: u32, job_uri: &str, req_id: u32) -> axum::response::Response {
+    let mut resp = match IppRequestResponse::new_response(IppVersion::v1_1(), StatusCode::SuccessfulOk, req_id) {
+        Ok(r) => r,
+        Err(_) => return axum::response::Response::new(axum::body::Body::empty()),
+    };
+    let mut add = |name: &str, val: IppValue| {
+        if let Ok(a) = IppAttribute::with_name(name, val) {
+            resp.attributes_mut().add(DelimiterTag::JobAttributes, a);
+        }
+    };
+    add("job-id", IppValue::Integer(job_id as i32));
+    if let Ok(u) = job_uri.try_into() { add("job-uri", IppValue::Uri(u)); }
+    add("job-state", IppValue::Enum(JobState::Processing.ipp_enum()));
+    if let Ok(k) = JobState::Processing.ipp_reason().try_into() {
+        add("job-state-reasons", IppValue::Keyword(k));
+    }
+    ipp_bytes(resp)
+}
+
+fn job_attributes_response(job: &JobRecord, req_id: u32) -> axum::response::Response {
+    let mut resp = match IppRequestResponse::new_response(IppVersion::v1_1(), StatusCode::SuccessfulOk, req_id) {
+        Ok(r) => r,
+        Err(_) => return axum::response::Response::new(axum::body::Body::empty()),
+    };
+    let mut add = |name: &str, val: IppValue| {
+        if let Ok(a) = IppAttribute::with_name(name, val) {
+            resp.attributes_mut().add(DelimiterTag::JobAttributes, a);
+        }
+    };
+    add("job-id", IppValue::Integer(job.id as i32));
+    if let Ok(u) = job.uri.as_str().try_into() { add("job-uri", IppValue::Uri(u)); }
+    add("job-state", IppValue::Enum(job.state.ipp_enum()));
+    if let Ok(k) = job.state.ipp_reason().try_into() {
+        add("job-state-reasons", IppValue::Keyword(k));
+    }
+    if let Ok(t) = job.state_message.as_str().try_into() {
+        add("job-state-message", IppValue::TextWithoutLanguage(t));
+    }
+    add("job-impressions-completed", IppValue::Integer(job.impressions_completed));
+    add("time-at-creation", IppValue::Integer(job.created_at as i32));
+    ipp_bytes(resp)
+}
+
+fn get_jobs_response(jobs: &[JobRecord], req_id: u32) -> axum::response::Response {
+    let mut resp = match IppRequestResponse::new_response(IppVersion::v1_1(), StatusCode::SuccessfulOk, req_id) {
+        Ok(r) => r,
+        Err(_) => return axum::response::Response::new(axum::body::Body::empty()),
+    };
+    for job in jobs {
+        let mut add = |name: &str, val: IppValue| {
+            if let Ok(a) = IppAttribute::with_name(name, val) {
+                resp.attributes_mut().add(DelimiterTag::JobAttributes, a);
+            }
+        };
+        add("job-id", IppValue::Integer(job.id as i32));
+        if let Ok(u) = job.uri.as_str().try_into() { add("job-uri", IppValue::Uri(u)); }
+        add("job-state", IppValue::Enum(job.state.ipp_enum()));
+        if let Ok(k) = job.state.ipp_reason().try_into() {
+            add("job-state-reasons", IppValue::Keyword(k));
+        }
+    }
+    ipp_bytes(resp)
+}
+
+/// Extract job-id from operation attributes, trying `job-id` (integer) then
+/// the trailing path component of `job-uri`.
+fn extract_job_id(parsed: &IppRequestResponse) -> Option<u32> {
+    parsed.attributes()
+        .groups_of(DelimiterTag::OperationAttributes)
+        .next()
+        .and_then(|g| {
+            if let Some(a) = g.attributes().get("job-id") {
+                if let IppValue::Integer(id) = a.value() {
+                    return Some(*id as u32);
+                }
+            }
+            if let Some(a) = g.attributes().get("job-uri") {
+                if let IppValue::Uri(u) = a.value() {
+                    return u.as_str().rsplit('/').next()?.parse::<u32>().ok();
+                }
+            }
+            None
+        })
+}
+
+async fn handle_ipp(
+    State(state): State<Arc<BridgeState>>,
+    Path(key): Path<String>,
+    body: Bytes,
+) -> axum::response::Response {
+    let reader = IppReader::new(Cursor::new(body.to_vec()));
+    let mut parsed = match IppParser::new(reader).parse() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("IPP: parse error: {e}");
+            return axum::response::Response::builder()
+                .status(400)
+                .body(axum::body::Body::empty())
+                .unwrap();
+        }
+    };
+
+    let op = parsed.header().operation_or_status;
+    let req_id = parsed.header().request_id;
+    tracing::debug!("IPP: op=0x{op:04x} req_id={req_id} key={key}");
+
+    let printer = {
+        let lock = state.printers.read().await;
+        lock.iter().find(|p| p.key == key).cloned()
+    };
+
+    let printer = match printer {
+        Some(p) => p,
+        None => return ipp_status(req_id, StatusCode::ClientErrorNotFound),
+    };
+
+    match op {
+        op if op == Operation::GetPrinterAttributes as u16 => {
+            printer_attributes(&printer, req_id)
+        }
+        op if op == Operation::PrintJob as u16 => {
+            let job_id = state.next_job_id.fetch_add(1, Ordering::Relaxed);
+            let job_uri = format!("ipp://localhost:8631/ipp/{}/{job_id}", printer.key);
+            let created_at = state.start_time.elapsed().as_secs() as u32;
+            let job = Arc::new(Mutex::new(JobRecord {
+                id: job_id,
+                printer_key: printer.key.clone(),
+                uri: job_uri.clone(),
+                state: JobState::Processing,
+                state_message: "Received".to_string(),
+                impressions_completed: 0,
+                created_at,
+            }));
+            {
+                let mut jobs = state.jobs.write().await;
+                let uptime = state.start_time.elapsed().as_secs();
+                jobs.retain(|_, arc| {
+                    if let Ok(j) = arc.try_lock() {
+                        j.state == JobState::Processing
+                            || uptime.saturating_sub(j.created_at as u64) < 3600
+                    } else {
+                        true
+                    }
+                });
+                jobs.insert(job_id, job.clone());
+            }
+
+            let fmt = doc_format(&parsed);
+            let tray = job_media_source(&parsed);
+            let mut doc = Vec::new();
+            parsed.payload_mut().read_to_end(&mut doc).ok();
+            tracing::info!("IPP: PrintJob id={job_id} fmt={fmt:?} doc_bytes={} tray={tray:?}", doc.len());
+
+            let ddp = state.ddp.clone();
+            let addr = printer.addr;
+            let dpi = printer.caps.dpi;
+            tokio::spawn(async move {
+                job.lock().await.state_message = "Rasterizing".to_string();
+                let (ps, page_count) = match rasterize_to_ps(doc, &fmt, &tray, dpi, job_id).await {
+                    Ok(r) => r,
+                    Err(e) => {
+                        tracing::error!("IPP: rasterize failed: {e}");
+                        let mut j = job.lock().await;
+                        j.state = JobState::Aborted;
+                        j.state_message = format!("Rasterize failed: {e}");
+                        return;
+                    }
+                };
+                tracing::info!("IPP: rasterized {page_count} page(s) to {} bytes PS", ps.len());
+                job.lock().await.state_message = "Printing".to_string();
+                match print_to_pap(ddp, addr, ps).await {
+                    Ok(printer_output) => {
+                        let mut j = job.lock().await;
+                        j.impressions_completed = page_count as i32;
+                        if let Some(err) = parse_printer_error(&printer_output) {
+                            tracing::warn!("IPP: job {job_id} printer error: {err}");
+                            j.state = JobState::Aborted;
+                            j.state_message = err;
+                        } else {
+                            j.state = JobState::Completed;
+                            j.state_message = "Completed".to_string();
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("IPP: job {job_id} PAP error: {e}");
+                        let mut j = job.lock().await;
+                        j.state = JobState::Aborted;
+                        j.state_message = format!("PAP error: {e}");
+                    }
+                }
+            });
+            job_created_response(job_id, &job_uri, req_id)
+        }
+        op if op == Operation::ValidateJob as u16 => ipp_ok(req_id),
+        op if op == Operation::CancelJob as u16 => ipp_ok(req_id),
+        op if op == Operation::GetJobAttributes as u16 => {
+            let job_id = extract_job_id(&parsed);
+            match job_id {
+                None => ipp_status(req_id, StatusCode::ClientErrorBadRequest),
+                Some(id) => {
+                    let arc = state.jobs.read().await.get(&id).cloned();
+                    match arc {
+                        None => ipp_status(req_id, StatusCode::ClientErrorNotFound),
+                        Some(arc) => {
+                            let j = arc.lock().await;
+                            job_attributes_response(&j, req_id)
+                        }
+                    }
+                }
+            }
+        }
+        op if op == Operation::GetJobs as u16 => {
+            let key = printer.key.clone();
+            let arcs: Vec<Arc<Mutex<JobRecord>>> =
+                state.jobs.read().await.values().cloned().collect();
+            let mut snapshots = Vec::new();
+            for arc in arcs {
+                let j = arc.lock().await;
+                if j.printer_key == key { snapshots.push(j.clone()); }
+            }
+            get_jobs_response(&snapshots, req_id)
+        }
+        _ => {
+            tracing::debug!("IPP: unsupported operation 0x{op:04x}");
+            ipp_status(req_id, StatusCode::ServerErrorOperationNotSupported)
+        }
+    }
+}
+
+/// Deterministic UUID URN derived from the printer key.
+/// Stable across restarts so PrintKit can identify the same printer session.
+fn printer_uuid(key: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut h1 = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut h1);
+    "tailtalk-ipp".hash(&mut h1);
+    let lo = h1.finish();
+    let mut h2 = std::collections::hash_map::DefaultHasher::new();
+    "tailtalk-ipp".hash(&mut h2);
+    key.len().hash(&mut h2);
+    let hi = h2.finish();
+    let b = ((hi as u128) << 64) | lo as u128;
+    let bytes = b.to_be_bytes();
+    format!(
+        "urn:uuid:{:08x}-{:04x}-4{:03x}-{:04x}-{:012x}",
+        u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+        u16::from_be_bytes([bytes[4], bytes[5]]),
+        u16::from_be_bytes([bytes[6], bytes[7]]) & 0x0FFF,
+        (u16::from_be_bytes([bytes[8], bytes[9]]) & 0x3FFF) | 0x8000,
+        u64::from_be_bytes([0, 0, bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]]),
+    )
+}
+
+fn printer_attributes(printer: &Printer, req_id: u32) -> axum::response::Response {
+    let mut resp = match IppRequestResponse::new_response(
+        IppVersion::v1_1(),
+        StatusCode::SuccessfulOk,
+        req_id,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("IPP: response build error: {e}");
+            return axum::response::Response::new(axum::body::Body::empty());
+        }
+    };
+
+    let uri = format!("ipp://localhost:8631/ipp/{}", printer.key);
+    let caps = &printer.caps;
+
+    let mut add = |name: &str, val: IppValue| {
+        if let Ok(a) = IppAttribute::with_name(name, val) {
+            resp.attributes_mut().add(DelimiterTag::PrinterAttributes, a);
+        }
+    };
+
+    if let Ok(u) = uri.as_str().try_into() {
+        add("printer-uri-supported", IppValue::Uri(u));
+    }
+    if let Ok(k) = "none".try_into() { add("uri-security-supported", IppValue::Keyword(k)); }
+    if let Ok(k) = "none".try_into() { add("uri-authentication-supported", IppValue::Keyword(k)); }
+    if let Ok(n) = printer.name.as_str().try_into() {
+        add("printer-name", IppValue::NameWithoutLanguage(n));
+    }
+    if let Ok(n) = caps.model.as_str().try_into() {
+        add("printer-make-and-model", IppValue::NameWithoutLanguage(n));
+    }
+
+    // printer-kind: required by PrintKit; include "photo" so Photos.app accepts the printer.
+    {
+        let kinds: Vec<IppValue> = ["document", "photo"].iter().copied()
+            .filter_map(|k| k.try_into().ok())
+            .map(IppValue::Keyword)
+            .collect();
+        add("printer-kind", IppValue::Array(kinds));
+    }
+    // printer-uuid: stable identifier; PrintKit loops on GetPrinterAttributes without it.
+    let uuid_urn = printer_uuid(&printer.key);
+    if let Ok(u) = uuid_urn.as_str().try_into() {
+        add("printer-uuid", IppValue::Uri(u));
+    }
+    if let Ok(n) = printer.name.as_str().try_into() {
+        add("printer-dns-sd-name", IppValue::NameWithoutLanguage(n));
+    }
+    if let Ok(t) = "".try_into() { add("printer-location", IppValue::TextWithoutLanguage(t)); }
+    // output-mode-supported: older Apple attribute; synonym for print-color-mode-supported.
+    {
+        let modes: Vec<IppValue> = ["auto", "color", "monochrome"].iter().copied()
+            .filter_map(|k| k.try_into().ok())
+            .map(IppValue::Keyword)
+            .collect();
+        add("output-mode-supported", IppValue::Array(modes));
+    }
+    add("pages-per-minute", IppValue::Integer(8));
+    add("pdf-k-octets-supported", IppValue::RangeOfInteger { min: 1, max: 65535 });
+    add("jpeg-k-octets-supported", IppValue::RangeOfInteger { min: 1, max: 65535 });
+    add("printer-state", IppValue::Enum(3)); // idle
+    if let Ok(k) = "none".try_into() { add("printer-state-reasons", IppValue::Keyword(k)); }
+    if let Ok(k) = "1.1".try_into() { add("ipp-versions-supported", IppValue::Keyword(k)); }
+    add("operations-supported", IppValue::Array(vec![
+        IppValue::Enum(Operation::PrintJob as i32),
+        IppValue::Enum(Operation::ValidateJob as i32),
+        IppValue::Enum(Operation::CancelJob as i32),
+        IppValue::Enum(Operation::GetJobAttributes as i32),
+        IppValue::Enum(Operation::GetJobs as i32),
+        IppValue::Enum(Operation::GetPrinterAttributes as i32),
+    ]));
+    if let Ok(c) = "utf-8".try_into() { add("charset-configured", IppValue::Charset(c)); }
+    if let Ok(c) = "utf_8".try_into() { add("charset-supported", IppValue::Charset(c)); }
+    if let Ok(l) = "en".try_into() { add("natural-language-configured", IppValue::NaturalLanguage(l)); }
+    if let Ok(l) = "en".try_into() { add("generated-natural-language-supported", IppValue::NaturalLanguage(l)); }
+    if let Ok(m) = "application/pdf".try_into() {
+        add("document-format-default", IppValue::MimeMediaType(m));
+    }
+    {
+        #[cfg(not(target_os = "windows"))]
+        let fmts = ["application/pdf", "application/postscript", "image/urf", "application/octet-stream"];
+        #[cfg(target_os = "windows")]
+        let fmts = ["application/pdf", "application/postscript", "application/octet-stream"];
+        let vals: Vec<IppValue> = fmts.iter().copied()
+            .filter_map(|f| f.try_into().ok())
+            .map(IppValue::MimeMediaType)
+            .collect();
+        add("document-format-supported", IppValue::Array(vals));
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let urf_str = urf_string(caps);
+        let urf_caps: Vec<&str> = urf_str.split(',').collect();
+        let vals: Vec<IppValue> = urf_caps.iter().copied()
+            .filter_map(|k| k.try_into().ok())
+            .map(IppValue::Keyword)
+            .collect();
+        add("urf-supported", IppValue::Array(vals));
+    }
+
+    add("printer-resolution-default", IppValue::Resolution {
+        cross_feed: caps.dpi as i32,
+        feed: caps.dpi as i32,
+        units: 3, // dots per inch
+    });
+    add("printer-resolution-supported", IppValue::Resolution {
+        cross_feed: caps.dpi as i32,
+        feed: caps.dpi as i32,
+        units: 3,
+    });
+
+    {
+        let vals: Vec<IppValue> = STANDARD_MEDIA.iter().copied()
+            .filter_map(|m| m.try_into().ok())
+            .map(IppValue::Keyword)
+            .collect();
+        add("media-supported", IppValue::Array(vals));
+    }
+    if let Ok(k) = caps.media_default.as_str().try_into() {
+        add("media-default", IppValue::Keyword(k));
+    }
+
+    if !caps.tray_sources.is_empty() {
+        let vals: Vec<IppValue> = caps.tray_sources.iter()
+            .filter_map(|s| s.as_str().try_into().ok())
+            .map(IppValue::Keyword)
+            .collect();
+        add("media-source-supported", IppValue::Array(vals));
+    }
+    if let Ok(k) = "main".try_into() {
+        add("media-source-default", IppValue::Keyword(k));
+    }
+
+    // Colour capability: the bridge converts via ghostscript so we always accept
+    // colour input, but report whether the physical device produces colour output.
+    add("color-supported", IppValue::Boolean(caps.color));
+
+    // RFC 8011 required job-template attributes.
+    add("copies-default", IppValue::Integer(1));
+    add("copies-supported", IppValue::RangeOfInteger { min: 1, max: 99 });
+    add("finishings-default", IppValue::Enum(3)); // 3 = none
+    add("finishings-supported", IppValue::Enum(3));
+    add("page-ranges-supported", IppValue::Boolean(false));
+    add("sides-default", IppValue::Keyword("one-sided".try_into().unwrap()));
+    add("sides-supported", IppValue::Keyword("one-sided".try_into().unwrap()));
+    add("print-quality-default", IppValue::Enum(4)); // 4 = normal
+    {
+        let vals = vec![IppValue::Enum(3), IppValue::Enum(4), IppValue::Enum(5)]; // draft/normal/high
+        add("print-quality-supported", IppValue::Array(vals));
+    }
+    // macOS Photos checks print-color-mode-supported before queuing photo jobs.
+    // Advertise all modes; ghostscript converts colour → mono for this printer.
+    {
+        let modes: Vec<IppValue> = ["auto", "color", "monochrome"].iter().copied()
+            .filter_map(|k| k.try_into().ok())
+            .map(IppValue::Keyword)
+            .collect();
+        add("print-color-mode-supported", IppValue::Array(modes));
+    }
+    if let Ok(k) = "monochrome".try_into() {
+        add("print-color-mode-default", IppValue::Keyword(k));
+    }
+
+    add("printer-is-accepting-jobs", IppValue::Boolean(true));
+    add("queued-job-count", IppValue::Integer(0));
+    if let Ok(k) = "not-attempted".try_into() {
+        add("pdl-override-supported", IppValue::Keyword(k));
+    }
+    add("printer-up-time", IppValue::Integer(1));
+    if let Ok(k) = "none".try_into() { add("compression-supported", IppValue::Keyword(k)); }
+
+    ipp_bytes(resp)
+}
+
+fn doc_format(parsed: &IppRequestResponse) -> String {
+    parsed.attributes()
+        .groups_of(DelimiterTag::OperationAttributes)
+        .next()
+        .and_then(|g| g.attributes().get("document-format"))
+        .and_then(|a| {
+            if let IppValue::MimeMediaType(m) = a.value() {
+                Some(m.as_str().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "application/octet-stream".to_string())
+}
+
+/// Extract the `media-source` job attribute, defaulting to `"main"`.
+fn job_media_source(parsed: &IppRequestResponse) -> String {
+    parsed.attributes()
+        .groups_of(DelimiterTag::JobAttributes)
+        .next()
+        .and_then(|g| g.attributes().get("media-source"))
+        .and_then(|a| {
+            if let IppValue::Keyword(k) = a.value() {
+                Some(k.as_str().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "main".to_string())
+}
+
+/// Convert `image/urf` to a format gs can rasterize.
+/// On macOS uses `sips` to produce PDF; on Linux uses `ippeveps` to produce PostScript.
+/// Both outputs are accepted by the gs pbmraw call downstream.
+async fn urf_to_rasterizable(data: Vec<u8>, job_token: u32) -> anyhow::Result<Vec<u8>> {
+    let tmp = std::env::temp_dir();
+    let urf_path = tmp.join(format!("tailtalk-{job_token}.urf"));
+    tokio::fs::write(&urf_path, &data).await?;
+
+    #[cfg(target_os = "macos")]
+    let result: anyhow::Result<Vec<u8>> = {
+        let pdf_path = tmp.join(format!("tailtalk-{job_token}.pdf"));
+        let status = tokio::process::Command::new("sips")
+            .args(["--setProperty", "format", "pdf"])
+            .arg(&urf_path)
+            .arg("--out")
+            .arg(&pdf_path)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .await?;
+        let _ = tokio::fs::remove_file(&urf_path).await;
+        anyhow::ensure!(status.success(), "sips URF→PDF failed: {}", status);
+        let pdf = tokio::fs::read(&pdf_path).await?;
+        let _ = tokio::fs::remove_file(&pdf_path).await;
+        Ok(pdf)
+    };
+
+    #[cfg(target_os = "linux")]
+    let result: anyhow::Result<Vec<u8>> = {
+        // ippeveps converts URF → PostScript; gs accepts PS from a file just as well as PDF.
+        let output = tokio::process::Command::new("ippeveps")
+            .arg(&urf_path)
+            .env("CONTENT_TYPE", "image/urf")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .await?;
+        let _ = tokio::fs::remove_file(&urf_path).await;
+        anyhow::ensure!(output.status.success(), "ippeveps URF→PS failed: {}", output.status);
+        Ok(output.stdout)
+    };
+
+    // URF conversion is not supported on Windows; the magic-byte sniff in rasterize_to_ps
+    // should never reach here because URF is not advertised in the mDNS record on Windows,
+    // but guard against it explicitly.
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    let result: anyhow::Result<Vec<u8>> = {
+        let _ = tokio::fs::remove_file(&urf_path).await;
+        anyhow::bail!("URF format is not supported on this platform");
+    };
+
+    result
+}
+
+/// Return the name of the Ghostscript executable on this platform.
+/// On Windows, Ghostscript may be installed as `gswin64c` or `gswin32c`
+/// rather than `gs`; try each in order and return the first one found.
+fn gs_command() -> &'static str {
+    #[cfg(target_os = "windows")]
+    {
+        for candidate in &["gswin64c", "gswin32c", "gs"] {
+            if std::process::Command::new(candidate)
+                .arg("--version")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false)
+            {
+                return candidate;
+            }
+        }
+        "gswin64c" // fall through to a named binary so the error message is useful
+    }
+    #[cfg(not(target_os = "windows"))]
+    "gs"
+}
+
+/// Returns true if a usable Ghostscript executable is found on this platform.
+pub fn gs_probe() -> bool {
+    #[cfg(target_os = "windows")]
+    {
+        // gs_command() already probes all candidates; if it falls through to the
+        // default name without finding anything, a --version call will fail.
+        for candidate in &["gswin64c", "gswin32c", "gs"] {
+            if std::process::Command::new(candidate)
+                .arg("--version")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false)
+            {
+                return true;
+            }
+        }
+        false
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        std::process::Command::new("gs")
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+}
+
+// gs pbmraw → per-page PS Level-2 image; most reliable path for classic LaserWriter firmware.
+async fn rasterize_to_ps(mut data: Vec<u8>, fmt: &str, tray_source: &str, dpi: u32, job_token: u32) -> anyhow::Result<(Vec<u8>, usize)> {
+    if fmt == "application/postscript" || fmt == "application/vnd.cups-postscript" {
+        let page_count = data.windows(7).filter(|w| *w == b"%%Page:").count().max(1);
+        return Ok((data, page_count));
+    }
+    // Track whether urf_to_rasterizable ran — on Linux it returns PostScript, not PDF.
+    let is_urf = fmt == "image/urf" || data.starts_with(b"UNIRAST");
+    if is_urf {
+        data = urf_to_rasterizable(data, job_token).await?;
+    }
+
+    // pbmraw cannot write to stdout, so use a temp file.
+    let tmp = std::env::temp_dir();
+    let pbm_path = tmp.join(format!("tailtalk-rip-{job_token}.pbm"));
+    let res_arg = format!("-r{dpi}");
+
+    // Use .ps extension when we know the content is PostScript (Linux ippeveps output),
+    // .pdf otherwise. gs content-sniffs regardless, but the correct extension avoids
+    // confusion when the input file is retained for post-mortem debugging.
+    #[cfg(target_os = "linux")]
+    let input_ext = if is_urf { "ps" } else { "pdf" };
+    #[cfg(not(target_os = "linux"))]
+    let input_ext = "pdf";
+    let input_path = tmp.join(format!("tailtalk-in-{job_token}.{input_ext}"));
+    tokio::fs::write(&input_path, &data).await?;
+
+    let output = tokio::process::Command::new(gs_command())
+        // Pass -sOutputFile as a separate -o arg so the OS handles path quoting,
+        // avoiding issues with spaces in the temp directory path on Windows.
+        .args(["-dNOPAUSE", "-dBATCH", "-dSAFER", "-sDEVICE=pbmraw", &res_arg, "-o"])
+        .arg(&pbm_path)
+        .arg(&input_path)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Keep the input file around for post-mortem; clean up the (possibly partial) pbm.
+        let _ = tokio::fs::remove_file(&pbm_path).await;
+        anyhow::bail!(
+            "gs pbmraw exited with {} (input kept at {})\nstderr: {}\nstdout: {}",
+            output.status,
+            input_path.display(),
+            stderr.trim(),
+            stdout.trim(),
+        );
+    }
+    let _ = tokio::fs::remove_file(&input_path).await;
+
+    let pbm = tokio::fs::read(&pbm_path).await;
+    let _ = tokio::fs::remove_file(&pbm_path).await;
+    let pbm = pbm?;
+
+    let pages = parse_pbm_pages(&pbm)?;
+    anyhow::ensure!(!pages.is_empty(), "gs produced no pages");
+
+    let page_count = pages.len();
+    Ok((build_ps_raster(&pages, dpi, tray_source), page_count))
+}
+
+/// Parse one or more concatenated P4 (binary PBM) images from `data`.
+fn parse_pbm_pages(data: &[u8]) -> anyhow::Result<Vec<(u32, u32, Vec<u8>)>> {
+    let mut pages = Vec::new();
+    let mut pos = 0;
+    while pos < data.len() {
+        let Some((w, h, header_len)) = parse_pbm_header(&data[pos..]) else { break };
+        let row_bytes = (w as usize + 7) / 8;
+        let page_bytes = row_bytes * h as usize;
+        let data_start = pos + header_len;
+        let data_end = data_start + page_bytes;
+        if data_end > data.len() { break; }
+        pages.push((w, h, data[data_start..data_end].to_vec()));
+        pos = data_end;
+    }
+    Ok(pages)
+}
+
+/// Parse a P4 (binary PBM) header starting at `data[0]`.
+fn parse_pbm_header(data: &[u8]) -> Option<(u32, u32, usize)> {
+    if data.get(0..2) != Some(b"P4") { return None; }
+    let mut pos = 2;
+
+    let skip = |data: &[u8], pos: &mut usize| {
+        loop {
+            while *pos < data.len() && matches!(data[*pos], b' ' | b'\t' | b'\r' | b'\n') {
+                *pos += 1;
+            }
+            if *pos < data.len() && data[*pos] == b'#' {
+                while *pos < data.len() && data[*pos] != b'\n' { *pos += 1; }
+            } else {
+                break;
+            }
+        }
+    };
+
+    let read_u32 = |data: &[u8], pos: &mut usize| -> Option<u32> {
+        skip(data, pos);
+        let start = *pos;
+        while *pos < data.len() && data[*pos].is_ascii_digit() { *pos += 1; }
+        if *pos == start { return None; }
+        std::str::from_utf8(&data[start..*pos]).ok()?.parse().ok()
+    };
+
+    let w = read_u32(data, &mut pos)?;
+    let h = read_u32(data, &mut pos)?;
+    if pos >= data.len() { return None; }
+    pos += 1; // mandatory single whitespace after height
+    Some((w, h, pos))
+}
+
+/// PackBits (PostScript RunLengthDecode) encoder.
+fn encode_runlength(data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < data.len() {
+        let b = data[i];
+        let mut run = 1;
+        while i + run < data.len() && data[i + run] == b && run < 128 { run += 1; }
+        if run >= 2 {
+            out.push((257 - run) as u8);
+            out.push(b);
+            i += run;
+        } else {
+            let lit_start = i;
+            i += 1;
+            while i < data.len() && (i - lit_start) < 128 {
+                let mut ahead = 1;
+                while i + ahead < data.len() && data[i + ahead] == data[i] && ahead < 128 { ahead += 1; }
+                if ahead >= 3 { break; }
+                i += 1;
+            }
+            let lit_len = i - lit_start;
+            out.push((lit_len - 1) as u8);
+            out.extend_from_slice(&data[lit_start..i]);
+        }
+    }
+    out.push(0x80); // EOD
+    out
+}
+
+// LaserWriter 4/600 fw 2014.107 crashes on multi-level filter chains (e.g. CCITTFax) — ASCIIHex only.
+fn encode_asciihex(data: &[u8]) -> Vec<u8> {
+    const BYTES_PER_LINE: usize = 38;
+    let mut out = Vec::with_capacity(data.len() * 2 + data.len() / BYTES_PER_LINE + 2);
+    for chunk in data.chunks(BYTES_PER_LINE) {
+        for byte in chunk {
+            let hi = byte >> 4;
+            let lo = byte & 0xF;
+            out.push(if hi < 10 { b'0' + hi } else { b'A' + hi - 10 });
+            out.push(if lo < 10 { b'0' + lo } else { b'A' + lo - 10 });
+        }
+        out.push(b'\n');
+    }
+    out.push(b'>');
+    out.push(b'\n');
+    out
+}
+
+/// Assemble a multi-page PS document from rasterized PBM pages.
+fn build_ps_raster(pages: &[(u32, u32, Vec<u8>)], dpi: u32, tray_source: &str) -> Vec<u8> {
+    let mut out = Vec::new();
+    let _ = writeln!(out, "%!PS-Adobe-3.0");
+    let _ = writeln!(out, "%%LanguageLevel: 2");
+    let _ = writeln!(out, "%%Pages: {}", pages.len());
+    let _ = writeln!(out, "%%EndComments");
+    match tray_source {
+        "manual" => {
+            let _ = writeln!(out, "%%BeginSetup");
+            let _ = writeln!(out, "<< /ManualFeed true >> setpagedevice");
+            let _ = writeln!(out, "%%EndSetup");
+        }
+        "alternate" => {
+            let _ = writeln!(out, "%%BeginSetup");
+            let _ = writeln!(out, "<< /MediaPosition 1 >> setpagedevice");
+            let _ = writeln!(out, "%%EndSetup");
+        }
+        _ => {}
+    }
+    for (i, (width, height, bitmap)) in pages.iter().enumerate() {
+        let (width, height) = (*width, *height);
+        let pts_w = width as f64 * 72.0 / dpi as f64;
+        let pts_h = height as f64 * 72.0 / dpi as f64;
+        let _ = writeln!(out, "%%Page: {} {}", i + 1, i + 1);
+        let _ = writeln!(out, "gsave");
+        let _ = writeln!(out, "{pts_w:.4} {pts_h:.4} scale");
+        let _ = writeln!(out, "{width} {height} 1");
+        // Matrix: map [0..1 × 0..1] to pixel coords, flip Y so row 0 → top of page.
+        let _ = writeln!(out, "[ {width} 0 0 -{height} 0 {height} ]");
+        let _ = writeln!(out, "currentfile /ASCIIHexDecode filter /RunLengthDecode filter");
+        let _ = writeln!(out, "image");
+        // PBM: 1 = black; PostScript image: 1 = white — invert.
+        let inverted: Vec<u8> = bitmap.iter().map(|b| !b).collect();
+        let compressed = encode_runlength(&inverted);
+        out.extend_from_slice(&encode_asciihex(&compressed));
+        let _ = writeln!(out, "grestore");
+        let _ = writeln!(out, "showpage");
+    }
+    let _ = writeln!(out, "%%EOF");
+    out
+}
+
+async fn print_to_pap(ddp: DdpHandle, addr: AtpAddress, doc: Vec<u8>) -> anyhow::Result<String> {
+    if doc.is_empty() {
+        tracing::warn!("IPP: empty document, skipping print");
+        return Ok(String::new());
+    }
+    let (_, req, resp) = Atp::spawn(&ddp, None).await;
+    let mut pap = PapClient::new(req, resp);
+    pap.connect(addr).await?;
+    pap.print_stream(Cursor::new(doc)).await?;
+    let output_bytes = tokio::time::timeout(Duration::from_secs(15), pap.read_response())
+        .await
+        .unwrap_or_else(|_| Ok(vec![]))?;
+    pap.close().await?;
+    let output = String::from_utf8_lossy(&output_bytes).into_owned();
+    if !output.trim().is_empty() {
+        tracing::info!("IPP: printer output: {output}");
+    }
+    Ok(output)
+}
+
+/// Returns the PS error string from `%%[ Error: ]%%` lines; ignores `PrinterError`/`LastError`.
+fn parse_printer_error(output: &str) -> Option<String> {
+    output.lines()
+        .map(|l| l.trim())
+        .find(|l| l.starts_with("%%[ Error:"))
+        .map(|l| l.trim_start_matches("%%[").trim_end_matches("]%%").trim().to_string())
+}

--- a/tailtalk-gui/main.rs
+++ b/tailtalk-gui/main.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 #[cfg(any(feature = "ethertalk", feature = "tashtalk"))]
 use std::rc::Rc;
@@ -15,6 +16,8 @@ use tracing_subscriber::{EnvFilter, prelude::*};
 
 slint::include_modules!();
 
+mod ipp_bridge;
+
 // ── Persisted user configuration ──────────────────────────────────────────────
 
 #[derive(Serialize, Deserialize, Default)]
@@ -28,6 +31,7 @@ struct AppConfig {
     ethernet_interface: Option<String>,
     pcap_enabled: bool,
     pcap_path: Option<String>,
+    ipp_bridge_enabled: bool,
 }
 
 fn config_path() -> Option<PathBuf> {
@@ -63,6 +67,7 @@ enum ServerCommand {
         tashtalk: Option<String>,
         volume: PathBuf,
         pcap_path: Option<PathBuf>,
+        ipp_bridge_enabled: bool,
     },
     Stop,
 }
@@ -190,6 +195,9 @@ fn open_in_file_manager(path: &Path) {
 
 fn main() -> anyhow::Result<()> {
     let (cmd_tx, cmd_rx) = tokio::sync::mpsc::channel::<ServerCommand>(4);
+    // Shared handle used to shut the stack down when the window closes.
+    let active_handle: Arc<tokio::sync::Mutex<Option<ShutdownHandle>>> =
+        Arc::new(tokio::sync::Mutex::new(None));
 
     let (_log_guard, log_dir) = init_logging();
 
@@ -263,10 +271,11 @@ fn main() -> anyhow::Result<()> {
         if let Some(ref path) = config.pcap_path {
             ui.set_pcap_path(path.as_str().into());
         }
+        ui.set_ipp_bridge_enabled(config.ipp_bridge_enabled);
     }
 
     let ui_handle = ui.as_weak();
-    rt_handle.spawn(server_loop(cmd_rx, ui_handle));
+    rt_handle.spawn(server_loop(cmd_rx, ui_handle, active_handle.clone()));
 
     let ui_weak = ui.as_weak();
     #[cfg(feature = "ethertalk")]
@@ -319,6 +328,41 @@ fn main() -> anyhow::Result<()> {
                 return;
             }
 
+            if ui.get_ipp_bridge_enabled() {
+                let gs_ok = ipp_bridge::gs_probe();
+                if !gs_ok {
+                    #[cfg(target_os = "macos")]
+                    let hint = "Please install it via \"brew install ghostscript\".";
+                    #[cfg(target_os = "linux")]
+                    let hint = "Please install it via \"sudo apt install ghostscript\" or your distro's equivalent.";
+                    #[cfg(target_os = "windows")]
+                    let hint = "Please install it from https://www.ghostscript.com/releases/gsdnld.html and ensure gswin64c or gs is in your PATH.";
+                    show_error(
+                        ui_weak.clone(),
+                        format!("Ghostscript is required for the LaserWriter printing bridge but was not found.\n{hint}"),
+                    );
+                    return;
+                }
+                #[cfg(target_os = "linux")]
+                {
+                    let ippeveps_ok = std::process::Command::new("ippeveps")
+                        .stdout(std::process::Stdio::null())
+                        // ippeveps exits with an error when no CONTENT_TYPE is set, but that
+                        // still means it's present — check for spawn failure instead.
+                        .stderr(std::process::Stdio::null())
+                        .status()
+                        .is_ok();
+                    if !ippeveps_ok {
+                        show_error(
+                            ui_weak.clone(),
+                            "ippeveps is required for the LaserWriter printing bridge on Linux but was not found.\n\
+                            Please install it via \"sudo apt install cups-ipp-utils\".".to_string(),
+                        );
+                        return;
+                    }
+                }
+            }
+
             save_config(&AppConfig {
                 server_name: Some(ui.get_server_name().to_string()),
                 volume_name: Some(ui.get_volume_name().to_string()),
@@ -340,6 +384,7 @@ fn main() -> anyhow::Result<()> {
                     let s = ui.get_pcap_path().to_string();
                     if s.is_empty() { None } else { Some(s) }
                 },
+                ipp_bridge_enabled: ui.get_ipp_bridge_enabled(),
             });
 
             let pcap_path: Option<PathBuf> = if ui.get_pcap_enabled() {
@@ -358,6 +403,7 @@ fn main() -> anyhow::Result<()> {
                 tashtalk,
                 volume,
                 pcap_path,
+                ipp_bridge_enabled: ui.get_ipp_bridge_enabled(),
             });
         }
     });
@@ -660,6 +706,14 @@ fn main() -> anyhow::Result<()> {
     };
 
     ui.run()?;
+
+    // Window closed — shut down any active stack so mDNS goodbye packets are sent.
+    rt.block_on(async {
+        if let Some(h) = active_handle.lock().await.take() {
+            h.graceful_shutdown().await;
+        }
+    });
+
     Ok(())
 }
 
@@ -668,6 +722,7 @@ fn main() -> anyhow::Result<()> {
 async fn server_loop(
     mut cmd_rx: tokio::sync::mpsc::Receiver<ServerCommand>,
     ui_weak: slint::Weak<AppWindow>,
+    active: Arc<tokio::sync::Mutex<Option<ShutdownHandle>>>,
 ) {
     let mut shutdown_handle: Option<ShutdownHandle> = None;
 
@@ -682,13 +737,15 @@ async fn server_loop(
                 tashtalk,
                 volume,
                 pcap_path,
+                ipp_bridge_enabled,
             } => {
                 if let Some(h) = shutdown_handle.take() {
+                    active.lock().await.take();
                     h.graceful_shutdown().await;
                 }
 
                 let ui_w = ui_weak.clone();
-                let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<ShutdownHandle>();
+                let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<(ShutdownHandle, ShutdownHandle)>();
                 tokio::spawn(run_server(
                     server_name,
                     volume_name,
@@ -698,13 +755,15 @@ async fn server_loop(
                     tashtalk,
                     volume,
                     pcap_path,
+                    ipp_bridge_enabled,
                     ready_tx,
                     ui_w.clone(),
                 ));
 
                 // Wait for the stack to finish initialising (AARP probe etc.)
                 // before flipping the UI to "Running".
-                if let Ok(handle) = ready_rx.await {
+                if let Ok((handle, extra)) = ready_rx.await {
+                    *active.lock().await = Some(extra);
                     shutdown_handle = Some(handle);
                     slint::invoke_from_event_loop(move || {
                         if let Some(ui) = ui_w.upgrade() {
@@ -719,6 +778,7 @@ async fn server_loop(
 
             ServerCommand::Stop => {
                 if let Some(h) = shutdown_handle.take() {
+                    active.lock().await.take();
                     h.graceful_shutdown().await;
                 }
                 let ui_w = ui_weak.clone();
@@ -1470,7 +1530,8 @@ async fn run_server(
     #[cfg(feature = "tashtalk")] tashtalk: Option<String>,
     volume: PathBuf,
     pcap_path: Option<PathBuf>,
-    ready_tx: tokio::sync::oneshot::Sender<ShutdownHandle>,
+    ipp_bridge_enabled: bool,
+    ready_tx: tokio::sync::oneshot::Sender<(ShutdownHandle, ShutdownHandle)>,
     ui_weak: slint::Weak<AppWindow>,
 ) {
     use tailtalk::{
@@ -1582,6 +1643,14 @@ async fn run_server(
         }
     };
 
+    if ipp_bridge_enabled {
+        tokio::spawn(ipp_bridge::run(
+            stack.nbp.clone(),
+            stack.ddp.clone(),
+            stack.token(),
+        ));
+    }
+
     #[cfg(any(feature = "ethertalk", feature = "tashtalk"))]
     {
         #[cfg(all(feature = "ethertalk", feature = "tashtalk"))]
@@ -1598,8 +1667,9 @@ async fn run_server(
         tracing::info!("AFP server running on {transport_desc}");
     }
 
-    // Signal the GUI that the stack is up; hand over the shutdown handle.
-    let _ = ready_tx.send(stack.shutdown_handle());
+    // Signal the GUI that the stack is up; hand over two shutdown handles —
+    // one for server_loop (Stop button), one held by main for window-close cleanup.
+    let _ = ready_tx.send((stack.shutdown_handle(), stack.shutdown_handle()));
 
     // Block until shutdown() is called (e.g. the user clicks Stop).
     stack.wait_for_shutdown().await;

--- a/tailtalk-gui/ui/app.slint
+++ b/tailtalk-gui/ui/app.slint
@@ -5,7 +5,7 @@ export component AppWindow inherits Window {
     min-width: 400px;
     min-height: 200px;
     preferred-width: 540px;
-    preferred-height: 440px;
+    preferred-height: 495px;
 
     in-out property <string> server-name: "TailTalk AFP";
     in property <[string]> ethernet-interfaces;
@@ -22,6 +22,7 @@ export component AppWindow inherits Window {
     in-out property <string> error-message: "";
     in-out property <bool> pcap-enabled: false;
     in-out property <string> pcap-path;
+    in-out property <bool> ipp-bridge-enabled: false;
     in-out property <string> info-message: "";
 
     in-out property <bool> import-progress-visible: false;
@@ -179,6 +180,21 @@ export component AppWindow inherits Window {
                         enabled: !root.running && root.pcap-enabled;
                         clicked => { root.browse-pcap(); }
                     }
+                }
+
+                // ── Printing ──────────────────────────────────────────────────
+                Rectangle { height: 8px; }
+                Text { text: "Printing (Experimental)"; font-weight: 700; }
+
+                HorizontalBox {
+                    padding-top: 0; padding-bottom: 0;
+                    Text { text: "IPP Bridge"; min-width: 140px; vertical-alignment: center; }
+                    CheckBox {
+                        checked <=> root.ipp-bridge-enabled;
+                        enabled: !root.running;
+                    }
+                    Text { text: "Expose printers via IPP (port 8631)"; vertical-alignment: center; }
+                    Rectangle { horizontal-stretch: 1; }
                 }
             }
         }

--- a/tailtalk/src/pap.rs
+++ b/tailtalk/src/pap.rs
@@ -109,6 +109,8 @@ impl PapClient {
         self.print_stream(std::io::Cursor::new(data)).await
     }
 
+    /// Stream `source` to the printer.  Call [`read_response`] afterwards to
+    /// collect any printer stdout output (errors, page stats) buffered until job end.
     pub async fn print_stream<R: AsyncRead + Unpin>(&mut self, mut source: R) -> Result<()> {
         tracing::info!("PAP: Starting streaming print job");
 
@@ -116,6 +118,8 @@ impl PapClient {
         let mut tickle_interval = interval(Duration::from_secs(30));
         tickle_interval.tick().await; // skip the immediate first tick
         let mut eof_sent = false;
+        // Skip the 30-s Tickle wait after EOF; return on the next printer SendData or a short deadline.
+        let mut eof_deadline: Option<tokio::time::Instant> = None;
 
         loop {
             tokio::select! {
@@ -152,19 +156,24 @@ impl PapClient {
                                 (n, buf)
                             };
 
+                            let eof = n == 0;
                             let pap_resp = PapPacket {
                                 connection_id: self.connection_id,
                                 function: PapFunction::Data,
                                 sequence_num: seq_num,
-                                eof: n == 0,
+                                eof,
                                 data: buf,
                             };
                             let (user_bytes, chunk_data) = pap_resp.to_atp_parts();
                             req.send_response_chunked(chunk_data.to_vec(), user_bytes, PAP_MAX_DATA_PER_PACKET).await?;
 
-                            if n == 0 && !eof_sent {
+                            if eof && !eof_sent {
                                 tracing::info!("PAP: EOF sent");
                                 eof_sent = true;
+                                eof_deadline = Some(tokio::time::Instant::now() + Duration::from_millis(500));
+                            } else if eof_sent {
+                                // Drained the in-flight SendData after our EOF; safe to return.
+                                return Ok(());
                             }
                         }
                         PapFunction::Tickle => {
@@ -207,6 +216,16 @@ impl PapClient {
                     let (ub, _) = tickle.to_atp_parts();
                     let _ = self.atp_requestor.send_alo(self.server_addr, ub).await;
                 }
+
+                _ = async {
+                    match eof_deadline {
+                        Some(d) => tokio::time::sleep_until(d).await,
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    // Short deadline after EOF elapsed with no further printer activity.
+                    return Ok(());
+                }
             }
         }
     }
@@ -235,11 +254,9 @@ impl PapClient {
             }
 
             response.extend_from_slice(&data_pkt.data);
-
             if data_pkt.eof {
                 break;
             }
-
             seq = seq.wrapping_add(1);
         }
 


### PR DESCRIPTION
Adds a new little feature to our GUI that when checked on the main screen will periodically scan for LaserWriters on the local network after the server starts. If one is found, we will query the printer for its capabilities and expose it as an AirPrint / IPP printer, making it usable by modern devices (i.e iPhones, the host system itself, and anything that can talk IPP).

It is _super_ hacky at this point. I made it do some pre-rasterisation down to 1-bit monochrome with runtime length encoding as the default sizes generated from received files would take 5-10 minutes sometimes on my LaserWriter 4/600. With this it starts to print pretty much immediately after all data is sent which is usually under a minute.

Of course the only device I have was the 4/600 and I have not tested it on anything else. I think it should work, but, testing is very much needed :)