### PR TITLE
ADSP: Fix ADSP implementation, add missing APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6121,6 +6121,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sw-rename"
+version = "0.7.1"
+dependencies = [
+ "anyhow",
+ "clap",
+ "tailtalk",
+ "tailtalk-packets",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "swash"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "examples/pap-print",
   "examples/afp-server",
   "examples/adsp-stylewriter",
+  "examples/sw-rename",
   "tailtalk-gui",
   "tashtalk",
   "hfs-reader",

--- a/examples/sw-rename/Cargo.toml
+++ b/examples/sw-rename/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sw-rename"
+version.workspace = true
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "sw-rename"
+path = "main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+tailtalk = { workspace = true, features = ["ethertalk"] }
+tailtalk-packets = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/sw-rename/main.rs
+++ b/examples/sw-rename/main.rs
@@ -1,0 +1,158 @@
+use clap::Parser;
+use tailtalk::{TalkStack, adsp::AdspAddress};
+use tailtalk_packets::nbp::EntityName;
+use tokio::io::AsyncReadExt;
+use tokio::time::{Duration, timeout};
+
+/// ADSP management socket — fixed at 129 on StyleWriter adapters.
+const SW_MGMT_SOCKET: u8 = 129;
+
+/// Attention command codes used by the StyleWriter name-change protocol.
+const ATTN_GET_NAME: u16 = 0x0011;
+const ATTN_SET_NAME: u16 = 0x0009;
+const ATTN_COMMIT:   u16 = 0x0012;
+
+#[derive(Parser, Debug)]
+#[command(about = "Rename a Color StyleWriter adapter via ADSP")]
+struct Args {
+    /// EtherTalk network interface
+    #[arg(short, long)]
+    interface: String,
+
+    /// NBP entity to search for (Object:Type@Zone)
+    #[arg(short, long, default_value = "=:ColorStyleWriter2400AT@*")]
+    target: String,
+
+    /// New printer name (max 31 characters)
+    #[arg(short, long)]
+    name: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(tracing::Level::WARN.into()),
+        )
+        .init();
+
+    let args = Args::parse();
+
+    if args.name.is_empty() || args.name.len() > 31 {
+        anyhow::bail!("name must be 1–31 characters (got {})", args.name.len());
+    }
+
+    let entity: EntityName = args
+        .target
+        .as_str()
+        .try_into()
+        .map_err(|e| anyhow::anyhow!("invalid target: {}", e))?;
+
+    println!("Building AppleTalk stack on {}...", args.interface);
+    let stack = TalkStack::builder()
+        .ethernet(&args.interface)
+        .build()
+        .await?;
+
+    println!("Looking up '{}'...", entity);
+    let tuples = timeout(Duration::from_secs(10), stack.nbp.lookup(entity))
+        .await
+        .map_err(|_| anyhow::anyhow!("NBP lookup timed out after 10 s"))?
+        .map_err(|e| anyhow::anyhow!("NBP lookup failed: {}", e))?;
+
+    if tuples.is_empty() {
+        anyhow::bail!("no printer found — is it powered on and on the same network?");
+    }
+
+    let printer = &tuples[0];
+    println!(
+        "Found: {} — {}.{} socket {}",
+        printer.entity_name, printer.network_number, printer.node_id, printer.socket_number
+    );
+    let old_name = printer.entity_name.object.clone();
+
+    // The management ADSP port is fixed at socket 129, independent of the PAP
+    // socket that NBP advertises.
+    let mgmt_addr = AdspAddress {
+        network_number: printer.network_number,
+        node_number:    printer.node_id,
+        socket_number:  SW_MGMT_SOCKET,
+    };
+
+    println!(
+        "Connecting ADSP to {}.{} socket {}...",
+        mgmt_addr.network_number, mgmt_addr.node_number, mgmt_addr.socket_number
+    );
+    let mut stream = timeout(Duration::from_secs(10), stack.connect_adsp(mgmt_addr))
+        .await
+        .map_err(|_| anyhow::anyhow!("ADSP connect timed out — is socket {} open?", SW_MGMT_SOCKET))?
+        .map_err(|e| anyhow::anyhow!("ADSP connect failed: {}", e))?;
+    println!("ADSP session established.");
+
+    let mut resp = [0u8; 2];
+
+    println!("Sending init query (0x{:04X})...", ATTN_GET_NAME);
+    stream.send_attention(ATTN_GET_NAME, &[0x00]).await?;
+    timeout(Duration::from_secs(30), stream.read_exact(&mut resp))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to 0x{:04X}", ATTN_GET_NAME))??;
+    if resp != [0x00, 0x00] {
+        anyhow::bail!("unexpected response to 0x{:04X}: {:02X?}", ATTN_GET_NAME, resp);
+    }
+
+    // Pascal string: length byte followed by the name bytes.
+    let name_bytes = args.name.as_bytes();
+    let mut pascal = Vec::with_capacity(1 + name_bytes.len());
+    pascal.push(name_bytes.len() as u8);
+    pascal.extend_from_slice(name_bytes);
+
+    println!("Setting name to {:?} (0x{:04X})...", args.name, ATTN_SET_NAME);
+    stream.send_attention(ATTN_SET_NAME, &pascal).await?;
+    timeout(Duration::from_secs(30), stream.read_exact(&mut resp))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to 0x{:04X}", ATTN_SET_NAME))??;
+    if resp != [0x00, 0x00] {
+        anyhow::bail!("unexpected response to 0x{:04X}: {:02X?}", ATTN_SET_NAME, resp);
+    }
+
+    println!("Committing (0x{:04X})...", ATTN_COMMIT);
+    stream.send_attention(ATTN_COMMIT, &[0x00]).await?;
+    timeout(Duration::from_secs(30), stream.read_exact(&mut resp))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to 0x{:04X}", ATTN_COMMIT))??;
+    if resp != [0x00, 0x00] {
+        anyhow::bail!("unexpected response to 0x{:04X}: {:02X?}", ATTN_COMMIT, resp);
+    }
+
+    stream.close().await?;
+    println!("Connection closed.");
+
+    println!("Waiting 3 s for the printer to re-register via NBP...");
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let verify_entity: EntityName = format!("{}:ColorStyleWriter2400AT@*", args.name)
+        .as_str()
+        .try_into()
+        .map_err(|e| anyhow::anyhow!("could not build verification entity: {}", e))?;
+
+    println!("Looking up '{}' to verify rename...", verify_entity);
+    let verify_tuples = timeout(Duration::from_secs(10), stack.nbp.lookup(verify_entity))
+        .await
+        .map_err(|_| anyhow::anyhow!("NBP verification lookup timed out"))?
+        .map_err(|e| anyhow::anyhow!("NBP verification lookup failed: {}", e))?;
+
+    if verify_tuples.is_empty() {
+        println!("WARNING: could not verify rename via NBP — printer may still be updating.");
+        println!("  Old name: {}", old_name);
+        println!("  New name: {} (requested)", args.name);
+    } else {
+        println!("Rename verified!");
+        for t in &verify_tuples {
+            println!("  {} — {}.{} socket {}", t.entity_name, t.network_number, t.node_id, t.socket_number);
+        }
+        println!("  {} → {}", old_name, args.name);
+    }
+
+    Ok(())
+}

