### PR TITLE
GUI+AFP: Use shellexpand for ~ expansion, return volume errors to user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5655,6 +5655,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6213,6 +6222,7 @@ dependencies = [
  "rfd",
  "serde",
  "serialport",
+ "shellexpand",
  "slint",
  "slint-build",
  "stuffit",

--- a/examples/afp-server/main.rs
+++ b/examples/afp-server/main.rs
@@ -51,7 +51,7 @@ async fn main() {
         ..AfpServerConfig::default()
     };
 
-    let _afp_server = stack.spawn_afp(Some(254), afp_config)
+    stack.spawn_afp(Some(254), afp_config)
         .await
         .expect("failed to spawn AFP server");
 

--- a/tailtalk-gui/Cargo.toml
+++ b/tailtalk-gui/Cargo.toml
@@ -23,6 +23,7 @@ if-addrs = "0.15"
 ipp = "6.0.1"
 mdns-sd = "0.20.0"
 rfd = "0.17"
+shellexpand = "3"
 serde = { version = "1", features = ["derive"] }
 serialport = { version = "4", optional = true }
 slint = "1"

--- a/tailtalk-gui/ipp_bridge.rs
+++ b/tailtalk-gui/ipp_bridge.rs
@@ -516,16 +516,14 @@ fn extract_job_id(parsed: &IppRequestResponse) -> Option<u32> {
         .groups_of(DelimiterTag::OperationAttributes)
         .next()
         .and_then(|g| {
-            if let Some(a) = g.attributes().get("job-id") {
-                if let IppValue::Integer(id) = a.value() {
+            if let Some(a) = g.attributes().get("job-id")
+                && let IppValue::Integer(id) = a.value() {
                     return Some(*id as u32);
                 }
-            }
-            if let Some(a) = g.attributes().get("job-uri") {
-                if let IppValue::Uri(u) = a.value() {
+            if let Some(a) = g.attributes().get("job-uri")
+                && let IppValue::Uri(u) = a.value() {
                     return u.as_str().rsplit('/').next()?.parse::<u32>().ok();
                 }
-            }
             None
         })
 }
@@ -1085,7 +1083,7 @@ fn parse_pbm_pages(data: &[u8]) -> anyhow::Result<Vec<(u32, u32, Vec<u8>)>> {
     let mut pos = 0;
     while pos < data.len() {
         let Some((w, h, header_len)) = parse_pbm_header(&data[pos..]) else { break };
-        let row_bytes = (w as usize + 7) / 8;
+        let row_bytes = (w as usize).div_ceil(8);
         let page_bytes = row_bytes * h as usize;
         let data_start = pos + header_len;
         let data_end = data_start + page_bytes;

--- a/tailtalk-gui/main.rs
+++ b/tailtalk-gui/main.rs
@@ -322,7 +322,7 @@ fn main() -> anyhow::Result<()> {
                 return;
             }
 
-            let volume = PathBuf::from(ui.get_volume_path().as_str());
+            let volume = PathBuf::from(shellexpand::tilde(ui.get_volume_path().as_str()).as_ref());
             if volume.as_os_str().is_empty() {
                 tracing::error!("No volume path selected");
                 return;
@@ -389,7 +389,7 @@ fn main() -> anyhow::Result<()> {
 
             let pcap_path: Option<PathBuf> = if ui.get_pcap_enabled() {
                 let s = ui.get_pcap_path().to_string();
-                if s.is_empty() { None } else { Some(PathBuf::from(s)) }
+                if s.is_empty() { None } else { Some(PathBuf::from(shellexpand::tilde(&s).as_ref())) }
             } else {
                 None
             };
@@ -1632,16 +1632,14 @@ async fn run_server(
         ..AfpServerConfig::default()
     };
 
-    let _afp = match stack.spawn_afp(Some(254), afp_config).await {
-        Ok(s) => s,
-        Err(e) => {
-            let msg = format!("Failed to start AFP server:\n{e}");
-            tracing::error!("{msg}");
-            show_error(ui_weak.clone(), msg);
-            set_stopped(ui_weak);
-            return;
-        }
-    };
+    if let Err(e) = stack.spawn_afp(Some(254), afp_config).await {
+        let msg = format!("Failed to start AFP server:\n{e}");
+        tracing::error!("{msg}");
+        show_error(ui_weak.clone(), msg);
+        stack.shutdown_handle().shutdown();
+        set_stopped(ui_weak);
+        return;
+    }
 
     if ipp_bridge_enabled {
         tokio::spawn(ipp_bridge::run(

--- a/tailtalk/src/afp/mod.rs
+++ b/tailtalk/src/afp/mod.rs
@@ -3,6 +3,8 @@ mod server;
 mod volume;
 
 pub use desktop::DesktopDatabase;
-pub use server::{AfpServer, AfpServerConfig};
+pub(crate) use server::AfpServer;
+pub use server::AfpServerConfig;
+
 pub use tailtalk_packets::afp::{FinderFlags, FinderInfo};
 pub use volume::{read_finder_info, write_finder_info, Volume};

--- a/tailtalk/src/afp/server.rs
+++ b/tailtalk/src/afp/server.rs
@@ -33,8 +33,8 @@ pub struct AfpServerConfig {
 
 impl Default for AfpServerConfig {
     fn default() -> Self {
-        // Default volume icon (same as example)
-        let _volume_icon = [
+        // Default volume icon taken from Mac OS 9
+        let volume_icon = [
             0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x2, 0x9f, 0xe0, 0x0,
             0x4, 0x50, 0x30, 0x0, 0x8, 0x30, 0x28, 0x0, 0x10, 0x10, 0x3c, 0x7, 0xa0, 0x8, 0x4,
             0x18, 0x7f, 0x4, 0x4, 0x10, 0x0, 0x82, 0x4, 0x10, 0x0, 0x81, 0x4, 0x10, 0x0, 0x82, 0x4,
@@ -59,7 +59,7 @@ impl Default for AfpServerConfig {
             machine_type: "Macintosh".to_string(),
             afp_versions: vec![AfpVersion::Version2, AfpVersion::Version2_1],
             uams: vec![AfpUam::NoUserAuthent],
-            volume_icon: None,
+            volume_icon: Some(volume_icon),
             flags: 0x3,
             volume_path: PathBuf::from("./"),
             volume_name: "MacShare".to_string(),
@@ -71,6 +71,8 @@ impl Default for AfpServerConfig {
 pub struct AfpServer {
     asp_handle: AspHandle,
     config: Arc<AfpServerConfig>,
+    db: sled::Db,
+    shutdown: CancellationToken,
 }
 
 impl AfpServer {
@@ -85,7 +87,7 @@ impl AfpServer {
         config: AfpServerConfig,
         shutdown: CancellationToken,
         services_done: CancellationToken,
-    ) -> anyhow::Result<Self> {
+    ) -> anyhow::Result<()> {
         let config = Arc::new(config);
 
         // Create server status information
@@ -114,60 +116,44 @@ impl AfpServer {
 
         info!("AFP server '{}' started", config.server_name);
 
-        let server = Self { asp_handle, config };
+        // Open the desktop DB before spawning so failures surface as errors to the caller.
+        // sled::Db is internally reference-counted so all clones share the same on-disk DB.
+        let db = crate::afp::DesktopDatabase::open_or_create(&config.volume_path)
+            .map_err(|e| anyhow::anyhow!("Failed to open desktop database: {e:?}"))?;
 
-        // Spawn session handler
-        let server_clone_config = server.config.clone();
-        let server_clone_handle = server.asp_handle.clone();
-        tokio::spawn(async move {
-            run_server(server_clone_handle, server_clone_config, shutdown).await;
-        });
+        tokio::spawn(Self { asp_handle, config, db, shutdown }.run());
 
-        Ok(server)
+        Ok(())
     }
-}
 
-/// Run the AFP server session loop
-async fn run_server(asp_handle: AspHandle, config: Arc<AfpServerConfig>, token: CancellationToken) {
-    info!(
-        "AFP server '{}' waiting for sessions...",
-        config.server_name
-    );
+    async fn run(self) {
+        info!("AFP server '{}' waiting for sessions...", self.config.server_name);
 
-    // Open the desktop DB once and share the handle across all sessions via clone.
-    // sled::Db is internally reference-counted so all clones share the same on-disk DB.
-    let shared_db = match crate::afp::DesktopDatabase::open_or_create(&config.volume_path) {
-        Ok(db) => db,
-        Err(e) => {
-            error!("Failed to open desktop database: {:?}", e);
-            return;
+        let mut session_count = 0;
+
+        loop {
+            let session = tokio::select! {
+                _ = self.shutdown.cancelled() => break,
+                result = self.asp_handle.get_session() => match result {
+                    Ok(s) => s,
+                    Err(e) => { error!("Failed to accept AFP session: {}", e); break; }
+                },
+            };
+
+            session_count += 1;
+            info!(
+                "AFP session {} accepted from {:?}",
+                session_count, session.remote_addr
+            );
+
+            let session_config = self.config.clone();
+            let session_db = self.db.clone();
+            tokio::spawn(async move {
+                if let Err(e) = session.handle_session(session_config, session_db).await {
+                    error!("Session error: {}", e);
+                }
+            });
         }
-    };
-
-    let mut session_count = 0;
-
-    loop {
-        let session = tokio::select! {
-            _ = token.cancelled() => break,
-            result = asp_handle.get_session() => match result {
-                Ok(s) => s,
-                Err(e) => { error!("Failed to accept AFP session: {}", e); break; }
-            },
-        };
-
-        session_count += 1;
-        info!(
-            "AFP session {} accepted from {:?}",
-            session_count, session.remote_addr
-        );
-
-        let session_config = config.clone();
-        let session_db = shared_db.clone();
-        tokio::spawn(async move {
-            if let Err(e) = session.handle_session(session_config, session_db).await {
-                error!("Session error: {}", e);
-            }
-        });
     }
 }
 

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -698,7 +698,7 @@ impl TalkStack {
     }
 
     /// Start an AFP file server on this stack.
-    pub async fn spawn_afp(&self, socket: Option<u8>, config: afp::AfpServerConfig) -> anyhow::Result<afp::AfpServer> {
+    pub async fn spawn_afp(&self, socket: Option<u8>, config: afp::AfpServerConfig) -> anyhow::Result<()> {
         afp::AfpServer::spawn(&self.ddp, &self.nbp, socket, config, self.service_token.clone(), self.services_done.clone()).await
     }
 


### PR DESCRIPTION
Imports the shellexpand crate so that way manually entered paths will be able to use `~/` as part of the pathname. Previously we would end up resolving this to `$CWD/~/` which when used with the macOS app version would give a confusing error.

Additionally this error was only visible in the logs - when a Mac would try and connect we'd return a server unavailable error message and it was very hidden what the true issue was. Now we will return this error early and report it up to the user, and shut down the stack. This then should make it more obvious what is going on and not leave the stack in a partially functioning state.

Lastly fixes a few clippy warnings I missed in the past run.