### PR TITLE
StyleWriter: Get color printing working over ADSP

### DIFF
--- a/examples/adsp-stylewriter/Cargo.toml
+++ b/examples/adsp-stylewriter/Cargo.toml
@@ -13,5 +13,5 @@ anyhow = { workspace = true } #unified
 clap = { workspace = true } #unified
 tailtalk = { workspace = true, features = ["ethertalk"] } #unified
 tailtalk-packets = { workspace = true } #unified
-tokio = { workspace = true, features = ["io-util"] } #unified
+tokio = { workspace = true, features = ["io-util", "time"] } #unified
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/adsp-stylewriter/main.rs
+++ b/examples/adsp-stylewriter/main.rs
@@ -1,17 +1,17 @@
 use clap::Parser;
+use std::io::Write;
 use tailtalk::{
     TalkStack,
     adsp::AdspAddress,
-    stylewriter::StyleWriterEncoder,
+    stylewriter::{StyleWriterEncoder, StyleWriterSession, MAX_BATCH_BYTES, SW2200_PRINT_ROWBYTES, SW2200_PRINT_WIDTH},
 };
 use tailtalk_packets::nbp::EntityName;
-use tokio::io::AsyncWriteExt;
 
 #[derive(Parser, Debug)]
 #[command(about = "Print a raw raster file to a Color StyleWriter via ADSP/EtherTalk")]
 struct Args {
-    /// Network interface to bind to
-    #[arg(short, long)]
+    /// Network interface to bind to (ignored when --dump is set)
+    #[arg(short, long, default_value = "")]
     interface: String,
 
     /// Printer entity name to look up, e.g. "Color StyleWriter 2400:LaserWriter@*"
@@ -25,6 +25,96 @@ struct Args {
     /// Raster width in pixels (for raw headerless formats)
     #[arg(short = 'W', long, default_value_t = 2880)]
     width: usize,
+
+    /// Dump encoded raster blocks to stdout instead of printing (for diffing against C reference)
+    #[arg(long)]
+    dump: bool,
+
+    /// AppleTalk username to send in the print request handshake
+    #[arg(short, long, default_value = "user")]
+    username: String,
+
+    /// Send only the K-nibble bit as a single monochrome plane ('R' tag)
+    /// instead of full 4-plane CMYK ('c' tag). The StyleWriter I tested with
+    /// allows using either the colour cartridge _or_ the black one. If Colour
+    /// is chosen the printer will ignore the K-nibble and print the CMY planes instead.
+    /// The native Mac OS driver does the same.
+    #[arg(long)]
+    mono: bool,
+
+}
+
+/// Unpack one chunky scanline into raw (pre-RLE) CMYK planar bytes.
+fn chunky_to_planes(chunky: &[u8], planar_input_len: usize) -> [Vec<u8>; 4] {
+    let mut planes = [
+        Vec::with_capacity(planar_input_len),
+        Vec::with_capacity(planar_input_len),
+        Vec::with_capacity(planar_input_len),
+        Vec::with_capacity(planar_input_len),
+    ];
+
+    for chunk_block in chunky.chunks(4) {
+        let mut c = 0u8;
+        let mut m = 0u8;
+        let mut y = 0u8;
+        let mut k = 0u8;
+        for i in 0..4 {
+            let b = chunk_block.get(i).copied().unwrap_or(0);
+            c = (c << 2) | ((b >> 6) & 2) | ((b >> 3) & 1);
+            m = (m << 2) | ((b >> 5) & 2) | ((b >> 2) & 1);
+            y = (y << 2) | ((b >> 4) & 2) | ((b >> 1) & 1);
+            k = (k << 2) | ((b >> 3) & 2) | (b & 1);
+        }
+        planes[0].push(c);
+        planes[1].push(m);
+        planes[2].push(y);
+        planes[3].push(k);
+    }
+    planes
+}
+
+/// Unpack one chunky scanline's K-nibble bit only into a raw (pre-RLE) plane.
+fn chunky_to_mono_plane(chunky: &[u8], planar_input_len: usize) -> Vec<u8> {
+    let mut plane = Vec::with_capacity(planar_input_len);
+    for chunk_block in chunky.chunks(4) {
+        let mut k = 0u8;
+        for i in 0..4 {
+            let b = chunk_block.get(i).copied().unwrap_or(0);
+            k = (k << 2) | ((b >> 3) & 2) | (b & 1);
+        }
+        plane.push(k);
+    }
+    plane
+}
+
+/// Encode one row's plane(s) into concatenated RLE bytes. `use_delta` XORs
+/// each plane against the previous row's raw plane first (lpstyl's
+/// `appendEncode()` differencing).
+///
+/// Delta is NOT optional for color: 'c'/"m2sAH" mode reconstructs each row
+/// by XORing against the previous one, so absolute rows print as
+/// cumulative-XOR garbage. Monochrome 'R'/"m2nZAB" bands are absolute.
+///
+/// `use_delta` must be false for the first row of every rect+G block, since
+/// the printer's differencing state resets per block. Does not mutate
+/// `last` — the caller updates it once per source row, so a row re-encoded
+/// after a batch flush still deltas correctly.
+fn encode_row(planes: &[Vec<u8>], last: &[Vec<u8>], use_delta: bool, mono: bool) -> Vec<u8> {
+    let mut out = Vec::new();
+    for (i, plane) in planes.iter().enumerate() {
+        let delta;
+        let src = if use_delta {
+            delta = plane.iter().zip(last[i].iter()).map(|(c, l)| c ^ l).collect::<Vec<u8>>();
+            &delta
+        } else {
+            plane
+        };
+        // K plane (mono, or index 3 of CMYK) never uses the blank-shortcut
+        // (see encode_scanline docs); C/M/Y planes do.
+        let allow_shortcut = !mono && i != 3;
+        out.extend_from_slice(&StyleWriterEncoder::encode_scanline(src, SW2200_PRINT_ROWBYTES, allow_shortcut));
+    }
+    out
 }
 
 #[tokio::main]
@@ -32,6 +122,70 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt().init();
 
     let args = Args::parse();
+
+    let raw_data = std::fs::read(&args.file)?;
+    // Color rows must be XOR-delta encoded; mono rows must be absolute
+    // (see encode_row) — this is the printer's wire format, not a choice.
+    let use_delta = !args.mono;
+    let width_pixels = args.width;
+    let chunky_scanline_len = width_pixels / 2;
+    let planar_scanline_len = width_pixels / 8;
+    let total_rows = raw_data.len() / chunky_scanline_len;
+
+    eprintln!("Image: {} pixels wide, {} scanlines", width_pixels, total_rows);
+    eprintln!("SW2200_PRINT_ROWBYTES = {}, padding {} px per plane with white",
+        SW2200_PRINT_ROWBYTES, SW2200_PRINT_WIDTH - width_pixels);
+
+    // ── Dump mode: write raster blocks to stdout for comparison with C reference ─
+    if args.dump {
+        let stdout = std::io::stdout();
+        let mut out = stdout.lock();
+        let mut batch_start = 0usize;
+        let mut batch_data = Vec::new();
+        let mut last_planes = vec![vec![0u8; planar_scanline_len]; if args.mono { 1 } else { 4 }];
+        for (row_idx, chunky) in raw_data.chunks(chunky_scanline_len).enumerate() {
+            let planes: Vec<Vec<u8>> = if args.mono {
+                vec![chunky_to_mono_plane(chunky, planar_scanline_len)]
+            } else {
+                chunky_to_planes(chunky, planar_scanline_len).into()
+            };
+            let mut row_enc = encode_row(&planes, &last_planes, use_delta && !batch_data.is_empty(), args.mono);
+            // Flush before this row would cross the printer's buffer size:
+            // one G block must stay strictly below MAX_BATCH_BYTES.
+            if !batch_data.is_empty() && batch_data.len() + row_enc.len() >= MAX_BATCH_BYTES {
+                let rect = StyleWriterEncoder::encode_rect(
+                    batch_start as u16, 0, (row_idx - 1) as u16, SW2200_PRINT_WIDTH as u16, !args.mono,
+                );
+                let g_block = StyleWriterEncoder::wrap_raster_chunk(&batch_data);
+                out.write_all(&rect)?;
+                out.write_all(&g_block)?;
+                batch_start = row_idx;
+                batch_data.clear();
+                if use_delta {
+                    // This row now starts a new block: the delta chain resets.
+                    row_enc = encode_row(&planes, &last_planes, false, args.mono);
+                }
+            }
+            batch_data.extend_from_slice(&row_enc);
+            last_planes = planes;
+            if row_idx + 1 == total_rows {
+                // Rows are padded to the full printable width, so the rect
+                // right edge is SW2200_PRINT_WIDTH (not the source width) —
+                // keeps dump output byte-identical to what write_batch sends.
+                let rect = StyleWriterEncoder::encode_rect(
+                    batch_start as u16, 0, row_idx as u16, SW2200_PRINT_WIDTH as u16, !args.mono,
+                );
+                let g_block = StyleWriterEncoder::wrap_raster_chunk(&batch_data);
+                out.write_all(&rect)?;
+                out.write_all(&g_block)?;
+            }
+        }
+        return Ok(());
+    }
+
+    // ── Network mode ─
+
+    anyhow::ensure!(!args.interface.is_empty(), "--interface is required for printing");
 
     let entity: EntityName = args
         .printer
@@ -45,14 +199,13 @@ async fn main() -> anyhow::Result<()> {
         .await
         .expect("failed to build AppleTalk stack");
 
-    // Locate the printer via NBP
-    println!("Looking up printer '{}'...", entity);
+    eprintln!("Looking up printer '{}'...", entity);
     let tuples = stack.nbp.lookup(entity).await?;
     let printer = tuples
         .first()
         .ok_or_else(|| anyhow::anyhow!("Printer not found on network"))?;
 
-    println!(
+    eprintln!(
         "Found printer {} at {}.{} socket {}",
         printer.entity_name, printer.network_number, printer.node_id, printer.socket_number
     );
@@ -63,76 +216,59 @@ async fn main() -> anyhow::Result<()> {
         socket_number: printer.socket_number,
     };
 
-    println!("Reading bitcmyk raster file '{}'...", args.file);
-    let raw_data = std::fs::read(&args.file)?;
+    eprintln!("Connecting to printer...");
+    let mut session = StyleWriterSession::connect(&stack, printer_addr, &args.username).await?;
+    eprintln!("Connected! Running setup...");
 
-    // Ghostscript's bitcmyk format is chunky: 4 bits per pixel (CMYK). So 2 pixels per byte.
-    let width_pixels = args.width;
-    let chunky_scanline_len = width_pixels / 2;
-    let planar_scanline_len = width_pixels / 8;
+    // Run setup + raster transmission in a block so any failure can eject
+    // the loaded page and reset the printer instead of leaving it stuck.
+    let print_result: anyhow::Result<()> = async {
+        session.setup(!args.mono).await?;
 
-    println!("Connecting ADSP session to printer...");
-    let mut adsp_stream = stack.connect_adsp(printer_addr).await?;
-    println!("ADSP session established!");
-
-    // Send the initialization boundaries
-    let mut init_block = Vec::new();
-    // Color header c (top 0, left 0, bottom 1000, right width)
-    init_block.extend_from_slice(&StyleWriterEncoder::encode_rect(
-        0,
-        0,
-        1000,
-        width_pixels as u16,
-        true,
-    ));
-    adsp_stream.write_all(&init_block).await?;
-    adsp_stream.write_eom().await?;
-
-    // Now send the chunks
-    println!("Encoding and transmitting color rasters...");
-    for chunky_scanline in raw_data.chunks(chunky_scanline_len) {
-        let mut planes = [
-            Vec::with_capacity(planar_scanline_len), // C
-            Vec::with_capacity(planar_scanline_len), // M
-            Vec::with_capacity(planar_scanline_len), // Y
-            Vec::with_capacity(planar_scanline_len), // K
-        ];
-
-        for chunk_block in chunky_scanline.chunks(4) {
-            let mut c_byte = 0u8;
-            let mut m_byte = 0u8;
-            let mut y_byte = 0u8;
-            let mut k_byte = 0u8;
-
-            for i in 0..4 {
-                let b = chunk_block.get(i).copied().unwrap_or(0);
-                c_byte = (c_byte << 2) | ((b >> 6) & 2) | ((b >> 3) & 1);
-                m_byte = (m_byte << 2) | ((b >> 5) & 2) | ((b >> 2) & 1);
-                y_byte = (y_byte << 2) | ((b >> 4) & 2) | ((b >> 1) & 1);
-                k_byte = (k_byte << 2) | ((b >> 3) & 2) | (b & 1);
+        eprintln!("Encoding and transmitting {} rasters ({}batched, {} bytes/batch max)...",
+            if args.mono { "monochrome" } else { "color" },
+            if use_delta { "delta-encoded, " } else { "" },
+            MAX_BATCH_BYTES);
+        let mut batch_start = 0usize;
+        let mut batch_data = Vec::new();
+        let mut last_planes = vec![vec![0u8; planar_scanline_len]; if args.mono { 1 } else { 4 }];
+        for (row_idx, chunky) in raw_data.chunks(chunky_scanline_len).enumerate() {
+            let planes: Vec<Vec<u8>> = if args.mono {
+                vec![chunky_to_mono_plane(chunky, planar_scanline_len)]
+            } else {
+                chunky_to_planes(chunky, planar_scanline_len).into()
+            };
+            let mut row_enc = encode_row(&planes, &last_planes, use_delta && !batch_data.is_empty(), args.mono);
+            // Flush before this row would cross the printer's buffer size:
+            // one G block must stay strictly below MAX_BATCH_BYTES.
+            if !batch_data.is_empty() && batch_data.len() + row_enc.len() >= MAX_BATCH_BYTES {
+                session.write_batch(batch_start as u16, (row_idx - 1) as u16, &batch_data, !args.mono).await?;
+                batch_start = row_idx;
+                batch_data.clear();
+                if use_delta {
+                    // This row now starts a new block: the delta chain resets.
+                    row_enc = encode_row(&planes, &last_planes, false, args.mono);
+                }
             }
-
-            planes[0].push(c_byte);
-            planes[1].push(m_byte);
-            planes[2].push(y_byte);
-            planes[3].push(k_byte);
+            batch_data.extend_from_slice(&row_enc);
+            last_planes = planes;
+            if row_idx + 1 == total_rows {
+                session.write_batch(batch_start as u16, row_idx as u16, &batch_data, !args.mono).await?;
+            }
         }
+        Ok(())
+    }
+    .await;
 
-        let mut raster_block = Vec::new();
-
-        // Color StyleWriter expected order: C, M, Y, K
-        for plane in &planes {
-            let encoded_line = StyleWriterEncoder::encode_scanline(plane, planar_scanline_len);
-            let g_wrapped = StyleWriterEncoder::wrap_raster_chunk(&encoded_line);
-            raster_block.extend_from_slice(&g_wrapped);
-        }
-
-        adsp_stream.write_all(&raster_block).await?;
-        adsp_stream.write_eom().await?;
+    if let Err(e) = print_result {
+        eprintln!("Print failed ({e:#}); ejecting page and resetting printer...");
+        let _ = session.abort().await;
+        return Err(e);
     }
 
-    println!("Print job finished! Closing connection...");
-    adsp_stream.close().await?;
+    eprintln!("Print data sent. Finishing page...");
+    session.finish().await?;
 
+    eprintln!("Done!");
     Ok(())
 }

--- a/tailtalk-packets/src/adsp.rs
+++ b/tailtalk-packets/src/adsp.rs
@@ -34,10 +34,13 @@ pub enum AdspDescriptor {
     CloseAdvice = 0x85,
     /// Forward reset
     ForwardReset = 0x86,
-    /// Retransmit advice
-    RetransmitAdvice = 0x87,
-    /// Acknowledgment
-    Acknowledgment = 0x88,
+    /// Forward reset acknowledgment
+    ForwardResetAck = 0x87,
+    /// Retransmit advice — the receiver is missing data from
+    /// `next_recv_seq` onward and asks the sender to roll back its send
+    /// queue and retransmit from there (Inside AppleTalk ch. 12, code 8).
+    /// Not a routine ack — plain acks are `ControlPacket` (code 0).
+    RetransmitAdvice = 0x88,
 }
 
 impl TryFrom<u8> for AdspDescriptor {
@@ -55,8 +58,8 @@ impl TryFrom<u8> for AdspDescriptor {
             0x84 => Ok(AdspDescriptor::OpenConnDeny),
             0x85 => Ok(AdspDescriptor::CloseAdvice),
             0x86 => Ok(AdspDescriptor::ForwardReset),
-            0x87 => Ok(AdspDescriptor::RetransmitAdvice),
-            0x88 => Ok(AdspDescriptor::Acknowledgment),
+            0x87 => Ok(AdspDescriptor::ForwardResetAck),
+            0x88 => Ok(AdspDescriptor::RetransmitAdvice),
             _ => Err(AdspError::UnknownDescriptor { code: value }),
         }
     }
@@ -245,18 +248,18 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_acknowledgment() {
+    fn test_parse_retransmit_advice() {
         let data: &[u8] = &[
             0x00, 0x42, // conn_id
             0x00, 0x00, 0x03, 0xE8, // first_byte_seq = 1000
             0x00, 0x00, 0x07, 0xD0, // next_recv_seq = 2000
             0x08, 0x00, // recv_window = 2048
-            0x88,       // descriptor = Acknowledgment
+            0x88,       // descriptor = RetransmitAdvice (control code 8)
         ];
 
         let packet = AdspPacket::parse(data).expect("failed to parse");
 
-        assert_eq!(packet.descriptor, AdspDescriptor::Acknowledgment);
+        assert_eq!(packet.descriptor, AdspDescriptor::RetransmitAdvice);
         assert_eq!(packet.connection_id, 0x0042);
         assert_eq!(packet.first_byte_seq, 1000);
         assert_eq!(packet.next_recv_seq, 2000);

--- a/tailtalk/src/adsp.rs
+++ b/tailtalk/src/adsp.rs
@@ -40,6 +40,15 @@ enum ConnectionState {
     Closing,
 }
 
+/// One blocked `write_eom` / `write_all` + flush waiting for window space.
+struct PendingWrite {
+    data: Vec<u8>,
+    /// Bytes of `data` already transmitted.
+    offset: usize,
+    eom: bool,
+    reply: oneshot::Sender<io::Result<()>>,
+}
+
 struct AdspConnection {
     /// Our own ConnID — placed in every outgoing packet's connection_id field.
     /// The HashMap key is the peer's ConnID (what arrives in inbound packets).
@@ -58,6 +67,10 @@ struct AdspConnection {
     attn_send_seq: u32,
     /// Delivers received data to the AdspStream reader.
     data_tx: mpsc::Sender<Vec<u8>>,
+    /// Writes blocked on the peer's receive window.
+    pending_writes: std::collections::VecDeque<PendingWrite>,
+    /// Deferred close: fires after all pending_writes have been sent.
+    pending_close: Option<oneshot::Sender<io::Result<()>>>,
 }
 
 // ── Actor command channel ─────────────────────────────────────────────────────
@@ -188,6 +201,8 @@ impl Adsp {
             retries: 0,
             attn_send_seq: 0,
             data_tx,
+            pending_writes: std::collections::VecDeque::new(),
+            pending_close: None,
         });
         self.make_stream(map_key, remote_addr, data_rx)
     }
@@ -225,16 +240,14 @@ impl Adsp {
     async fn handle_cmd(&mut self, cmd: ActorCmd) {
         match cmd {
             ActorCmd::SendData { conn_id, data, eom, reply } => {
-                let result = self.send_data(conn_id, &data, eom).await;
-                let _ = reply.send(result);
+                self.send_data(conn_id, data, eom, reply).await;
             }
             ActorCmd::SendAttention { conn_id, code, data, reply } => {
                 let result = self.send_attention_msg(conn_id, code, &data).await;
                 let _ = reply.send(result);
             }
             ActorCmd::Close { conn_id, reply } => {
-                let result = self.close_connection(conn_id).await;
-                let _ = reply.send(result);
+                self.close_or_defer(conn_id, reply).await;
             }
         }
     }
@@ -268,32 +281,43 @@ impl Adsp {
                 conn.retries
             );
 
-            let data: Vec<u8> = conn.flight_buffer.clone();
-            let remote_addr = conn.remote_addr;
-            let oldest_seq = conn.oldest_unacked_seq;
-            let recv_seq = conn.recv_seq;
-            let our_conn_id = conn.our_conn_id;
+            self.resend_unacked(conn_id).await;
+        }
+    }
 
-            for (i, chunk) in data.chunks(ADSP_MAX_DATA).enumerate() {
-                let chunk_seq = oldest_seq.wrapping_add((i * ADSP_MAX_DATA) as u32);
-                let pkt = AdspPacket {
-                    descriptor: AdspDescriptor::DataPacket,
-                    connection_id: our_conn_id,
-                    first_byte_seq: chunk_seq,
-                    next_recv_seq: recv_seq,
-                    recv_window: ADSP_RECV_WINDOW,
-                    flags: AdspPacket::FLAG_ACK,
-                };
-                let mut buf = vec![0u8; AdspPacket::HEADER_LEN + chunk.len()];
-                if pkt.to_bytes(&mut buf).is_ok() {
-                    buf[AdspPacket::HEADER_LEN..].copy_from_slice(chunk);
-                    let _ = self.sock.send_to(&buf, ddp_dest(remote_addr)).await;
-                }
-            }
+    /// Resend everything in the flight buffer from `oldest_unacked_seq`.
+    /// Called from the retransmit tick and on peer RetransmitAdvice.
+    async fn resend_unacked(&mut self, conn_id: u16) {
+        let Some(conn) = self.connections.get_mut(&conn_id) else { return };
+        if conn.flight_buffer.is_empty() {
+            return;
+        }
 
-            if let Some(c) = self.connections.get_mut(&conn_id) {
-                c.last_tx = now;
+        let data: Vec<u8> = conn.flight_buffer.clone();
+        let remote_addr = conn.remote_addr;
+        let oldest_seq = conn.oldest_unacked_seq;
+        let recv_seq = conn.recv_seq;
+        let our_conn_id = conn.our_conn_id;
+
+        for (i, chunk) in data.chunks(ADSP_MAX_DATA).enumerate() {
+            let chunk_seq = oldest_seq.wrapping_add((i * ADSP_MAX_DATA) as u32);
+            let pkt = AdspPacket {
+                descriptor: AdspDescriptor::DataPacket,
+                connection_id: our_conn_id,
+                first_byte_seq: chunk_seq,
+                next_recv_seq: recv_seq,
+                recv_window: ADSP_RECV_WINDOW,
+                flags: AdspPacket::FLAG_ACK,
+            };
+            let mut buf = vec![0u8; AdspPacket::HEADER_LEN + chunk.len()];
+            if pkt.to_bytes(&mut buf).is_ok() {
+                buf[AdspPacket::HEADER_LEN..].copy_from_slice(chunk);
+                let _ = self.sock.send_to(&buf, ddp_dest(remote_addr)).await;
             }
+        }
+
+        if let Some(c) = self.connections.get_mut(&conn_id) {
+            c.last_tx = std::time::Instant::now();
         }
     }
 
@@ -336,8 +360,14 @@ impl Adsp {
             AdspDescriptor::DataPacket | AdspDescriptor::ControlPacket => {
                 self.handle_data(packet, &payload[AdspPacket::HEADER_LEN..]).await;
             }
-            AdspDescriptor::Acknowledgment => {
+            AdspDescriptor::RetransmitAdvice => {
+                // Peer is missing data from packet.next_recv_seq onward:
+                // apply the ack state (which rolls oldest_unacked back to
+                // exactly what the peer has), then resend immediately
+                // instead of waiting for the retransmit tick.
+                let conn_id = packet.connection_id;
                 self.handle_ack(packet).await;
+                self.resend_unacked(conn_id).await;
             }
             AdspDescriptor::CloseAdvice => {
                 self.handle_close(packet).await;
@@ -475,14 +505,71 @@ impl Adsp {
     async fn handle_data(&mut self, packet: AdspPacket, data: &[u8]) {
         let Some(conn) = self.connections.get_mut(&packet.connection_id) else { return };
 
-        if !data.is_empty() {
-            conn.recv_seq = packet.first_byte_seq.wrapping_add(data.len() as u32);
-            if conn.data_tx.try_send(data.to_vec()).is_err() {
-                tracing::warn!("ADSP conn {} receive buffer full, dropping data", packet.connection_id);
+        // EOM consumes one byte of sequence space even with no payload (like
+        // TCP FIN) — must advance recv_seq even when data is empty, or our
+        // own ack of the peer's EOM packet will look short by one to them.
+        let eom_seq_bump: u32 = if packet.flags & AdspPacket::FLAG_EOM != 0 { 1 } else { 0 };
+        let total_len = data.len() as u32 + eom_seq_bump;
+        if total_len > 0 {
+            // Sequence-validate before delivering: peers retransmit on their own
+            // timers, so both duplicates and (after a lost packet) data beyond a
+            // hole occur. Delivering a duplicate corrupts request/reply pairing;
+            // acking past a hole makes the peer never resend it, deadlocking the
+            // stream.
+            let diff = conn.recv_seq.wrapping_sub(packet.first_byte_seq) as i32;
+            if diff < 0 {
+                // Data beyond a hole: discard; the ack below re-states our
+                // recv_seq so the peer rolls back and retransmits.
+                tracing::warn!(
+                    "ADSP conn {} out-of-order data (seq {}, expected {}), discarding",
+                    packet.connection_id,
+                    packet.first_byte_seq,
+                    conn.recv_seq
+                );
+            } else if (diff as u32) < total_len {
+                // In order (diff == 0), or a retransmission overlapping our
+                // position: deliver only the bytes we haven't seen yet.
+                let skip = (diff as usize).min(data.len());
+                let fresh = &data[skip..];
+                if fresh.is_empty() || conn.data_tx.try_send(fresh.to_vec()).is_ok() {
+                    conn.recv_seq = packet.first_byte_seq.wrapping_add(total_len);
+                } else {
+                    // Receive buffer full: leave recv_seq (and thus our ack)
+                    // where it is so the peer retransmits instead of the
+                    // bytes being silently lost.
+                    tracing::warn!(
+                        "ADSP conn {} receive buffer full, deferring data",
+                        packet.connection_id
+                    );
+                }
+            } else {
+                // Pure duplicate of already-delivered data: drop it. The ack
+                // below tells the peer where we really are.
+                tracing::debug!(
+                    "ADSP conn {} dropping duplicate retransmission (seq {}, {} bytes)",
+                    packet.connection_id,
+                    packet.first_byte_seq,
+                    total_len
+                );
             }
         }
 
-        let _ = self.send_ack(packet.connection_id).await;
+        // All ADSP packets (data and control) carry ACK state — apply sender flow control.
+        conn.send_window = packet.recv_window;
+        // Valid ack range is bounded by our own send_seq (which already
+        // accounts for EOM's phantom byte), not flight_buffer.len() directly —
+        // an EOM-terminated send acks 1 higher than its real byte count.
+        let max_valid_acked = conn.send_seq.wrapping_sub(conn.oldest_unacked_seq) as usize;
+        let acked = packet.next_recv_seq.wrapping_sub(conn.oldest_unacked_seq) as usize;
+        if acked > 0 && acked <= max_valid_acked {
+            conn.flight_buffer.drain(..acked.min(conn.flight_buffer.len()));
+            conn.oldest_unacked_seq = packet.next_recv_seq;
+            conn.retries = 0;
+        }
+
+        let conn_id = packet.connection_id;
+        let _ = self.send_ack(conn_id).await;
+        self.drain_pending(conn_id).await;
     }
 
     async fn handle_ack(&mut self, packet: AdspPacket) {
@@ -490,14 +577,18 @@ impl Adsp {
 
         conn.send_window = packet.recv_window;
 
+        let max_valid_acked = conn.send_seq.wrapping_sub(conn.oldest_unacked_seq) as usize;
         let acked = packet
             .next_recv_seq
             .wrapping_sub(conn.oldest_unacked_seq) as usize;
-        if acked > 0 && acked <= conn.flight_buffer.len() {
-            conn.flight_buffer.drain(..acked);
+        if acked > 0 && acked <= max_valid_acked {
+            conn.flight_buffer.drain(..acked.min(conn.flight_buffer.len()));
             conn.oldest_unacked_seq = packet.next_recv_seq;
             conn.retries = 0;
         }
+
+        let conn_id = packet.connection_id;
+        self.drain_pending(conn_id).await;
     }
 
     async fn handle_close(&mut self, packet: AdspPacket) {
@@ -530,43 +621,65 @@ impl Adsp {
     async fn send_data(
         &mut self,
         conn_id: u16,
-        data: &[u8],
+        data: Vec<u8>,
         eom: bool,
-    ) -> io::Result<()> {
+        reply: oneshot::Sender<io::Result<()>>,
+    ) {
+        let Some(conn) = self.connections.get_mut(&conn_id) else {
+            let _ = reply.send(Err(io::Error::new(io::ErrorKind::NotConnected, "no such connection")));
+            return;
+        };
+
+        if conn.state != ConnectionState::Open {
+            let _ = reply.send(Err(io::Error::new(io::ErrorKind::NotConnected, "connection closing")));
+            return;
+        }
+
+        // If earlier writes are still queued, preserve order by appending.
+        if !conn.pending_writes.is_empty() {
+            conn.pending_writes.push_back(PendingWrite { data, offset: 0, eom, reply });
+            return;
+        }
+
+        // Empty EOM (no payload — just marks a record boundary, doesn't consume window).
+        if data.is_empty() && eom {
+            let result = self.send_eom_only(conn_id).await;
+            let _ = reply.send(result);
+            return;
+        }
+
+        // How many bytes fit in the peer's receive window right now?
+        let in_flight = conn.send_seq.wrapping_sub(conn.oldest_unacked_seq);
+        let available = (conn.send_window as u32).saturating_sub(in_flight) as usize;
+
+        if available == 0 {
+            conn.pending_writes.push_back(PendingWrite { data, offset: 0, eom, reply });
+            return;
+        }
+
+        let to_send = data.len().min(available);
+        let all_sent = to_send == data.len();
+        let result = self.send_raw(conn_id, &data[..to_send], eom && all_sent).await;
+
+        if result.is_err() || all_sent {
+            let _ = reply.send(result);
+        } else {
+            let conn = self.connections.get_mut(&conn_id).unwrap();
+            conn.pending_writes.push_back(PendingWrite { data, offset: to_send, eom, reply });
+        }
+    }
+
+    /// Send raw data bytes on a connection without any queuing or window checks.
+    /// Updates flight_buffer and send_seq.
+    async fn send_raw(&mut self, conn_id: u16, data: &[u8], eom: bool) -> io::Result<()> {
         let conn = self
             .connections
             .get_mut(&conn_id)
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotConnected, "no such connection"))?;
 
-        if conn.state != ConnectionState::Open {
-            return Err(io::Error::new(io::ErrorKind::NotConnected, "connection closing"));
-        }
-
-        // Empty EOM flush (data packet with EOM set, no payload bytes).
-        if data.is_empty() && eom {
-            let pkt = AdspPacket {
-                descriptor: AdspDescriptor::DataPacket,
-                connection_id: conn.our_conn_id,
-                first_byte_seq: conn.send_seq,
-                next_recv_seq: conn.recv_seq,
-                recv_window: ADSP_RECV_WINDOW,
-                flags: AdspPacket::FLAG_ACK | AdspPacket::FLAG_EOM,
-            };
-            let mut buf = [0u8; AdspPacket::HEADER_LEN];
-            pkt.to_bytes(&mut buf)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
-            return self
-                .sock
-                .send_to(&buf, ddp_dest(conn.remote_addr))
-                .await
-                .map_err(io::Error::other);
-        }
-
         let last_idx = data.chunks(ADSP_MAX_DATA).count().saturating_sub(1);
-
         for (i, chunk) in data.chunks(ADSP_MAX_DATA).enumerate() {
             let eom_flag = if eom && i == last_idx { AdspPacket::FLAG_EOM } else { 0 };
-
             let pkt = AdspPacket {
                 descriptor: AdspDescriptor::DataPacket,
                 connection_id: conn.our_conn_id,
@@ -575,23 +688,124 @@ impl Adsp {
                 recv_window: ADSP_RECV_WINDOW,
                 flags: AdspPacket::FLAG_ACK | eom_flag,
             };
-
             let mut buf = vec![0u8; AdspPacket::HEADER_LEN + chunk.len()];
             pkt.to_bytes(&mut buf)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
             buf[AdspPacket::HEADER_LEN..].copy_from_slice(chunk);
-
-            self.sock
-                .send_to(&buf, ddp_dest(conn.remote_addr))
-                .await
-                .map_err(io::Error::other)?;
-
+            self.sock.send_to(&buf, ddp_dest(conn.remote_addr)).await.map_err(io::Error::other)?;
             conn.flight_buffer.extend_from_slice(chunk);
-            conn.send_seq = conn.send_seq.wrapping_add(chunk.len() as u32);
+            // EOM consumes one extra byte of sequence space (like TCP FIN),
+            // even though it carries no payload of its own. Omitting this
+            // makes the peer's legitimate cumulative ack look like an
+            // over-ack, which handle_data/handle_ack then silently reject —
+            // stalling oldest_unacked_seq and retransmitting forever.
+            let eom_seq_bump = if eom_flag != 0 { 1 } else { 0 };
+            conn.send_seq = conn.send_seq.wrapping_add(chunk.len() as u32 + eom_seq_bump);
         }
         conn.last_tx = std::time::Instant::now();
-
         Ok(())
+    }
+
+    async fn send_eom_only(&mut self, conn_id: u16) -> io::Result<()> {
+        let conn = self
+            .connections
+            .get_mut(&conn_id)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotConnected, "no such connection"))?;
+        let pkt = AdspPacket {
+            descriptor: AdspDescriptor::DataPacket,
+            connection_id: conn.our_conn_id,
+            first_byte_seq: conn.send_seq,
+            next_recv_seq: conn.recv_seq,
+            recv_window: ADSP_RECV_WINDOW,
+            flags: AdspPacket::FLAG_ACK | AdspPacket::FLAG_EOM,
+        };
+        let remote_addr = conn.remote_addr;
+        let mut buf = [0u8; AdspPacket::HEADER_LEN];
+        pkt.to_bytes(&mut buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        self.sock.send_to(&buf, ddp_dest(remote_addr)).await.map_err(io::Error::other)?;
+        // EOM consumes one byte of sequence space even with no payload (see send_raw).
+        conn.send_seq = conn.send_seq.wrapping_add(1);
+        conn.last_tx = std::time::Instant::now();
+        Ok(())
+    }
+
+    /// Drain as much of the pending write queue as the current window allows.
+    /// Fires deferred replies for completed writes, and a deferred close when the
+    /// queue empties.
+    async fn drain_pending(&mut self, conn_id: u16) {
+        loop {
+            // Extract what we need without holding a reference across the await.
+            enum Task { Eom, Data { chunk: Vec<u8>, eom: bool, all_sent: bool } }
+
+            let task = {
+                let Some(conn) = self.connections.get_mut(&conn_id) else { return };
+                let Some(front) = conn.pending_writes.front() else { break };
+
+                if front.data.is_empty() && front.eom {
+                    Task::Eom
+                } else {
+                    let in_flight = conn.send_seq.wrapping_sub(conn.oldest_unacked_seq);
+                    let available = (conn.send_window as u32).saturating_sub(in_flight) as usize;
+                    if available == 0 {
+                        break;
+                    }
+                    let remaining_len = front.data.len() - front.offset;
+                    let to_send = remaining_len.min(available);
+                    let chunk = front.data[front.offset..front.offset + to_send].to_vec();
+                    let all_sent = to_send == remaining_len;
+                    Task::Data { chunk, eom: front.eom && all_sent, all_sent }
+                }
+            };
+
+            match task {
+                Task::Eom => {
+                    let result = self.send_eom_only(conn_id).await;
+                    if let Some(conn) = self.connections.get_mut(&conn_id)
+                        && let Some(pw) = conn.pending_writes.pop_front()
+                    {
+                        let _ = pw.reply.send(result);
+                    }
+                }
+                Task::Data { chunk, eom, all_sent } => {
+                    let chunk_len = chunk.len();
+                    let result = self.send_raw(conn_id, &chunk, eom).await;
+                    let Some(conn) = self.connections.get_mut(&conn_id) else { return };
+                    if result.is_err() || all_sent {
+                        if let Some(pw) = conn.pending_writes.pop_front() {
+                            let _ = pw.reply.send(result);
+                        }
+                    } else {
+                        if let Some(front) = conn.pending_writes.front_mut() {
+                            front.offset += chunk_len;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        // If queue is now empty and a close was deferred, execute it.
+        let needs_close = self.connections.get(&conn_id)
+            .map(|c| c.pending_writes.is_empty() && c.pending_close.is_some())
+            .unwrap_or(false);
+        if needs_close {
+            let reply = self.connections.get_mut(&conn_id).unwrap().pending_close.take().unwrap();
+            let result = self.do_close(conn_id).await;
+            let _ = reply.send(result);
+        }
+    }
+
+    async fn close_or_defer(&mut self, conn_id: u16, reply: oneshot::Sender<io::Result<()>>) {
+        let Some(conn) = self.connections.get_mut(&conn_id) else {
+            let _ = reply.send(Ok(())); // already gone
+            return;
+        };
+        if conn.pending_writes.is_empty() {
+            let result = self.do_close(conn_id).await;
+            let _ = reply.send(result);
+        } else {
+            conn.pending_close = Some(reply);
+        }
     }
 
     async fn send_ack(&mut self, conn_id: u16) -> io::Result<()> {
@@ -600,8 +814,11 @@ impl Adsp {
             .get(&conn_id)
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotConnected, "no such connection"))?;
 
+        // Plain acks are control code 0 (probe/ack, 0x80), not RetransmitAdvice
+        // (0x88) — that's a rollback command and must only be sent in response
+        // to an actual gap in the peer's stream.
         let pkt = AdspPacket {
-            descriptor: AdspDescriptor::Acknowledgment,
+            descriptor: AdspDescriptor::ControlPacket,
             connection_id: conn.our_conn_id,
             first_byte_seq: conn.send_seq,
             next_recv_seq: conn.recv_seq,
@@ -650,7 +867,7 @@ impl Adsp {
             .map_err(io::Error::other)
     }
 
-    async fn close_connection(&mut self, conn_id: u16) -> io::Result<()> {
+    async fn do_close(&mut self, conn_id: u16) -> io::Result<()> {
         let Some(conn) = self.connections.get(&conn_id) else {
             return Ok(()); // already gone
         };

--- a/tailtalk/src/stylewriter.rs
+++ b/tailtalk/src/stylewriter.rs
@@ -1,3 +1,345 @@
+use crate::{
+    TalkStack,
+    adsp::{AdspAddress, AdspStream},
+};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// Native printable width / row-byte-count for the Color StyleWriter 2200
+/// (lpstyl `printerSetup()` for KIND_SW2200).
+pub const SW2200_PRINT_WIDTH: usize = 2919;
+pub const SW2200_PRINT_ROWBYTES: usize = SW2200_PRINT_WIDTH.div_ceil(8); // 365
+
+/// The printer's internal raster buffer size (lpstyl `MAX_BUFFER` for the
+/// CS family). It holds one whole rect+G block before printing the band, so
+/// a block must stay *strictly smaller* than this or the printer stalls with
+/// 'B' = 0x00 (buffer full) and ejects blank — confirmed with a 32863-byte
+/// block. Callers must flush before a row would cross this limit, carrying
+/// it over to the next block (lpstyl does the same).
+///
+/// A rect+G block must also span many rows, not one block per row — the
+/// latter never printed anything despite being byte-correct.
+pub const MAX_BATCH_BYTES: usize = 0x8000;
+
+// SW2200 is idle when 'B' has both 0x80 and 0x20 set: 0xA2 (no paper) and
+// 0xA3 (paper loaded) are the observed idle values; mid-page 'B' is a
+// buffer-drain gauge that climbs through values like 0x23/0x25 while a band
+// drains. Testing bit 0x20 alone matches those transient gauge values,
+// releasing the next band before the previous one has fully drained and
+// wedging the printer (B=0x00). lpstyl only waits for 0xA3; the mask here
+// also accepts 0xA2 since the low bits vary with paper presence.
+const SW2200_IDLE_MASK: u8 = 0xA0;
+
+/// Real inkjet mechanics (paper feed motor, ink deposition) can report an
+/// idle-looking status bit before they've actually finished moving — confirmed
+/// by observing the eject command fire while paper was visibly still being
+/// pulled in. A short fixed settle delay avoids racing ahead of the hardware.
+const MECHANISM_SETTLE_DELAY: Duration = Duration::from_secs(3);
+
+/// Build the attention payload for the 0x000b print-request message
+/// (lpstyl §at_printer_open): `struct printRequest { u_int32_t port; char string[66]; }`.
+fn build_print_request(socket_num: u8, username: &str) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(70);
+    payload.extend_from_slice(&(socket_num as u32).to_be_bytes());
+    let name = username.as_bytes();
+    let name_len = name.len().min(64);
+    payload.push(name_len as u8);
+    payload.extend_from_slice(&name[..name_len]);
+    payload.resize(70, 0);
+    payload
+}
+
+/// Write bytes and flush immediately — `AdspStream::poll_write` only buffers
+/// into an internal write_buf; nothing reaches the wire until flushed.
+async fn write_flush(data: &mut AdspStream, bytes: &[u8]) -> anyhow::Result<()> {
+    data.write_all(bytes).await?;
+    data.flush().await?;
+    Ok(())
+}
+
+/// A live ADSP connection to a StyleWriter printer, past the initial
+/// two-connection handshake and ready for `setup()` / `write_batch()` / `finish()`.
+///
+/// Protocol notes (reverse-engineered from a real Mac OS driver capture, since
+/// this goes further than lpstyl's own reimplementation covers):
+/// - `setup()` sends the minimal sequence that reliably triggers paper feed.
+///   lpstyl-style extras ('I' reset, '?' identify, 'p' submodel, and two
+///   further writes the printer never acknowledges) actively regressed paper
+///   feed in testing — likely because 'I' resets the printer into a state
+///   that expects those follow-ups to complete, and they never do.
+/// - Raster data must be batched (`write_batch`) as one rect+G block spanning
+///   many rows, not one block per row — the latter looked byte-correct but
+///   the printer silently never printed anything.
+/// - Color ('c'/"m2sAH") scanlines must be XOR-delta encoded against the
+///   previous row, restarting absolute at each rect+G block; the printer
+///   XOR-reconstructs rows, so absolute color rows print as cumulative-XOR
+///   noise. Monochrome ('R'/"m2nZAB") scanlines are absolute. See
+///   `encode_row` in the adsp-stylewriter example.
+/// - `finish()`'s teardown replicates lpstyl's `at_printer_kill(), whose own
+///   comment warns: "If you don't get it just right, after the disconnect
+///   the printer tries to open a new connection to the original control
+///   socket" — confirmed by observation when this was skipped.
+pub struct StyleWriterSession {
+    data: AdspStream,
+}
+
+impl StyleWriterSession {
+    /// Perform the two-connection StyleWriter ADSP handshake (lpstyl
+    /// `at_printer_open`): connect to the printer's control socket, send the
+    /// ATTN 0x000b print request, close the control connection on success,
+    /// then accept the printer's reverse connection on our data socket.
+    pub async fn connect(
+        stack: &TalkStack,
+        printer_addr: AdspAddress,
+        username: &str,
+    ) -> anyhow::Result<Self> {
+        let (data_socket_num, mut data_listener) = stack.listen_adsp(None).await?;
+
+        let mut ctrl = stack.connect_adsp(printer_addr).await?;
+        let req_payload = build_print_request(data_socket_num, username);
+        ctrl.send_attention(0x000b, &req_payload).await?;
+
+        let mut result_buf = [0u8; 2];
+        ctrl.read_exact(&mut result_buf).await?;
+        let result = u16::from_be_bytes(result_buf);
+        match result {
+            0 => ctrl.close().await?,
+            0xFFFF => anyhow::bail!("Printer rejected the print request (0xFFFF)"),
+            _ => anyhow::bail!("Printer busy (result 0x{:04X}); retry later", result),
+        }
+
+        let data = data_listener.accept().await?;
+        Ok(Self { data })
+    }
+
+    /// Discard bytes already buffered from the printer. `poll_status`
+    /// re-sends its query after a timeout, so a merely-late reply would
+    /// otherwise answer the *next* query instead — permanently off by one.
+    async fn drain_stale_input(&mut self) {
+        let mut buf = [0u8; 16];
+        while let Ok(Ok(n)) =
+            tokio::time::timeout(Duration::from_millis(5), self.data.read(&mut buf)).await
+        {
+            if n == 0 {
+                break;
+            }
+            tracing::debug!("discarded {} stale printer reply byte(s)", n);
+        }
+    }
+
+    /// Send a single `\xFF\xFF\xFF<query>` status request and read the 1-byte
+    /// reply. Returns `None` on a fatal write/read error (caller should give
+    /// up); a read timeout is treated as "not ready yet" and retried,
+    /// matching lpstyl's `comm_printer_getc_block()` / `waitStatus()`.
+    async fn poll_status(&mut self, query: u8, deadline: tokio::time::Instant) -> Option<u8> {
+        loop {
+            if tokio::time::Instant::now() >= deadline {
+                return None;
+            }
+            self.drain_stale_input().await;
+            if write_flush(&mut self.data, &[0xFF, 0xFF, 0xFF, query]).await.is_err() {
+                return None;
+            }
+            let mut s = [0u8; 1];
+            match tokio::time::timeout(Duration::from_secs(5), self.data.read_exact(&mut s)).await {
+                Ok(Ok(_)) => return Some(s[0]),
+                Ok(Err(_)) => return None,
+                Err(_) => {} // no reply yet, retry
+            }
+        }
+    }
+
+    /// Poll until status 'B' reports idle (lpstyl `waitStatus()`/`waitNonBusy()`),
+    /// polling '1'/'2'/'B' each round. Used before raster data and after the
+    /// form feed, since a full page (paper pull + print + eject) can take
+    /// well over a minute.
+    ///
+    /// '2' == 0x04 (out of paper) gets lpstyl's retry handling: send
+    /// `FF FF FF 'S'` and keep waiting. Other non-0x00/0x80 values are only
+    /// logged, since the full set of benign codes on this adapter isn't known.
+    pub async fn wait_ready(&mut self) -> anyhow::Result<()> {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(180);
+        let mut last = None;
+        loop {
+            let (Some(c1), Some(c2), Some(cb)) = (
+                self.poll_status(b'1', deadline).await,
+                self.poll_status(b'2', deadline).await,
+                self.poll_status(b'B', deadline).await,
+            ) else {
+                match last {
+                    Some((c1, c2, cb)) => anyhow::bail!(
+                        "Printer did not become ready in time (last status: 1=0x{c1:02X} 2=0x{c2:02X} B=0x{cb:02X})"
+                    ),
+                    None => anyhow::bail!("No reply to printer status queries"),
+                }
+            };
+            last = Some((c1, c2, cb));
+            if c2 == 0x04 {
+                tracing::warn!("Printer is out of paper; sending retry ('S') and waiting...");
+                write_flush(&mut self.data, &[0xFF, 0xFF, 0xFF, b'S']).await?;
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                continue;
+            }
+            if c2 != 0x00 && c2 != 0x80 {
+                tracing::warn!(
+                    "Unexpected printer error status: 2=0x{c2:02X} (1=0x{c1:02X} B=0x{cb:02X})"
+                );
+            }
+            if cb & SW2200_IDLE_MASK == SW2200_IDLE_MASK {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+
+        // lpstyl's AppleTalk waitNonBusy() follows the idle wait with two
+        // ADSP attention 0x0006 "buffer ready" queries, each answered by two
+        // in-band bytes (0xFFFF in a real Mac driver capture); real Mac
+        // drivers send the same pairs before each band. A missing reply is
+        // non-fatal — and if a reply arrives late, drain_stale_input
+        // discards it before the next status poll, so this can no longer
+        // desync the query/reply pairing (the likely reason earlier attempts
+        // to send this query seemed to get no answer).
+        for _ in 0..2 {
+            self.data.send_attention(0x0006, &[0x00]).await?;
+            let mut reply = [0u8; 2];
+            if tokio::time::timeout(Duration::from_secs(3), self.data.read_exact(&mut reply))
+                .await
+                .is_err()
+            {
+                tracing::debug!("no reply to buffer-ready attention 0x0006");
+                break; // don't stack a second unanswered query
+            }
+        }
+        Ok(())
+    }
+
+    /// Minimal setup that reliably triggers paper feed: 'D', cartridge query
+    /// 'H', quality string, 'L' (page start), then wait for paper feed to
+    /// settle and the printer to report idle.
+    ///
+    /// `color` selects the quality string: monochrome uses `"m2nZAB"`, color
+    /// uses `"m2sAH"` (from real driver captures) — the string must match
+    /// the raster tag ('R'/'c') or the printer's configured mode disagrees
+    /// with the data it's told to expect.
+    pub async fn setup(&mut self, color: bool) -> anyhow::Result<()> {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+
+        write_flush(&mut self.data, b"D").await?;
+        self.poll_status(b'B', deadline).await;
+
+        // 'H' reports the installed cartridge: bit 0x80 set = color (lpstyl
+        // `printerSetup()`). A color job with a black cartridge would be
+        // silently accepted and misprinted, so fail it up front. Mono jobs
+        // print fine with either cartridge.
+        let cartridge = self.poll_status(b'H', deadline).await;
+        if color {
+            let h = cartridge
+                .ok_or_else(|| anyhow::anyhow!("No reply to cartridge query 'H'"))?;
+            anyhow::ensure!(
+                h & 0x80 != 0,
+                "Color job, but a black ink cartridge is installed (H=0x{h:02X})"
+            );
+        }
+
+        let quality = if color { b"m2sAH".as_slice() } else { b"m2nZAB".as_slice() };
+        write_flush(&mut self.data, quality).await?;
+        write_flush(&mut self.data, b"L").await?;
+
+        tokio::time::sleep(MECHANISM_SETTLE_DELAY).await;
+
+        self.wait_ready()
+            .await
+            .map_err(|e| e.context("waiting for printer to become ready after page start"))
+    }
+
+    /// Send one rect+G batch spanning rows `top..=bottom`. The rect's bottom
+    /// coordinate is *inclusive* (confirmed against lpstyl and real driver
+    /// captures), so `encoded_planes` must hold exactly `bottom - top + 1`
+    /// rows' worth of already-RLE-encoded plane(s) — claiming more rows than
+    /// supplied leaves the printer waiting for the missing scanlines.
+    ///
+    /// Waits for a fully-idle 'B' status before sending, since the previous
+    /// band must be completely drained first (see `SW2200_IDLE_MASK`).
+    pub async fn write_batch(
+        &mut self,
+        top: u16,
+        bottom: u16,
+        encoded_planes: &[u8],
+        color: bool,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            encoded_planes.len() < MAX_BATCH_BYTES,
+            "G block of {} bytes would overflow the printer's {} byte buffer and stall it",
+            encoded_planes.len(),
+            MAX_BATCH_BYTES
+        );
+        self.wait_ready()
+            .await
+            .map_err(|e| e.context("waiting for printer to drain before raster block"))?;
+        let rect = StyleWriterEncoder::encode_rect(top, 0, bottom, SW2200_PRINT_WIDTH as u16, color);
+        let g_block = StyleWriterEncoder::wrap_raster_chunk(encoded_planes);
+        self.data.write_all(&rect).await?;
+        self.data.write_all(&g_block).await?;
+        self.data.flush().await?;
+        Ok(())
+    }
+
+    /// Finish the page: wait for the last raster batch to fully drain, form
+    /// feed, wait for the print engine to settle and report idle, send the
+    /// real eject trigger (`"El"` — present in every real driver capture but
+    /// commented out as "may not be necessary" in lpstyl), then tear down
+    /// the connection.
+    ///
+    /// The pre-form-feed wait matters: `write_batch` only confirms drain
+    /// *before* the next batch, so without it here the form feed could fire
+    /// while the last band is still printing, cutting off the bottom of the
+    /// page. lpstyl calls `waitNonBusy(0)` right before its form-feed/eject
+    /// sequence for the same reason.
+    pub async fn finish(mut self) -> anyhow::Result<()> {
+        self.wait_ready()
+            .await
+            .map_err(|e| e.context("waiting for last raster batch to drain before form feed"))?;
+
+        self.data.write_all(b"\x0C").await?;
+        self.data.write_eom().await?;
+
+        tokio::time::sleep(MECHANISM_SETTLE_DELAY).await;
+        if let Err(e) = self.wait_ready().await {
+            // Still worth ejecting and closing cleanly; 'El'/'I' below force it.
+            tracing::warn!("Printer not idle after form feed ({e}); ejecting anyway");
+        }
+
+        write_flush(&mut self.data, b"El").await?;
+        self.teardown().await
+    }
+
+    /// Abort mid-page: skip the form-feed/'El' finish sequence and go
+    /// straight to the teardown, whose `FF FF FF 'I'` ejects any loaded page
+    /// and resets the printer (lpstyl's `ejectAndReset()` is exactly that
+    /// code). Without this, a failed job leaves paper sitting in the feed
+    /// path until the next job's 'L'.
+    pub async fn abort(self) -> anyhow::Result<()> {
+        self.teardown().await
+    }
+
+    /// lpstyl's `at_printer_kill()` sequence (null byte, 'I' eject/reset,
+    /// ATTN 0x0012, read reply), minus adsp_fwd_reset (not implemented in
+    /// our ADSP stack) and the non-blocking input drain (defensive only) —
+    /// skipping this teardown causes the printer to repeatedly try to
+    /// reopen a connection to us after we disconnect.
+    async fn teardown(mut self) -> anyhow::Result<()> {
+        self.data.write_all(&[0x00]).await?;
+        self.data.flush().await?;
+        write_flush(&mut self.data, &[0xFF, 0xFF, 0xFF, b'I']).await?;
+        self.data.send_attention(0x0012, &[0x00]).await?;
+        let mut kill_reply = [0u8; 2];
+        let _ = tokio::time::timeout(Duration::from_secs(5), self.data.read_exact(&mut kill_reply)).await;
+
+        self.data.close().await?;
+        Ok(())
+    }
+}
+
 pub struct StyleWriterEncoder;
 
 // StyleWriter Encoding Protocol Constants
@@ -25,8 +367,15 @@ impl StyleWriterEncoder {
         buf
     }
 
-    /// Prepend the Apple `'G'` 2-byte chunk sizes to an encoded RLE block
+    /// Prepend the Apple `'G'` 2-byte chunk sizes to an encoded RLE block.
+    /// The size field is u16, and anything at or above `MAX_BATCH_BYTES`
+    /// stalls the printer anyway (`write_batch` enforces the latter).
     pub fn wrap_raster_chunk(encoded_data: &[u8]) -> Vec<u8> {
+        debug_assert!(
+            encoded_data.len() <= u16::MAX as usize,
+            "G block length {} overflows the u16 size field",
+            encoded_data.len()
+        );
         let size = encoded_data.len() as u16;
         let mut buf = Vec::with_capacity(4 + size as usize);
         buf.push(b'G');
@@ -37,12 +386,17 @@ impl StyleWriterEncoder {
     }
 
     /// Encode a single raw bitmap scanline into the proprietary Apple RLE format
-    /// Ported directly from lpstyl.c `encodescanline()`
-    pub fn encode_scanline(src: &[u8], print_width_bytes: usize) -> Vec<u8> {
+    /// Ported directly from lpstyl.c `encodescanline()`.
+    ///
+    /// `allow_blank_shortcut` controls the single-byte "entire plane is blank"
+    /// special case: real color captures never use it for the K plane, even
+    /// when blank, only for C/M/Y. Pass `false` for K/monochrome, `true` for
+    /// C/M/Y.
+    pub fn encode_scanline(src: &[u8], print_width_bytes: usize, allow_blank_shortcut: bool) -> Vec<u8> {
         let mut dst = Vec::with_capacity(src.len());
 
         // SPECIAL CASE: Check for a completely blank line
-        if src.iter().all(|&b| b == DATA_WHITE) {
+        if allow_blank_shortcut && src.iter().all(|&b| b == DATA_WHITE) {
             dst.push(MASK_RUNWHT);
             return dst;
         }
@@ -166,21 +520,32 @@ mod tests {
     fn test_encode_scanline() {
         // Test a pure white line (all 0s)
         let white_line = vec![DATA_WHITE; 100];
-        let encoded = StyleWriterEncoder::encode_scanline(&white_line, 100);
+        let encoded = StyleWriterEncoder::encode_scanline(&white_line, 100, true);
         assert_eq!(encoded, vec![MASK_RUNWHT]);
 
         // Test a line padded with white at the end
         let src = vec![DATA_BLACK, DATA_BLACK, DATA_BLACK]; // 3 black pixels
-        let encoded = StyleWriterEncoder::encode_scanline(&src, 10);
+        let encoded = StyleWriterEncoder::encode_scanline(&src, 10, true);
         // Expect: MASK_RUNBLK + 3, MASK_RUNWHT + 7
         assert_eq!(encoded, vec![MASK_RUNBLK + 3, MASK_RUNWHT + 7]);
 
         // Test random data
         let src = vec![0x11, 0x22, 0x33, DATA_WHITE, DATA_WHITE];
-        let encoded = StyleWriterEncoder::encode_scanline(&src, 5);
+        let encoded = StyleWriterEncoder::encode_scanline(&src, 5, true);
         // Expect: random length 3 | 0x11 | 0x22 | 0x33 | then white pad/run
         assert_eq!(encoded[0], 3); // 3 bytes of raw data
         assert_eq!(&encoded[1..4], &[0x11, 0x22, 0x33]);
         assert_eq!(encoded[4], MASK_RUNWHT + 2); // 2 bytes of white
+    }
+
+    #[test]
+    fn test_encode_scanline_blank_shortcut_disabled() {
+        // With the shortcut disabled, an all-white line must be encoded as
+        // explicit white runs, not the single MASK_RUNWHT byte — matching
+        // how a real color print capture always encodes the K plane.
+        let white_line = vec![DATA_WHITE; 100];
+        let encoded = StyleWriterEncoder::encode_scanline(&white_line, 100, false);
+        assert_ne!(encoded, vec![MASK_RUNWHT]);
+        assert_eq!(encoded, vec![MASK_RUNWHT + 62, MASK_RUNWHT + 38]);
     }
 }


### PR DESCRIPTION
Fixed a _bunch_ of ADSP issues from my previous poor implementation of it:

- Mislabeled 0x88 as Acknowledgment instead of RetransmitAdvice, which was ordering the peer to roll back its send queue on every ack
- Missing sequence validation in handle_data let duplicate retransmits reach the app and let acks overrun gaps in the stream
- No flow-control window tracking on sends, so a fast writer could overrun the peer's receive buffer

On the StyleWriter driver side: batch raster rows into rect+G blocks instead of one per row, keep blocks under the printer's ~32KB internal buffer, XOR-delta encode color scanlines (required by the printer, not optional), tighten the idle-status check to a two-bit mask so a draining buffer isn't mistaken for idle, wait for the last band to fully drain before the form feed (was cutting off the bottom of the page), and reject color jobs on a black-only cartridge instead of silently misprinting. Also added abort()/teardown() so a failed job ejects and resets the printer instead of leaving paper stuck.

NOTE: I only own a Colour StyleWriter 2200 and thus was only able to test this code on that device with an EtherTalk adapter. I believe it should work with the 2400 and 2500 as well as the print driver is exactly the same but I have no idea if that is truly the case.