--- a/tailtalk-packets/src/adsp.rs
+++ b/tailtalk-packets/src/adsp.rs
@@ -10,10 +10,17 @@ pub enum AdspError {
 }
 
 /// ADSP descriptor (packet type) codes
+///
+/// The descriptor byte is the LAST byte of the 13-byte ADSP header (per spec Figure 12-2).
+/// Bit 7 = Control flag. When clear, the packet carries stream data (DataPacket).
+/// When set, bits 3-0 encode the control code; bits 6-4 are additional flags
+/// (AckReq, EOM, Attention) stored separately in `AdspPacket::flags`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
 pub enum AdspDescriptor {
-    /// Control packet (probe, acknowledgment)
+    /// Data packet (Control bit = 0); flag bits live in `AdspPacket::flags`
+    DataPacket = 0x00,
+    /// Control packet / probe-ack (Control=1, code=0)
     ControlPacket = 0x80,
     /// Connection open request
     OpenConnRequest = 0x81,
@@ -37,7 +44,10 @@ impl TryFrom<u8> for AdspDescriptor {
     type Error = AdspError;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
+        if value & 0x80 == 0 {
+            return Ok(AdspDescriptor::DataPacket);
+        }
+        match value & 0x8F {
             0x80 => Ok(AdspDescriptor::ControlPacket),
             0x81 => Ok(AdspDescriptor::OpenConnRequest),
             0x82 => Ok(AdspDescriptor::OpenConnAck),
@@ -57,12 +67,12 @@ impl TryFrom<u8> for AdspDescriptor {
 /// ADSP (AppleTalk Data Stream Protocol) provides connection-oriented,
 /// full-duplex byte-stream communication over DDP.
 ///
-/// Packet format:
-/// - Byte 0: Descriptor (packet type)
-/// - Bytes 1-2: Connection ID (u16, big-endian)
-/// - Bytes 3-6: First Byte Sequence number (u32, big-endian)
-/// - Bytes 7-10: Next Receive Sequence number (u32, big-endian)
-/// - Bytes 11-12: Receive Window size (u16, big-endian)
+/// Packet format (per spec Figure 12-2):
+/// - Bytes 0-1:  Connection ID (u16, big-endian)
+/// - Bytes 2-5:  First Byte Sequence number (u32, big-endian)
+/// - Bytes 6-9:  Next Receive Sequence number (u32, big-endian)
+/// - Bytes 10-11: Receive Window size (u16, big-endian)
+/// - Byte 12:    Descriptor (packet type + flag bits)
 /// - Remaining bytes: Data payload (not owned by this struct)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AdspPacket {
@@ -101,12 +111,13 @@ impl AdspPacket {
             });
         }
 
-        let descriptor = AdspDescriptor::try_from(buf[0])?;
-        let connection_id = BigEndian::read_u16(&buf[1..3]);
-        let first_byte_seq = BigEndian::read_u32(&buf[3..7]);
-        let next_recv_seq = BigEndian::read_u32(&buf[7..11]);
-        let recv_window = BigEndian::read_u16(&buf[11..13]);
-        let flags = buf[0] & 0xF0; // Top 4 bits are flags on ControlPacket/Ack/etc but we'll store the whole byte since descriptor is just 0x8x
+        let connection_id = BigEndian::read_u16(&buf[0..2]);
+        let first_byte_seq = BigEndian::read_u32(&buf[2..6]);
+        let next_recv_seq = BigEndian::read_u32(&buf[6..10]);
+        let recv_window = BigEndian::read_u16(&buf[10..12]);
+        let desc_byte = buf[12];
+        let descriptor = AdspDescriptor::try_from(desc_byte)?;
+        let flags = desc_byte & 0xF0;
 
         Ok(Self {
             descriptor,
@@ -130,12 +141,11 @@ impl AdspPacket {
             });
         }
 
-        // The descriptor byte effectively contains both the control flags and the descriptor code
-        buf[0] = (self.descriptor as u8) | self.flags;
-        BigEndian::write_u16(&mut buf[1..3], self.connection_id);
-        BigEndian::write_u32(&mut buf[3..7], self.first_byte_seq);
-        BigEndian::write_u32(&mut buf[7..11], self.next_recv_seq);
-        BigEndian::write_u16(&mut buf[11..13], self.recv_window);
+        BigEndian::write_u16(&mut buf[0..2], self.connection_id);
+        BigEndian::write_u32(&mut buf[2..6], self.first_byte_seq);
+        BigEndian::write_u32(&mut buf[6..10], self.next_recv_seq);
+        BigEndian::write_u16(&mut buf[10..12], self.recv_window);
+        buf[12] = (self.descriptor as u8) | self.flags;
 
         Ok(Self::HEADER_LEN)
     }
@@ -198,10 +208,12 @@ mod tests {
 
     #[test]
     fn test_parse_open_conn_request() {
-        // OpenConnRequest: descriptor=0x81, conn_id=0x1234,
-        // first_byte_seq=0, next_recv_seq=0, recv_window=4096
         let data: &[u8] = &[
-            0x81, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00,
+            0x12, 0x34, // conn_id
+            0x00, 0x00, 0x00, 0x00, // first_byte_seq
+            0x00, 0x00, 0x00, 0x00, // next_recv_seq
+            0x10, 0x00, // recv_window = 4096
+            0x81,       // descriptor = OpenConnRequest
         ];
 
         let packet = AdspPacket::parse(data).expect("failed to parse");
@@ -215,9 +227,12 @@ mod tests {
 
     #[test]
     fn test_parse_control_packet() {
-        // ControlPacket with sequence numbers and window
         let data: &[u8] = &[
-            0x80, 0xAB, 0xCD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x20, 0x00,
+            0xAB, 0xCD, // conn_id
+            0x00, 0x01, 0x00, 0x00, // first_byte_seq
+            0x00, 0x02, 0x00, 0x00, // next_recv_seq
+            0x20, 0x00, // recv_window = 8192
+            0x80,       // descriptor = ControlPacket
         ];
 
         let packet = AdspPacket::parse(data).expect("failed to parse");
@@ -231,9 +246,12 @@ mod tests {
 
     #[test]
     fn test_parse_acknowledgment() {
-        // Acknowledgment packet
         let data: &[u8] = &[
-            0x88, 0x00, 0x42, 0x00, 0x00, 0x03, 0xE8, 0x00, 0x00, 0x07, 0xD0, 0x08, 0x00,
+            0x00, 0x42, // conn_id
+            0x00, 0x00, 0x03, 0xE8, // first_byte_seq = 1000
+            0x00, 0x00, 0x07, 0xD0, // next_recv_seq = 2000
+            0x08, 0x00, // recv_window = 2048
+            0x88,       // descriptor = Acknowledgment
         ];
 
         let packet = AdspPacket::parse(data).expect("failed to parse");
@@ -243,6 +261,36 @@ mod tests {
         assert_eq!(packet.first_byte_seq, 1000);
         assert_eq!(packet.next_recv_seq, 2000);
         assert_eq!(packet.recv_window, 2048);
+    }
+
+    #[test]
+    fn test_parse_data_packet() {
+        let data: &[u8] = &[
+            0x00, 0x0A, // conn_id = 10
+            0x00, 0x00, 0x00, 0x00, // first_byte_seq
+            0x00, 0x00, 0x00, 0x00, // next_recv_seq
+            0x06, 0xB4, // recv_window = 1716
+            0x40,       // descriptor = DataPacket (AckReq flag)
+        ];
+        let packet = AdspPacket::parse(data).expect("failed to parse");
+        assert_eq!(packet.descriptor, AdspDescriptor::DataPacket);
+        assert_eq!(packet.connection_id, 0x000A);
+        assert_eq!(packet.flags & AdspPacket::FLAG_ACK, AdspPacket::FLAG_ACK);
+        assert_eq!(packet.flags & AdspPacket::FLAG_ATTENTION, 0);
+    }
+
+    #[test]
+    fn test_parse_attention_ack() {
+        let data: &[u8] = &[
+            0x00, 0x0A, // conn_id
+            0x00, 0x00, 0x00, 0x00, // first_byte_seq
+            0x00, 0x00, 0x00, 0x01, // next_recv_seq
+            0x00, 0x00, // recv_window
+            0x90,       // Control=1, Attention=1, code=0
+        ];
+        let packet = AdspPacket::parse(data).expect("failed to parse");
+        assert_eq!(packet.descriptor, AdspDescriptor::ControlPacket);
+        assert_ne!(packet.flags & AdspPacket::FLAG_ATTENTION, 0);
     }
 
     #[test]
@@ -257,7 +305,11 @@ mod tests {
         };
 
         let expected: &[u8] = &[
-            0x82, 0x56, 0x78, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00,
+            0x56, 0x78, // conn_id
+            0x00, 0x00, 0x00, 0x00, // first_byte_seq
+            0x00, 0x00, 0x00, 0x00, // next_recv_seq
+            0x20, 0x00, // recv_window = 8192
+            0x82,       // descriptor = OpenConnAck
         ];
 
         let mut buf = [0u8; 13];
@@ -282,11 +334,11 @@ mod tests {
         let len = packet.to_bytes(&mut buf).expect("failed to encode");
 
         assert_eq!(len, AdspPacket::HEADER_LEN);
-        assert_eq!(buf[0], 0x85); // CloseAdvice
-        assert_eq!(BigEndian::read_u16(&buf[1..3]), 0x9999);
-        assert_eq!(BigEndian::read_u32(&buf[3..7]), 1234567);
-        assert_eq!(BigEndian::read_u32(&buf[7..11]), 7654321);
-        assert_eq!(BigEndian::read_u16(&buf[11..13]), 0);
+        assert_eq!(BigEndian::read_u16(&buf[0..2]), 0x9999);
+        assert_eq!(BigEndian::read_u32(&buf[2..6]), 1234567);
+        assert_eq!(BigEndian::read_u32(&buf[6..10]), 7654321);
+        assert_eq!(BigEndian::read_u16(&buf[10..12]), 0);
+        assert_eq!(buf[12], 0x85);
     }
 
     #[test]
@@ -297,7 +349,7 @@ mod tests {
             first_byte_seq: 0xDEADBEEF,
             next_recv_seq: 0xCAFEBABE,
             recv_window: 0xFFFF,
-            flags: 0x80, // Descriptor is 0x86, so when parsed the top nibble (0x80) is saved as flags
+            flags: 0x80,
         };
 
         let mut buf = [0u8; 13];
@@ -310,9 +362,8 @@ mod tests {
 
     #[test]
     fn test_invalid_descriptor() {
-        // Invalid descriptor code 0x99
         let data: &[u8] = &[
-            0x99, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x99,
         ];
 
         let result = AdspPacket::parse(data);
@@ -363,9 +414,12 @@ mod tests {
 
     #[test]
     fn test_parse_with_data_payload() {
-        // ADSP header followed by data payload
         let data: &[u8] = &[
-            0x80, 0x11, 0x22, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x10, 0x00,
+            0x11, 0x22, // conn_id
+            0x00, 0x00, 0x00, 0x01, // first_byte_seq
+            0x00, 0x00, 0x00, 0x02, // next_recv_seq
+            0x10, 0x00, // recv_window = 4096
+            0x80,       // descriptor = ControlPacket
             // Data payload follows:
             b'H', b'e', b'l', b'l', b'o',
         ];

--- a/tailtalk/src/adsp.rs
+++ b/tailtalk/src/adsp.rs
@@ -41,6 +41,9 @@ enum ConnectionState {
 }
 
 struct AdspConnection {
+    /// Our own ConnID — placed in every outgoing packet's connection_id field.
+    /// The HashMap key is the peer's ConnID (what arrives in inbound packets).
+    our_conn_id: u16,
     state: ConnectionState,
     remote_addr: AdspAddress,
     send_seq: u32,
@@ -51,6 +54,8 @@ struct AdspConnection {
     flight_buffer: Vec<u8>,
     last_tx: std::time::Instant,
     retries: u8,
+    /// Sequence number of the next attention message to send.
+    attn_send_seq: u32,
     /// Delivers received data to the AdspStream reader.
     data_tx: mpsc::Sender<Vec<u8>>,
 }
@@ -66,6 +71,12 @@ enum ActorCmd {
         conn_id: u16,
         data: Vec<u8>,
         eom: bool,
+        reply: oneshot::Sender<io::Result<()>>,
+    },
+    SendAttention {
+        conn_id: u16,
+        code: u16,
+        data: Vec<u8>,
         reply: oneshot::Sender<io::Result<()>>,
     },
     Close {
@@ -153,15 +164,19 @@ impl Adsp {
         }
     }
 
-    /// Register a new open connection and return the user-facing stream.
+    // Connections are always keyed by the peer's ConnID: that is the value carried in the
+    // connection_id field of every inbound packet, so it is what we must dispatch on.
+    // `our_conn_id` (placed in every outbound packet) is stored separately per connection.
     fn open_connection(
         &mut self,
-        conn_id: u16,
+        map_key: u16,
+        our_conn_id: u16,
         remote_addr: AdspAddress,
         peer_window: u16,
     ) -> AdspStream {
         let (data_tx, data_rx) = mpsc::channel(32);
-        self.connections.insert(conn_id, AdspConnection {
+        self.connections.insert(map_key, AdspConnection {
+            our_conn_id,
             state: ConnectionState::Open,
             remote_addr,
             send_seq: 0,
@@ -171,9 +186,10 @@ impl Adsp {
             flight_buffer: Vec::new(),
             last_tx: std::time::Instant::now(),
             retries: 0,
+            attn_send_seq: 0,
             data_tx,
         });
-        self.make_stream(conn_id, remote_addr, data_rx)
+        self.make_stream(map_key, remote_addr, data_rx)
     }
 
     // ── Event loop ────────────────────────────────────────────────────────────
@@ -212,6 +228,10 @@ impl Adsp {
                 let result = self.send_data(conn_id, &data, eom).await;
                 let _ = reply.send(result);
             }
+            ActorCmd::SendAttention { conn_id, code, data, reply } => {
+                let result = self.send_attention_msg(conn_id, code, &data).await;
+                let _ = reply.send(result);
+            }
             ActorCmd::Close { conn_id, reply } => {
                 let result = self.close_connection(conn_id).await;
                 let _ = reply.send(result);
@@ -227,10 +247,7 @@ impl Adsp {
 
         let conn_ids: Vec<u16> = self.connections.keys().copied().collect();
         for conn_id in conn_ids {
-            let conn = match self.connections.get_mut(&conn_id) {
-                Some(c) => c,
-                None => continue,
-            };
+            let Some(conn) = self.connections.get_mut(&conn_id) else { continue };
 
             if conn.flight_buffer.is_empty()
                 || now.duration_since(conn.last_tx) <= timeout
@@ -255,16 +272,17 @@ impl Adsp {
             let remote_addr = conn.remote_addr;
             let oldest_seq = conn.oldest_unacked_seq;
             let recv_seq = conn.recv_seq;
+            let our_conn_id = conn.our_conn_id;
 
             for (i, chunk) in data.chunks(ADSP_MAX_DATA).enumerate() {
                 let chunk_seq = oldest_seq.wrapping_add((i * ADSP_MAX_DATA) as u32);
                 let pkt = AdspPacket {
-                    descriptor: AdspDescriptor::ControlPacket,
-                    connection_id: conn_id,
+                    descriptor: AdspDescriptor::DataPacket,
+                    connection_id: our_conn_id,
                     first_byte_seq: chunk_seq,
                     next_recv_seq: recv_seq,
                     recv_window: ADSP_RECV_WINDOW,
-                    flags: 0,
+                    flags: AdspPacket::FLAG_ACK,
                 };
                 let mut buf = vec![0u8; AdspPacket::HEADER_LEN + chunk.len()];
                 if pkt.to_bytes(&mut buf).is_ok() {
@@ -312,9 +330,10 @@ impl Adsp {
                 self.handle_open_request(ddp, packet).await;
             }
             AdspDescriptor::OpenConnAck | AdspDescriptor::OpenConnReqAck => {
-                self.handle_open_ack(ddp, packet).await;
+                self.handle_open_ack(ddp, packet, payload).await;
             }
-            AdspDescriptor::ControlPacket => {
+            // DataPacket (bit7=0): data from peer. ControlPacket (0x80): probe/ack, may carry data.
+            AdspDescriptor::DataPacket | AdspDescriptor::ControlPacket => {
                 self.handle_data(packet, &payload[AdspPacket::HEADER_LEN..]).await;
             }
             AdspDescriptor::Acknowledgment => {
@@ -344,14 +363,16 @@ impl Adsp {
         let remote_addr = conn.remote_addr;
         let send_seq = conn.send_seq;
         let recv_seq = conn.recv_seq;
+        let our_conn_id = conn.our_conn_id;
 
+        // Attention ack: descriptor 0x90 = ControlPacket(0x80) | Attention(0x10).
         let ack = AdspPacket {
             descriptor: AdspDescriptor::ControlPacket,
-            connection_id: packet.connection_id,
+            connection_id: our_conn_id,
             first_byte_seq: send_seq,
             next_recv_seq: recv_seq,
-            recv_window: ADSP_RECV_WINDOW,
-            flags: AdspPacket::FLAG_ATTENTION | AdspPacket::FLAG_ACK,
+            recv_window: 0,
+            flags: AdspPacket::FLAG_ATTENTION,
         };
         let mut buf = vec![0u8; AdspPacket::HEADER_LEN + 2];
         if ack.to_bytes(&mut buf).is_ok() {
@@ -368,27 +389,31 @@ impl Adsp {
         ddp: tailtalk_packets::ddp::DdpPacket,
         packet: AdspPacket,
     ) {
-        let conn_id = packet.connection_id;
+        let client_conn_id = packet.connection_id;
+        let our_conn_id: u16 = rand::random();
         let remote_addr = AdspAddress {
             network_number: ddp.src_network_num,
             node_number: ddp.src_node_id,
             socket_number: ddp.src_sock_num,
         };
 
-        tracing::info!("ADSP accepting conn {} from {:?}", conn_id, remote_addr);
+        tracing::info!("ADSP accepting conn {} from {:?}", client_conn_id, remote_addr);
 
-        let stream = self.open_connection(conn_id, remote_addr, packet.recv_window);
+        let stream = self.open_connection(client_conn_id, our_conn_id, remote_addr, packet.recv_window);
 
+        // OpenConnReqAck carries 8-byte open-conn params (spec §12, Figure 12-11).
         let ack = AdspPacket {
-            descriptor: AdspDescriptor::OpenConnAck,
-            connection_id: conn_id,
+            descriptor: AdspDescriptor::OpenConnReqAck,
+            connection_id: our_conn_id,
             first_byte_seq: 0,
             next_recv_seq: 0,
             recv_window: ADSP_RECV_WINDOW,
             flags: 0,
         };
-        let mut buf = [0u8; AdspPacket::HEADER_LEN];
+        let mut buf = [0u8; AdspPacket::HEADER_LEN + 8];
         if ack.to_bytes(&mut buf).is_ok() {
+            byteorder::BigEndian::write_u16(&mut buf[AdspPacket::HEADER_LEN..], 0x0100);
+            byteorder::BigEndian::write_u16(&mut buf[AdspPacket::HEADER_LEN + 2..], client_conn_id);
             let _ = self.sock.send_to(&buf, ddp_dest(remote_addr)).await;
         }
 
@@ -401,9 +426,18 @@ impl Adsp {
         &mut self,
         ddp: tailtalk_packets::ddp::DdpPacket,
         packet: AdspPacket,
+        payload: &[u8],
     ) {
-        let conn_id = packet.connection_id;
-        let Some(ready_tx) = self.pending_opens.remove(&conn_id) else { return };
+        // Our ConnID echoed back in the open-conn params at payload[15..17]
+        // (DestConnID field, bytes 2-3 of the 8-byte block following the header).
+        let server_conn_id = packet.connection_id;
+        let our_conn_id = if payload.len() >= 17 {
+            u16::from_be_bytes([payload[15], payload[16]])
+        } else {
+            server_conn_id
+        };
+
+        let Some(ready_tx) = self.pending_opens.remove(&our_conn_id) else { return };
 
         let remote_addr = AdspAddress {
             network_number: ddp.src_network_num,
@@ -411,9 +445,30 @@ impl Adsp {
             socket_number: ddp.src_sock_num,
         };
 
-        tracing::info!("ADSP conn {} established to {:?}", conn_id, remote_addr);
+        tracing::info!(
+            "ADSP conn established: our={} server={} remote={:?}",
+            our_conn_id, server_conn_id, remote_addr
+        );
 
-        let stream = self.open_connection(conn_id, remote_addr, packet.recv_window);
+        let stream = self.open_connection(server_conn_id, our_conn_id, remote_addr, packet.recv_window);
+
+        // OpenConnAck completes the 3-way handshake; carries 8-byte open-conn params
+        // like the other two handshake packets (spec §12, Figure 12-11).
+        let ack = AdspPacket {
+            descriptor: AdspDescriptor::OpenConnAck,
+            connection_id: our_conn_id,
+            first_byte_seq: 0,
+            next_recv_seq: 0,
+            recv_window: ADSP_RECV_WINDOW,
+            flags: 0,
+        };
+        let mut buf = [0u8; AdspPacket::HEADER_LEN + 8];
+        if ack.to_bytes(&mut buf).is_ok() {
+            byteorder::BigEndian::write_u16(&mut buf[AdspPacket::HEADER_LEN..], 0x0100);
+            byteorder::BigEndian::write_u16(&mut buf[AdspPacket::HEADER_LEN + 2..], server_conn_id);
+            let _ = self.sock.send_to(&buf, ddp_dest(remote_addr)).await;
+        }
+
         let _ = ready_tx.send(Ok(stream));
     }
 
@@ -463,8 +518,11 @@ impl Adsp {
             recv_window: ADSP_RECV_WINDOW,
             flags: 0,
         };
-        let mut buf = [0u8; AdspPacket::HEADER_LEN];
+        // Header + 8-byte open-conn params (spec §12, Figure 12-11).
+        // DestConnID is 0 — we don't know the server's ConnID yet.
+        let mut buf = [0u8; AdspPacket::HEADER_LEN + 8];
         if pkt.to_bytes(&mut buf).is_ok() {
+            byteorder::BigEndian::write_u16(&mut buf[AdspPacket::HEADER_LEN..], 0x0100);
             let _ = self.sock.send_to(&buf, ddp_dest(remote_addr)).await;
         }
     }
@@ -484,15 +542,15 @@ impl Adsp {
             return Err(io::Error::new(io::ErrorKind::NotConnected, "connection closing"));
         }
 
-        // Empty EOM flush (just a control packet with EOM set, no data).
+        // Empty EOM flush (data packet with EOM set, no payload bytes).
         if data.is_empty() && eom {
             let pkt = AdspPacket {
-                descriptor: AdspDescriptor::ControlPacket,
-                connection_id: conn_id,
+                descriptor: AdspDescriptor::DataPacket,
+                connection_id: conn.our_conn_id,
                 first_byte_seq: conn.send_seq,
                 next_recv_seq: conn.recv_seq,
                 recv_window: ADSP_RECV_WINDOW,
-                flags: AdspPacket::FLAG_EOM,
+                flags: AdspPacket::FLAG_ACK | AdspPacket::FLAG_EOM,
             };
             let mut buf = [0u8; AdspPacket::HEADER_LEN];
             pkt.to_bytes(&mut buf)
@@ -504,19 +562,18 @@ impl Adsp {
                 .map_err(io::Error::other);
         }
 
-        let chunks: Vec<&[u8]> = data.chunks(ADSP_MAX_DATA).collect();
-        let last_idx = chunks.len().saturating_sub(1);
+        let last_idx = data.chunks(ADSP_MAX_DATA).count().saturating_sub(1);
 
-        for (i, chunk) in chunks.iter().enumerate() {
-            let flags = if eom && i == last_idx { AdspPacket::FLAG_EOM } else { 0 };
+        for (i, chunk) in data.chunks(ADSP_MAX_DATA).enumerate() {
+            let eom_flag = if eom && i == last_idx { AdspPacket::FLAG_EOM } else { 0 };
 
             let pkt = AdspPacket {
-                descriptor: AdspDescriptor::ControlPacket,
-                connection_id: conn_id,
+                descriptor: AdspDescriptor::DataPacket,
+                connection_id: conn.our_conn_id,
                 first_byte_seq: conn.send_seq,
                 next_recv_seq: conn.recv_seq,
                 recv_window: ADSP_RECV_WINDOW,
-                flags,
+                flags: AdspPacket::FLAG_ACK | eom_flag,
             };
 
             let mut buf = vec![0u8; AdspPacket::HEADER_LEN + chunk.len()];
@@ -545,7 +602,7 @@ impl Adsp {
 
         let pkt = AdspPacket {
             descriptor: AdspDescriptor::Acknowledgment,
-            connection_id: conn_id,
+            connection_id: conn.our_conn_id,
             first_byte_seq: conn.send_seq,
             next_recv_seq: conn.recv_seq,
             recv_window: ADSP_RECV_WINDOW,
@@ -562,6 +619,37 @@ impl Adsp {
             .map_err(io::Error::other)
     }
 
+    async fn send_attention_msg(&mut self, conn_id: u16, code: u16, data: &[u8]) -> io::Result<()> {
+        let (remote_addr, attn_send_seq, recv_seq, our_conn_id) = {
+            let conn = self.connections.get_mut(&conn_id).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotConnected, "no such connection")
+            })?;
+            let seq = conn.attn_send_seq;
+            conn.attn_send_seq = conn.attn_send_seq.wrapping_add(1);
+            (conn.remote_addr, seq, conn.recv_seq, conn.our_conn_id)
+        };
+
+        // Attention packet (spec §12, Figure 12-7): desc byte 0x50.
+        let mut buf = vec![0u8; AdspPacket::HEADER_LEN + 2 + data.len()];
+        let pkt = AdspPacket {
+            descriptor: AdspDescriptor::DataPacket,
+            connection_id: our_conn_id,
+            first_byte_seq: attn_send_seq,
+            next_recv_seq: recv_seq,
+            recv_window: 0, // must be 0 for attention per spec
+            flags: AdspPacket::FLAG_ACK | AdspPacket::FLAG_ATTENTION,
+        };
+        pkt.to_bytes(&mut buf)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        byteorder::BigEndian::write_u16(&mut buf[AdspPacket::HEADER_LEN..], code);
+        buf[AdspPacket::HEADER_LEN + 2..].copy_from_slice(data);
+
+        self.sock
+            .send_to(&buf, ddp_dest(remote_addr))
+            .await
+            .map_err(io::Error::other)
+    }
+
     async fn close_connection(&mut self, conn_id: u16) -> io::Result<()> {
         let Some(conn) = self.connections.get(&conn_id) else {
             return Ok(()); // already gone
@@ -569,7 +657,7 @@ impl Adsp {
 
         let pkt = AdspPacket {
             descriptor: AdspDescriptor::CloseAdvice,
-            connection_id: conn_id,
+            connection_id: conn.our_conn_id,
             first_byte_seq: conn.send_seq,
             next_recv_seq: conn.recv_seq,
             recv_window: 0,
@@ -611,6 +699,26 @@ pub struct AdspStream {
 impl AdspStream {
     pub fn remote_addr(&self) -> AdspAddress {
         self.remote_addr
+    }
+
+    /// Send an ADSP attention message with the given 16-bit code and payload.
+    ///
+    /// Attention messages are out-of-band from the normal data stream; they
+    /// are delivered to the peer using a separate sequence number space and
+    /// a dedicated descriptor (Control=0, AckReq=1, Attn=1).
+    pub async fn send_attention(&mut self, code: u16, data: &[u8]) -> io::Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.cmd_tx
+            .send(ActorCmd::SendAttention {
+                conn_id: self.conn_id,
+                code,
+                data: data.to_vec(),
+                reply: tx,
+            })
+            .await
+            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "adsp actor dead"))?;
+        rx.await
+            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "adsp actor dead"))?
     }
 
     /// Flush the write buffer and mark the message boundary with the EOM flag.

--- a/tailtalk/tests/adsp_test.rs
+++ b/tailtalk/tests/adsp_test.rs
@@ -5,10 +5,11 @@ use tailtalk::{
     DataLinkPacket, OutboundHandle,
     addressing::Addressing,
     adsp::{Adsp, AdspAddress},
-    ddp::DdpProcessor,
+    ddp::{DdpAddress, DdpProcessor},
     route_table::{LearningMode, RouteTable},
 };
-use tailtalk_packets::aarp::AddressSource;
+use tailtalk_packets::aarp::{AddressSource, AppleTalkAddress};
+use tailtalk_packets::ddp::DdpProtocolType;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{broadcast, mpsc};
 
@@ -229,4 +230,307 @@ async fn test_adsp_connection() {
     stream_b.close().await.expect("failed to close stream B");
 
     hub_task.abort();
+}
+
+// ── StyleWriter name-change session test ──────────────────────────────────────
+//
+// Replicates a session captured from a PowerBook G3 connecting to a StyleWriter
+// 2200 over ADSP and issuing three attention-message commands to rename the
+// adapter.  The raw "server" side below speaks correct ADSP per the spec
+// (§12, Figure 12-2: ConnID first, descriptor last); the client side uses
+// only the high-level AdspStream API.
+
+// ── Raw server helpers (spec byte order) ─────────────────────────────────────
+
+fn adsp_addr(net: u16, node: u8, sock: u8) -> DdpAddress {
+    DdpAddress::new(AppleTalkAddress { network_number: net, node_number: node }, sock)
+}
+
+/// Parse a 13-byte ADSP header per spec (ConnID first, descriptor last).
+/// Returns (conn_id, first_byte_seq, next_recv_seq, recv_window, descriptor).
+fn parse_adsp_hdr(buf: &[u8]) -> (u16, u32, u32, u16, u8) {
+    let conn_id  = u16::from_be_bytes([buf[0], buf[1]]);
+    let first    = u32::from_be_bytes([buf[2], buf[3], buf[4], buf[5]]);
+    let next     = u32::from_be_bytes([buf[6], buf[7], buf[8], buf[9]]);
+    let window   = u16::from_be_bytes([buf[10], buf[11]]);
+    let desc     = buf[12];
+    (conn_id, first, next, window, desc)
+}
+
+/// Build a 13-byte ADSP header per spec.
+fn build_adsp_hdr(conn_id: u16, first: u32, next: u32, window: u16, desc: u8) -> [u8; 13] {
+    let mut b = [0u8; 13];
+    b[0..2].copy_from_slice(&conn_id.to_be_bytes());
+    b[2..6].copy_from_slice(&first.to_be_bytes());
+    b[6..10].copy_from_slice(&next.to_be_bytes());
+    b[10..12].copy_from_slice(&window.to_be_bytes());
+    b[12] = desc;
+    b
+}
+
+// ── Raw StyleWriter server ────────────────────────────────────────────────────
+
+const SW_CONN_ID:  u16 = 0x000a; // server ConnID from capture
+const SW_WINDOW:   u16 = 0x06b4; // server receive window from capture
+const ADSP_VER:    u16 = 0x0100; // ADSP version 1.0
+
+/// Server-side state extracted from the OpenConnRequest.
+struct ClientInfo {
+    net:  u16,
+    node: u8,
+    sock: u8,
+    conn_id: u16,
+}
+
+async fn recv_until(
+    sock: &mut tailtalk::ddp::DdpSocket,
+    want_desc: u8,
+) -> (ClientInfo, Vec<u8>) {
+    loop {
+        let pkt = tokio::time::timeout(Duration::from_secs(5), sock.recv())
+            .await
+            .expect("server recv timed out")
+            .expect("server recv error");
+
+        let payload = pkt.payload.to_vec();
+        if payload.len() < 13 {
+            continue;
+        }
+        let (conn_id, _, _, _, desc) = parse_adsp_hdr(&payload);
+        if desc == want_desc {
+            return (
+                ClientInfo {
+                    net:  pkt.headers.src_network_num,
+                    node: pkt.headers.src_node_id,
+                    sock: pkt.headers.src_sock_num,
+                    conn_id,
+                },
+                payload,
+            );
+        }
+    }
+}
+
+async fn stylewriter_server(mut sock: tailtalk::ddp::DdpSocket) {
+    // ── Handshake ──────────────────────────────────────────────────────────
+
+    let (client, req_payload) = recv_until(&mut sock, 0x81).await;
+
+    // Open-conn params follow the 13-byte header (spec §12, Figure 12-11):
+    // version(2) | DestConnID(2) | PktAttnRecvSeq(4).
+    // DestConnID is 0x0000 in the request — client doesn't know our ConnID yet.
+    assert!(
+        req_payload.len() >= 21,
+        "OpenConnRequest must carry 8-byte open-conn params (got {} bytes)",
+        req_payload.len()
+    );
+    let req_ver   = u16::from_be_bytes([req_payload[13], req_payload[14]]);
+    let req_dcid  = u16::from_be_bytes([req_payload[15], req_payload[16]]);
+    assert_eq!(req_ver,  ADSP_VER, "OpenConnRequest version mismatch");
+    assert_eq!(req_dcid, 0x0000,   "OpenConnRequest DestConnID must be 0");
+
+    let mut resp = vec![0u8; 13 + 8];
+    resp[..13].copy_from_slice(&build_adsp_hdr(SW_CONN_ID, 0, 0, SW_WINDOW, 0x83));
+    resp[13..15].copy_from_slice(&ADSP_VER.to_be_bytes());
+    resp[15..17].copy_from_slice(&client.conn_id.to_be_bytes());
+    sock.send_to(&resp, adsp_addr(client.net, client.node, client.sock))
+        .await
+        .expect("send OpenConnReqAck failed");
+
+    // All three handshake packets carry 8-byte open-conn params (spec §12, Figure 12-11).
+    // The real StyleWriter validates the params before completing the handshake.
+    let (_, ack_payload) = recv_until(&mut sock, 0x82).await;
+    assert!(
+        ack_payload.len() >= 21,
+        "OpenConnAck must carry 8-byte open-conn params (got {} bytes)",
+        ack_payload.len()
+    );
+    let ack_ver  = u16::from_be_bytes([ack_payload[13], ack_payload[14]]);
+    let ack_dcid = u16::from_be_bytes([ack_payload[15], ack_payload[16]]);
+    assert_eq!(ack_ver,  ADSP_VER,   "OpenConnAck open-conn version mismatch");
+    assert_eq!(ack_dcid, SW_CONN_ID, "OpenConnAck DestConnID must match server ConnID");
+
+    // ── Three attention-message rounds ─────────────────────────────────────
+    //
+    // Each round: client sends an attention packet (desc=0x50), server replies
+    // with an attention ack (desc=0x90) and a 2-byte [0x00, 0x00] data packet.
+    //
+    // Invariants verified per attention packet (from the captured session):
+    //   - connection_id == client.conn_id  (client's own ConnID, not the server's)
+    //   - first_byte_seq == round index    (attention sequence: 0, 1, 2)
+    //   - recv_window == 0                 (spec §12 requires zero in attention packets)
+
+    let expected_attention_codes: &[u16] = &[0x0011, 0x0009, 0x0012];
+
+    let expected_attn_data: &[&[u8]] = &[
+        &[0x00],
+        b"\x16Color StyleWriter 2200",
+        &[0x00],
+    ];
+
+    let mut attn_recv_seq: u32 = 0; // server's AttnRecvSeq: next attention seq expected
+    let mut data_send_seq: u32 = 0; // server's data SendSeq: bytes sent so far
+
+    for i in 0..3 {
+        // Receive attention from client (descriptor = 0x50)
+        let (_, attn_payload) = recv_until(&mut sock, 0x50).await;
+
+        assert!(
+            attn_payload.len() >= 15,
+            "attention {} payload too short: {} bytes",
+            i, attn_payload.len()
+        );
+        let (pkt_conn_id, pkt_first, _, pkt_window, _) = parse_adsp_hdr(&attn_payload);
+
+        // Outgoing packets must carry the CLIENT's own ConnID (from its OpenConnRequest),
+        // not the server's ConnID.  This is the invariant broken by the our_conn_id bug.
+        assert_eq!(
+            pkt_conn_id, client.conn_id,
+            "attention {} connID 0x{:04x} != client connID 0x{:04x} \
+             (client must use its own ConnID in outgoing packets, not the server's)",
+            i, pkt_conn_id, client.conn_id
+        );
+
+        // Attention packets use a separate sequence number that starts at 0
+        // and increments by 1 per attention message (pcap: F04=0, F08=1, F12=2).
+        assert_eq!(
+            pkt_first, i as u32,
+            "attention {} first_byte_seq={} want {} (attn seq must increment per message)",
+            i, pkt_first, i
+        );
+
+        // Per spec §12, recv_window must be 0 in attention packets.
+        assert_eq!(
+            pkt_window, 0,
+            "attention {} recv_window={} want 0 (spec §12 requires zero in attention packets)",
+            i, pkt_window
+        );
+
+        // ── Validate attention code and payload ───────────────────────────
+        let code = u16::from_be_bytes([attn_payload[13], attn_payload[14]]);
+        assert_eq!(
+            code, expected_attention_codes[i],
+            "attention {} wrong code: got 0x{:04x}, want 0x{:04x}",
+            i, code, expected_attention_codes[i]
+        );
+        let attn_data = &attn_payload[15..];
+        assert_eq!(
+            attn_data, expected_attn_data[i],
+            "attention {} wrong data",
+            i
+        );
+
+        attn_recv_seq += 1;
+
+        let ack_hdr = build_adsp_hdr(SW_CONN_ID, 0, attn_recv_seq, 0, 0x90);
+        sock.send_to(&ack_hdr, adsp_addr(client.net, client.node, client.sock))
+            .await
+            .expect("send attn ack failed");
+
+        let mut data_pkt = [0u8; 15];
+        data_pkt[..13].copy_from_slice(&build_adsp_hdr(
+            SW_CONN_ID, data_send_seq, 0, SW_WINDOW, 0x40,
+        ));
+        // bytes [13..15] = 0x00 0x00 (already zeroed)
+        sock.send_to(&data_pkt, adsp_addr(client.net, client.node, client.sock))
+            .await
+            .expect("send data response failed");
+
+        data_send_seq += 2;
+    }
+
+    recv_until(&mut sock, 0x85).await;
+}
+
+// ── Test ──────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_adsp_stylewriter_name_change() {
+    let _ = tracing_subscriber::fmt().try_init();
+
+    // Network hub
+    let hub = TestHub::new();
+    let (hub_in_tx, hub_in_rx) = mpsc::channel(100);
+    let hub_ref = Arc::new(hub);
+    let hub_clone = hub_ref.clone();
+    tokio::spawn(async move { hub_clone.run(hub_in_rx).await });
+
+    // Two nodes on the simulated network
+    let mac_server = [0x00, 0x00, 0xC5, 0x1C, 0x1F, 0x8A]; // StyleWriter MAC
+    let mac_client = [0x00, 0x05, 0x02, 0x7C, 0x85, 0x93]; // PowerBook MAC
+
+    let server_node = TestClient::new(mac_server, hub_in_tx.clone(), hub_ref.subscribe()).await;
+    let client_node = TestClient::new(mac_client, hub_in_tx.clone(), hub_ref.subscribe()).await;
+
+    // Allow AARP to assign node addresses
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    let server_at_addr = server_node.addressing.addr().await.expect("server addr");
+
+    // Bind a raw DDP socket on the well-known StyleWriter ADSP socket (129)
+    let server_sock = server_node
+        .ddp
+        .new_sock(DdpProtocolType::Adsp, Some(129))
+        .await
+        .expect("bind server socket");
+
+    // Run the raw StyleWriter server in the background
+    let server_task = tokio::spawn(stylewriter_server(server_sock));
+
+    let remote = AdspAddress {
+        network_number: server_at_addr.network_number,
+        node_number:    server_at_addr.node_number,
+        socket_number:  129,
+    };
+
+    let mut stream = tokio::time::timeout(
+        Duration::from_secs(5),
+        Adsp::connect(&client_node.ddp, remote),
+    )
+    .await
+    .expect("connect timed out — ADSP header byte order is likely wrong")
+    .expect("connect returned error");
+
+    stream
+        .send_attention(0x0011, &[0x00])
+        .await
+        .expect("send_attention 0x0011 failed");
+
+    let mut resp = [0u8; 2];
+    tokio::time::timeout(Duration::from_secs(5), stream.read_exact(&mut resp))
+        .await
+        .expect("read timed out after attention 0x0011")
+        .expect("read error after attention 0x0011");
+    assert_eq!(resp, [0x00, 0x00], "unexpected response to attention 0x0011");
+
+    stream
+        .send_attention(0x0009, b"\x16Color StyleWriter 2200")
+        .await
+        .expect("send_attention 0x0009 failed");
+
+    tokio::time::timeout(Duration::from_secs(5), stream.read_exact(&mut resp))
+        .await
+        .expect("read timed out after attention 0x0009")
+        .expect("read error after attention 0x0009");
+    assert_eq!(resp, [0x00, 0x00], "unexpected response to attention 0x0009");
+
+    stream
+        .send_attention(0x0012, &[0x00])
+        .await
+        .expect("send_attention 0x0012 failed");
+
+    tokio::time::timeout(Duration::from_secs(5), stream.read_exact(&mut resp))
+        .await
+        .expect("read timed out after attention 0x0012")
+        .expect("read error after attention 0x0012");
+    assert_eq!(resp, [0x00, 0x00], "unexpected response to attention 0x0012");
+
+    // Close the connection (sends CloseAdvice per spec §12)
+    stream.close().await.expect("close failed");
+
+    // Wait for the server to finish cleanly
+    tokio::time::timeout(Duration::from_secs(5), server_task)
+        .await
+        .expect("server task timed out")
+        .expect("server task panicked");
 }


### PR DESCRIPTION
The ADSP code was.. rather wrong to say the least. I could find very few real examples of this unfortunately but now with a working PowerBook G3 and a StyleWriter EtherTalk adapter I was able to capture a working ADSP session to start validating our code against. This specific session was renaming the adapter and used ADSP attention messages which we just flat out did not support.

This change now fixes a number of incorrect assumptions I made and I have included a little demo tool I was using for validation that looks up one of these EtherTalk adapters and gives it a new user provided name. This was based on the capture I performed, and we largely replicate the same behaviour. As part of this too I made a unit test that performs this same sequence to verify our ADSP logic (at least for this session) is correct.

Now the plan is to get the adsp-stylewriter tool actually working and we can start getting support for these printers in to TailTalk :)