### PR TITLE
TailTalk: Introduce a remote daemon underlay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7"
 dependencies = [
  "anstyle",
  "memchr",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -276,7 +276,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -287,7 +287,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -666,6 +666,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bincode"
@@ -1520,7 +1526,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1740,7 +1746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1886,6 +1892,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flagset"
@@ -2246,7 +2258,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3475,6 +3487,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive 0.15.1",
+]
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive 0.16.1",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen 0.15.1",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen 0.16.1",
+]
+
+[[package]]
 name = "loop9"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3656,6 +3734,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3730,6 +3830,12 @@ dependencies = [
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "natord"
@@ -3861,7 +3967,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4540,6 +4646,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
+
+[[package]]
 name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4740,6 +4857,96 @@ checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590aa145fee8f7a26b5a6055365e7c5e89a5c1caae9869de76ec0ee73181a2f9"
+dependencies = [
+ "logos 0.16.1",
+ "miette",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protox"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
+dependencies = [
+ "logos 0.15.1",
+ "miette",
+ "prost-types",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5296,7 +5503,7 @@ dependencies = [
  "natord",
  "snafu",
  "unicode-linebreak",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -5343,7 +5550,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5400,7 +5607,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5675,7 +5882,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.2.8",
+ "errno 0.3.14",
  "libc",
 ]
 
@@ -5988,7 +6195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6210,6 +6417,7 @@ dependencies = [
  "rand 0.10.1",
  "sled",
  "tailtalk-packets",
+ "tailtalk-proto",
  "tashtalk",
  "tempfile",
  "tokio",
@@ -6218,6 +6426,25 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "xattr",
+]
+
+[[package]]
+name = "tailtalk-daemon"
+version = "0.7.2"
+dependencies = [
+ "anyhow",
+ "clap",
+ "futures",
+ "prost",
+ "tailtalk",
+ "tailtalk-packets",
+ "tailtalk-proto",
+ "tashtalk",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -6262,6 +6489,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tailtalk-proto"
+version = "0.7.2"
+dependencies = [
+ "bytes",
+ "prost",
+ "prost-build",
+ "protox",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6294,7 +6533,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6800,7 +7039,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6871,6 +7110,12 @@ name = "unicode-vo"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -7347,7 +7592,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 members = [
   "tailtalk-packets",
   "tailtalk",
+  "tailtalk-proto",
+  "tailtalk-daemon",
   "examples/nbp-lookup",
   "examples/aep-echo",
   "examples/pap-print",
@@ -22,8 +24,10 @@ clap = { version = "^4.6.0", features = ["derive"] } #unified
 encoding_rs = "^0.8.35" #unified
 futures = "^0.3.32" #unified
 hfs-reader = { path = "hfs-reader", version = "^0.1.1" } #unified
+prost = "^0.14" #unified
 tailtalk = { path = "tailtalk" } #unified
 tailtalk-packets = { path = "tailtalk-packets", version = "^0.7" } #unified
+tailtalk-proto = { path = "tailtalk-proto", version = "^0.7" } #unified
 tashtalk = { path = "tashtalk", version = "^0.2" } #unified
 thiserror = "^1.0.69" #unified
 tokio = { version = "^1.51.1", features = ["full", "io-util"] } #unified

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Packet parsers and fully async APIs for almost all the major AppleTalk protocols
 
 It additionally supports running with TashTalk for LocalTalk Macs.
 
+The AARP/DDP underlay can run either in-process (the default) or in a shared
+daemon, `tailtalkd`, which owns the interfaces and serves DDP sockets,
+addressing, and routing rules to multiple clients over a protobuf protocol on
+a Unix or UDP socket — usable from TailTalk (`TalkStack::builder().daemon_unix(..)`)
+or plain C clients. See [docs/daemon-protocol.md](docs/daemon-protocol.md).
+
 ## Building
 
 ### Prerequisites
@@ -107,6 +113,7 @@ There are 4 demo programs I have written to verify the functionality of this sof
 - [afp-server](/examples/afp-server) - An AFP 1.0, 1.1 and 2.0 compatible AFP server. Very much a work in progress but is capable of reading and writing files to classic Mac systems. Basic directory browsing and file operations are supported.
 - [nbp-lookup](/examples/nbp-lookup) - Performs an NBP lookup based on the provided request string and returns the results
 - [pap-print](/examples/pap-print) - Sends a PostScript file to a PAP printer. Aimed at LaserWriters, and have only tested on my own 4/600 PS.
+- [tailtalkd](/tailtalk-daemon/) - The TailTalk underlay daemon. Owns the physical AppleTalk interfaces and serves DDP sockets, addressing, and routing to client applications over a Unix/UDP socket.
 - [tailtalk-gui](/examples/tailtalk-gui/) - A simple GUI for sharing a folder as a volume over EtherTalk and/or LocalTalk (via TashTalk).
 
 All of the examples run a complete copy of the stack using a raw socket (if EtherTalk is enabled) and thus need to be run as root,

--- a/docs/daemon-protocol.md
+++ b/docs/daemon-protocol.md
@@ -1,0 +1,121 @@
+# TailTalk Daemon (`tailtalkd`) Wire Protocol
+
+`tailtalkd` owns the physical AppleTalk interfaces — EtherTalk (raw
+Ethernet + AARP) and/or LocalTalk (TashTalk serial + LLAP) — and exposes the
+DDP layer to any number of client processes. TailTalk stacks use it via
+`TalkStack::builder().daemon_unix(..)` / `.daemon_udp(..)`, but the protocol
+is deliberately simple so that C programs (or anything with a protobuf
+library) can speak it directly.
+
+The authoritative message definitions live in
+[`tailtalk-proto/proto/tailtalk.proto`](../tailtalk-proto/proto/tailtalk.proto).
+For C, generate bindings with [protobuf-c](https://github.com/protobuf-c/protobuf-c)
+or [nanopb](https://jpa.kapsi.fi/nanopb/).
+
+## Transports and framing
+
+The daemon listens on a SOCK_STREAM **Unix domain socket** (default
+`/tmp/tailtalkd.sock`, `--unix PATH`) and/or **UDP** (`--udp ADDR:PORT`).
+
+Every message is **varint-length-delimited**: a LEB128 varint carrying the
+encoded length, followed by that many bytes of protobuf message. This is the
+same framing as protobuf-java's `writeDelimitedTo` / prost's
+`encode_length_delimited`.
+
+* On the Unix stream, messages are concatenated back to back.
+* On UDP, each datagram holds one or more *complete* messages; a message may
+  not span datagrams.
+* Messages over 65535 encoded bytes are rejected.
+
+Clients send `Request`; the daemon sends `ServerMessage`, which is either a
+`Reply` or an unsolicited `ReceivedDatagram`.
+
+## Correlation
+
+`Request.id` is client-chosen. Non-zero ids get exactly one `Reply` with the
+same id. **Id 0 means fire-and-forget** — the daemon executes the request but
+never replies, which is the intended mode for `SendDatagram`. Replies carry
+either a result kind (`Ok`, `ListInterfacesReply`, `OpenSocketReply`,
+`ListRoutesReply`) or an `Error { code, message }`.
+
+## Sessions
+
+All DDP sockets a client opens belong to its session and are closed
+automatically when the session ends:
+
+* **Unix**: the session is the connection. Closing it frees everything.
+* **UDP**: the session is keyed by the client's source address and expires
+  after **300 s** without traffic. Send `PingRequest` (e.g. every 30 s) to
+  keep it alive. There is no explicit close; just stop talking.
+
+## Operations
+
+| Request | Reply | Notes |
+|---|---|---|
+| `ListInterfacesRequest` | `ListInterfacesReply` | Name, type (EtherTalk/LocalTalk), current AppleTalk address of each interface. |
+| `SetAddressRequest` | `Ok` | Force an interface's address (no probe). LocalTalk: network must be 0, node 1-254. Reprograms TashTalk node bits on LocalTalk. |
+| `OpenSocketRequest` | `OpenSocketReply` | `socket` 1-254 or 0 for dynamic (64-254); `ddp_type` stamps outbound datagrams (2=NBP, 3=ATP, 4=AEP, 7=ADSP, …). `ERROR_CODE_ADDR_IN_USE` if taken — socket numbers are one namespace shared by all sessions. |
+| `CloseSocketRequest` | `Ok` | Frees the socket number. |
+| `SendDatagram` | `Ok` (usually sent with id 0) | Max 586-byte payload. Best-effort, like DDP: errors after acceptance are not reported. |
+| — | `ReceivedDatagram` (unsolicited) | Delivered for any open socket: source/dest address+socket, DDP type, payload. `dest.node == 255` marks broadcasts. |
+| `ListRoutesRequest` | `ListRoutesReply` | Routes (cable range → next-hop router), zone→range mappings, and the local cable range. |
+| `AddRouteRequest`, `RemoveRouteRequest`, `AddZoneRequest`, `RemoveZoneRequest`, `SetLocalRangeRequest` | `Ok` | Modify the daemon's routing rules. Affects DDP forwarding for every client. |
+| — | `routes_changed` (unsolicited `ListRoutesReply`) | Broadcast to every session whenever the rules change — by any client or the daemon itself. Carries the complete new rule set; replace any cached copy with it. |
+| `PingRequest` | `Ok` | Keepalive / liveness. |
+
+## A minimal client, step by step
+
+1. Connect to the Unix socket (or bind a UDP socket and remember to ping).
+2. `ListInterfacesRequest` → learn your interfaces and current addresses.
+3. `OpenSocketRequest { socket: 0, ddp_type: 3 }` → get e.g. socket 129.
+4. Send: `Request { id: 0, send: SendDatagram { socket_id: 129, dest: {network: 0, node: 255}, dest_socket: 2, payload: … } }`.
+5. Read `ServerMessage`s in a loop: replies resolve your pending requests,
+   `ReceivedDatagram`s are inbound traffic for your sockets.
+
+## Semantics worth knowing
+
+* **The daemon owns the routing layer** — it fills the role of the old Linux
+  AppleTalk kernel module. Clients name a destination network/node/socket
+  and the daemon picks the path: it resolves the link-level next hop (the
+  destination itself when it is on a local cable or unknown, otherwise the
+  responsible router from the route table), then transmits on whichever
+  interface reaches that hop — LocalTalk for hops on network 0, EtherTalk
+  (with AARP resolution) otherwise. Network 0 addresses the local cable;
+  `{0, 255}` broadcasts on every interface. Routing rules are shared,
+  daemon-global state: a change made by one client affects forwarding for
+  all, and every session is notified via `routes_changed`. Clients never
+  need their own routing logic; TailTalk stacks in remote mode keep only a
+  passive cache of the rules (for NBP zone dispatch), synchronized by these
+  pushes.
+* **Well-known sockets are first come, first served.** A full TailTalk stack
+  in remote mode binds NBP (2) and AEP (4); a second such stack on the same
+  daemon will fail to build. Plain DDP/ATP/ADSP clients with dynamic sockets
+  coexist freely.
+* **Interface addresses are acquired before serving starts** (AARP probe on
+  EtherTalk, LLAP ENQ on LocalTalk), so `ListInterfacesReply` normally always
+  carries addresses. After `SetAddressRequest` the daemon answers AARP/LLAP
+  for the new address immediately.
+
+## Running the daemon
+
+```sh
+# LocalTalk via TashTalk, Unix socket at the default path
+tailtalkd --localtalk /dev/ttyUSB0
+
+# EtherTalk (build with --features ethertalk), plus UDP for remote clients
+tailtalkd --ethernet en0 --udp 0.0.0.0:1954
+
+# Static routing rules, fixed node address
+tailtalkd --localtalk /dev/ttyUSB0 --localtalk-node 129 \
+          --local-range 100-105 --route 200-210=100.1 --zone 'Engineering=200-210'
+```
+
+And a TailTalk client:
+
+```rust
+let stack = TalkStack::builder()
+    .daemon_unix("/tmp/tailtalkd.sock")
+    .build()
+    .await?;
+// Everything above DDP (NBP, ATP, ADSP, ASP, AFP, PAP…) works unchanged.
+```

--- a/examples/afp-server/main.rs
+++ b/examples/afp-server/main.rs
@@ -19,6 +19,16 @@ struct Args {
     /// TashTalk serial port path (LocalTalk)
     #[arg(short, long)]
     tashtalk: Option<String>,
+
+    /// Unix socket path of a running tailtalkd to use instead of
+    /// handling the interfaces in-process
+    #[cfg(unix)]
+    #[arg(short, long, conflicts_with_all = ["interface", "tashtalk", "daemon_udp"])]
+    daemon: Option<PathBuf>,
+
+    /// UDP address of a running tailtalkd (e.g. 127.0.0.1:1954)
+    #[arg(long, conflicts_with_all = ["interface", "tashtalk", "daemon"])]
+    daemon_udp: Option<std::net::SocketAddr>,
 }
 
 #[tokio::main]
@@ -32,8 +42,15 @@ async fn main() {
 
     let args = Args::parse();
 
-    if args.interface.is_none() && args.tashtalk.is_none() {
-        eprintln!("error: at least one of --interface or --tashtalk is required");
+    if args.interface.is_none()
+        && args.tashtalk.is_none()
+        && {
+            #[cfg(unix)] { args.daemon.is_none() }
+            #[cfg(not(unix))] { true }
+        }
+        && args.daemon_udp.is_none()
+    {
+        eprintln!("error: at least one of --interface, --tashtalk, --daemon or --daemon-udp is required");
         std::process::exit(1);
     }
 
@@ -43,6 +60,13 @@ async fn main() {
     }
     if let Some(ref tty) = args.tashtalk {
         builder = builder.localtalk(tty);
+    }
+    #[cfg(unix)]
+    if let Some(ref sock) = args.daemon {
+        builder = builder.daemon_unix(sock);
+    }
+    if let Some(addr) = args.daemon_udp {
+        builder = builder.daemon_udp(addr);
     }
     let stack = builder.build().await.expect("failed to build AppleTalk stack");
 
@@ -55,7 +79,16 @@ async fn main() {
         .await
         .expect("failed to spawn AFP server");
 
-    let transport = args.interface.as_deref().unwrap_or("LocalTalk");
+    let mut transport = "LocalTalk".to_string();
+    if let Some(intf) = &args.interface {
+        transport = intf.clone();
+    } else if let Some(addr) = &args.daemon_udp {
+        transport = format!("daemon at {addr}");
+    }
+    #[cfg(unix)]
+    if let Some(sock) = &args.daemon {
+        transport = format!("daemon at {}", sock.display());
+    }
     tracing::info!("AFP server serving {:?} on {}", args.path, transport);
     tracing::info!("Press Ctrl+C to exit");
 

--- a/tailtalk-daemon/Cargo.toml
+++ b/tailtalk-daemon/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "tailtalk-daemon"
+version.workspace = true
+edition = "2024"
+license-file = "../LICENSE"
+description = "AppleTalk underlay daemon (AARP/DDP) serving the TailTalk protobuf API"
+authors = ["FeralFirmware"]
+repository = "https://github.com/feralfirmware/tailtalk"
+
+[[bin]]
+name = "tailtalkd"
+path = "src/main.rs"
+
+[lib]
+name = "tailtalk_daemon"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = { workspace = true } #unified
+clap = { workspace = true } #unified
+prost = { workspace = true } #unified
+tailtalk = { workspace = true } #unified
+tailtalk-packets = { workspace = true } #unified
+tailtalk-proto = { workspace = true } #unified
+tashtalk = { workspace = true } #unified
+tokio = { workspace = true } #unified
+tokio-util = { version = "0.7", features = ["codec"] }
+futures = { workspace = true }
+tracing = { workspace = true } #unified
+tracing-subscriber = { version = "^0.3", features = ["env-filter"] }
+
+[features]
+ethertalk = ["tailtalk/ethertalk"]
+
+[dev-dependencies]
+tempfile = "3.13"

--- a/tailtalk-daemon/src/lib.rs
+++ b/tailtalk-daemon/src/lib.rs
@@ -1,0 +1,779 @@
+//! Server implementation for `tailtalkd`, the TailTalk underlay daemon.
+//!
+//! The daemon owns the physical AppleTalk interfaces and runs AARP/LLAP
+//! addressing plus DDP in-process, serving clients over the protobuf
+//! protocol defined in the `tailtalk-proto` crate.
+
+use std::collections::HashMap;
+#[cfg(unix)]
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::Context;
+use tailtalk::addressing::AddressingHandle;
+use tailtalk::ddp::{DdpAddress, DdpHandle, DdpSocket, DdpSocketSender};
+use tailtalk::route_table::RouteTable;
+use tailtalk::{CancellationToken, TalkStack};
+use tailtalk_packets::aarp::AppleTalkAddress;
+use tailtalk_packets::ddp::DdpProtocolType;
+use tailtalk_proto as proto;
+use tokio::sync::{broadcast, mpsc};
+
+/// UDP sessions expire after this long without any traffic from the client.
+const UDP_SESSION_TIMEOUT: Duration = Duration::from_secs(300);
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Default, Clone)]
+pub struct DaemonConfig {
+    /// EtherTalk network interface name (requires the `ethertalk` feature).
+    pub ethernet: Option<String>,
+    /// Fixed EtherTalk address; probes via AARP when `None`.
+    pub ethernet_address: Option<(u16, u8)>,
+    /// LocalTalk TashTalk serial device path.
+    pub localtalk: Option<String>,
+    /// Fixed LocalTalk node number; probes via LLAP ENQ when `None`.
+    pub localtalk_node: Option<u8>,
+    /// LocalTalk pcap capture path.
+    pub pcap: Option<PathBuf>,
+}
+
+// ── Daemon state ──────────────────────────────────────────────────────────────
+
+pub struct InterfaceEntry {
+    pub name: String,
+    pub kind: proto::InterfaceType,
+    pub addressing: AddressingHandle,
+}
+
+pub struct DaemonState {
+    pub interfaces: Vec<InterfaceEntry>,
+    pub ddp: DdpHandle,
+    /// The authoritative routing table: DDP outbound routing and interface
+    /// selection happen daemon-side against this table. Clients only cache it.
+    pub route_table: RouteTable,
+    /// Fan-out of routing-rule changes; every session forwards these to its
+    /// client as unsolicited `routes_changed` messages.
+    routes_tx: broadcast::Sender<proto::ListRoutesReply>,
+}
+
+pub struct Daemon {
+    state: Arc<DaemonState>,
+    transport_token: CancellationToken,
+}
+
+impl Daemon {
+    /// Bring up the underlay (interfaces, addressing, DDP) per `config`.
+    pub async fn start(config: DaemonConfig) -> anyhow::Result<Self> {
+        let mut builder = TalkStack::builder();
+
+        if let Some(ref serial) = config.localtalk {
+            builder = builder.localtalk(serial);
+            if let Some(node) = config.localtalk_node {
+                builder = builder.localtalk_fixed_address(node);
+            }
+        }
+
+        #[cfg(feature = "ethertalk")]
+        if let Some(ref intf) = config.ethernet {
+            builder = builder.ethernet(intf);
+            if let Some((net, node)) = config.ethernet_address {
+                builder = builder.fixed_address(net, node);
+            }
+        }
+        #[cfg(not(feature = "ethertalk"))]
+        if config.ethernet.is_some() {
+            anyhow::bail!("this build has no EtherTalk support (rebuild with --features ethertalk)");
+        }
+
+        if let Some(ref path) = config.pcap {
+            builder = builder.pcap_capture(path);
+        }
+
+        let underlay = builder.build_underlay().await?;
+
+        let mut interfaces = Vec::new();
+        #[cfg(feature = "ethertalk")]
+        if let (Some(name), Some(addressing)) =
+            (config.ethernet.clone(), underlay.et_addressing.clone())
+        {
+            interfaces.push(InterfaceEntry {
+                name,
+                kind: proto::InterfaceType::Ethertalk,
+                addressing,
+            });
+        }
+        if let (Some(name), Some(addressing)) =
+            (config.localtalk.clone(), underlay.lt_addressing.clone())
+        {
+            interfaces.push(InterfaceEntry {
+                name,
+                kind: proto::InterfaceType::Localtalk,
+                addressing,
+            });
+        }
+
+        // Broadcast every routing-rule change (from any session, or made
+        // directly on this table) to all connected clients. Changes are
+        // coalesced: a burst produces one snapshot broadcast.
+        let (routes_tx, _) = broadcast::channel(16);
+        let (change_tx, mut change_rx) = mpsc::unbounded_channel();
+        underlay.route_table.set_publisher(change_tx);
+        {
+            let table = underlay.route_table.clone();
+            let routes_tx = routes_tx.clone();
+            tokio::spawn(async move {
+                while change_rx.recv().await.is_some() {
+                    while change_rx.try_recv().is_ok() {}
+                    let _ = routes_tx.send(routes_to_proto(&table));
+                }
+            });
+        }
+
+        Ok(Self {
+            state: Arc::new(DaemonState {
+                interfaces,
+                ddp: underlay.ddp,
+                route_table: underlay.route_table,
+                routes_tx,
+            }),
+            transport_token: underlay.transport_token,
+        })
+    }
+
+    pub fn state(&self) -> &DaemonState {
+        &self.state
+    }
+
+    pub fn route_table(&self) -> &RouteTable {
+        &self.state.route_table
+    }
+
+    /// Stop the underlay and all serving tasks.
+    pub fn shutdown(&self) {
+        self.transport_token.cancel();
+    }
+
+    /// Wait until the daemon has been shut down.
+    pub async fn wait_for_shutdown(&self) {
+        self.transport_token.cancelled().await;
+    }
+
+    /// Serve the protocol on a Unix domain socket at `path`.
+    ///
+    /// A stale socket file from a previous run is removed first.
+    #[cfg(unix)]
+    pub fn serve_unix(&self, path: &Path) -> anyhow::Result<()> {
+        if path.exists() {
+            std::fs::remove_file(path)
+                .with_context(|| format!("failed to remove stale socket '{}'", path.display()))?;
+        }
+        let listener = tokio::net::UnixListener::bind(path)
+            .with_context(|| format!("failed to bind unix socket '{}'", path.display()))?;
+        tracing::info!("listening on unix socket {}", path.display());
+
+        let state = self.state.clone();
+        let token = self.transport_token.clone();
+        tokio::spawn(async move {
+            loop {
+                let accepted = tokio::select! {
+                    _ = token.cancelled() => break,
+                    accepted = listener.accept() => accepted,
+                };
+                match accepted {
+                    Ok((stream, _)) => {
+                        tokio::spawn(run_unix_session(state.clone(), stream, token.clone()));
+                    }
+                    Err(e) => {
+                        tracing::error!("unix accept error: {e}");
+                        break;
+                    }
+                }
+            }
+        });
+        Ok(())
+    }
+
+    /// Serve the protocol over UDP. Returns the bound local address.
+    pub async fn serve_udp(&self, addr: std::net::SocketAddr) -> anyhow::Result<std::net::SocketAddr> {
+        let socket = Arc::new(
+            tokio::net::UdpSocket::bind(addr)
+                .await
+                .with_context(|| format!("failed to bind UDP socket {addr}"))?,
+        );
+        let local = socket.local_addr()?;
+        tracing::info!("listening on udp {local}");
+
+        let state = self.state.clone();
+        let token = self.transport_token.clone();
+        tokio::spawn(run_udp_server(state, socket, token));
+        Ok(local)
+    }
+}
+
+// ── Session (transport-independent request handling) ──────────────────────────
+
+/// One open DDP socket owned by a session. Dropping it cancels the pump task,
+/// which drops the underlying `DdpSocket` and deregisters it from DDP.
+struct OpenSocket {
+    outbound: mpsc::Sender<proto::SendDatagram>,
+    cancel: CancellationToken,
+}
+
+impl Drop for OpenSocket {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
+struct Session {
+    state: Arc<DaemonState>,
+    out_tx: mpsc::Sender<proto::ServerMessage>,
+    sockets: HashMap<u8, OpenSocket>,
+}
+
+impl Session {
+    fn new(state: Arc<DaemonState>, out_tx: mpsc::Sender<proto::ServerMessage>) -> Self {
+        Self {
+            state,
+            out_tx,
+            sockets: HashMap::new(),
+        }
+    }
+
+    /// Execute one request. Returns the reply to send, or `None` when the
+    /// request was fire-and-forget (id 0).
+    async fn handle(&mut self, req: proto::Request) -> Option<proto::Reply> {
+        let id = req.id;
+        let reply = match req.kind {
+            None => proto::Reply::error(id, proto::ErrorCode::InvalidArgument, "missing request kind"),
+            Some(kind) => self.dispatch(id, kind).await,
+        };
+        (id != 0).then_some(reply)
+    }
+
+    async fn dispatch(&mut self, id: u64, kind: proto::request::Kind) -> proto::Reply {
+        use proto::request::Kind;
+        match kind {
+            Kind::ListInterfaces(_) => self.list_interfaces(id).await,
+            Kind::SetAddress(r) => self.set_address(id, r).await,
+            Kind::OpenSocket(r) => self.open_socket(id, r).await,
+            Kind::CloseSocket(r) => {
+                match u8::try_from(r.socket_id).ok().and_then(|s| self.sockets.remove(&s)) {
+                    Some(_) => proto::Reply::ok(id),
+                    None => proto::Reply::error(
+                        id,
+                        proto::ErrorCode::NotFound,
+                        format!("socket {} is not open in this session", r.socket_id),
+                    ),
+                }
+            }
+            Kind::Send(r) => self.send_datagram(id, r),
+            Kind::ListRoutes(_) => self.list_routes(id),
+            Kind::AddRoute(r) => self.add_route(id, r),
+            Kind::RemoveRoute(r) => match r.range.and_then(range_from_proto) {
+                Some((lo, hi)) => {
+                    self.state.route_table.remove_route(lo, hi);
+                    proto::Reply::ok(id)
+                }
+                None => invalid(id, "remove_route requires a valid range"),
+            },
+            Kind::AddZone(r) => {
+                let Some(ranges) = r
+                    .ranges
+                    .iter()
+                    .map(|r| range_from_proto(*r))
+                    .collect::<Option<Vec<_>>>()
+                else {
+                    return invalid(id, "zone range out of bounds");
+                };
+                if r.zone.is_empty() {
+                    return invalid(id, "zone name must not be empty");
+                }
+                self.state.route_table.insert_zone(&r.zone, &ranges);
+                proto::Reply::ok(id)
+            }
+            Kind::RemoveZone(r) => {
+                self.state.route_table.remove_zone(&r.zone);
+                proto::Reply::ok(id)
+            }
+            Kind::SetLocalRange(r) => match r.range.and_then(range_from_proto) {
+                Some((lo, hi)) => {
+                    self.state.route_table.set_local_range(lo, hi);
+                    proto::Reply::ok(id)
+                }
+                None => invalid(id, "set_local_range requires a valid range"),
+            },
+            Kind::Ping(_) => proto::Reply::ok(id),
+        }
+    }
+
+    async fn list_interfaces(&self, id: u64) -> proto::Reply {
+        let mut interfaces = Vec::with_capacity(self.state.interfaces.len());
+        for iface in &self.state.interfaces {
+            let address = iface.addressing.addr().await.ok().map(|a| {
+                proto::AppleTalkAddress::new(a.network_number, a.node_number)
+            });
+            interfaces.push(proto::Interface {
+                name: iface.name.clone(),
+                r#type: iface.kind as i32,
+                address,
+            });
+        }
+        proto::Reply::new(
+            id,
+            proto::reply::Kind::Interfaces(proto::ListInterfacesReply { interfaces }),
+        )
+    }
+
+    async fn set_address(&self, id: u64, r: proto::SetAddressRequest) -> proto::Reply {
+        let Some(iface) = self.state.interfaces.iter().find(|i| i.name == r.interface) else {
+            return proto::Reply::error(
+                id,
+                proto::ErrorCode::NotFound,
+                format!("no interface named '{}'", r.interface),
+            );
+        };
+        let Some(addr) = r.address else {
+            return invalid(id, "set_address requires an address");
+        };
+        let (Ok(network), Ok(node)) = (u16::try_from(addr.network), u8::try_from(addr.node)) else {
+            return invalid(id, "address out of range");
+        };
+        if node == 0 || node == 255 {
+            return invalid(id, "node must be 1-254");
+        }
+        if iface.kind == proto::InterfaceType::Localtalk && network != 0 {
+            return invalid(id, "LocalTalk network number must be 0");
+        }
+
+        match iface
+            .addressing
+            .set_addr(AppleTalkAddress {
+                network_number: network,
+                node_number: node,
+            })
+            .await
+        {
+            Ok(()) => proto::Reply::ok(id),
+            Err(e) => proto::Reply::error(id, proto::ErrorCode::Internal, e.to_string()),
+        }
+    }
+
+    async fn open_socket(&mut self, id: u64, r: proto::OpenSocketRequest) -> proto::Reply {
+        let Ok(ddp_type) = u8::try_from(r.ddp_type) else {
+            return invalid(id, "ddp_type must be 0-255");
+        };
+        let requested = match r.socket {
+            0 => None,
+            n @ 1..=254 => Some(n as u8),
+            _ => return invalid(id, "socket must be 0 (dynamic) or 1-254"),
+        };
+
+        let sock = match self
+            .state
+            .ddp
+            .new_sock(DdpProtocolType::from(ddp_type), requested)
+            .await
+        {
+            Ok(sock) => sock,
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                return proto::Reply::error(
+                    id,
+                    proto::ErrorCode::AddrInUse,
+                    format!("DDP socket {} is already bound", r.socket),
+                );
+            }
+            Err(e) => return proto::Reply::error(id, proto::ErrorCode::Internal, e.to_string()),
+        };
+
+        let socket_id = sock.socket_num();
+        let (outbound_tx, outbound_rx) = mpsc::channel(100);
+        let cancel = CancellationToken::new();
+        let send_handle = sock.send_handle();
+        tokio::spawn(socket_pump_inbound(
+            sock,
+            socket_id,
+            self.out_tx.clone(),
+            cancel.clone(),
+        ));
+        tokio::spawn(socket_pump_outbound(
+            send_handle,
+            socket_id,
+            outbound_rx,
+            cancel.clone(),
+        ));
+        self.sockets.insert(
+            socket_id,
+            OpenSocket {
+                outbound: outbound_tx,
+                cancel,
+            },
+        );
+
+        proto::Reply::new(
+            id,
+            proto::reply::Kind::Socket(proto::OpenSocketReply {
+                socket_id: socket_id as u32,
+            }),
+        )
+    }
+
+    fn send_datagram(&self, id: u64, r: proto::SendDatagram) -> proto::Reply {
+        let Some(open) = u8::try_from(r.socket_id).ok().and_then(|s| self.sockets.get(&s)) else {
+            return proto::Reply::error(
+                id,
+                proto::ErrorCode::NotFound,
+                format!("socket {} is not open in this session", r.socket_id),
+            );
+        };
+        if r.payload.len() > 586 {
+            return invalid(id, "DDP payload exceeds 586 bytes");
+        }
+        let socket_id = r.socket_id;
+        // Best-effort, like DDP itself: drop on backpressure rather than
+        // stalling the whole session behind one slow socket.
+        if open.outbound.try_send(r).is_err() {
+            tracing::warn!("socket {socket_id}: outbound queue full, dropping datagram");
+        }
+        proto::Reply::ok(id)
+    }
+
+    fn list_routes(&self, id: u64) -> proto::Reply {
+        proto::Reply::new(
+            id,
+            proto::reply::Kind::Routes(routes_to_proto(&self.state.route_table)),
+        )
+    }
+
+    fn add_route(&self, id: u64, r: proto::AddRouteRequest) -> proto::Reply {
+        let Some(route) = r.route else {
+            return invalid(id, "add_route requires a route");
+        };
+        let Some((lo, hi)) = route.range.and_then(range_from_proto) else {
+            return invalid(id, "route range out of bounds");
+        };
+        let Some(nh) = route.next_hop else {
+            return invalid(id, "add_route requires a next_hop");
+        };
+        let (Ok(network), Ok(node)) = (u16::try_from(nh.network), u8::try_from(nh.node)) else {
+            return invalid(id, "next_hop out of range");
+        };
+        self.state.route_table.insert_route(
+            lo,
+            hi,
+            AppleTalkAddress {
+                network_number: network,
+                node_number: node,
+            },
+        );
+        proto::Reply::ok(id)
+    }
+}
+
+fn invalid(id: u64, msg: &str) -> proto::Reply {
+    proto::Reply::error(id, proto::ErrorCode::InvalidArgument, msg)
+}
+
+fn range_from_proto(r: proto::CableRange) -> Option<(u16, u16)> {
+    let lo = u16::try_from(r.lo).ok()?;
+    let hi = u16::try_from(r.hi).ok()?;
+    (lo <= hi).then_some((lo, hi))
+}
+
+fn range_to_proto((lo, hi): (u16, u16)) -> proto::CableRange {
+    proto::CableRange {
+        lo: lo as u32,
+        hi: hi as u32,
+    }
+}
+
+/// Snapshot the routing table into its wire representation.
+fn routes_to_proto(table: &RouteTable) -> proto::ListRoutesReply {
+    let snapshot = table.snapshot();
+    proto::ListRoutesReply {
+        routes: snapshot
+            .routes
+            .into_iter()
+            .map(|(lo, hi, next_hop)| proto::Route {
+                range: Some(range_to_proto((lo, hi))),
+                next_hop: Some(proto::AppleTalkAddress::new(
+                    next_hop.network_number,
+                    next_hop.node_number,
+                )),
+            })
+            .collect(),
+        zones: snapshot
+            .zones
+            .into_iter()
+            .map(|(name, ranges)| proto::Zone {
+                name,
+                ranges: ranges.into_iter().map(range_to_proto).collect(),
+            })
+            .collect(),
+        local_range: snapshot.local_range.map(range_to_proto),
+    }
+}
+
+/// Turn a route-broadcast receive result into the message to forward, or
+/// `None` when the channel is closed. A lagged receiver recovers by sending
+/// a fresh snapshot (the broadcast payload is always the complete rule set).
+fn routes_broadcast_to_msg(
+    res: Result<proto::ListRoutesReply, broadcast::error::RecvError>,
+    table: &RouteTable,
+) -> Option<proto::ServerMessage> {
+    match res {
+        Ok(reply) => Some(proto::ServerMessage::routes_changed(reply)),
+        Err(broadcast::error::RecvError::Lagged(_)) => {
+            Some(proto::ServerMessage::routes_changed(routes_to_proto(table)))
+        }
+        Err(broadcast::error::RecvError::Closed) => None,
+    }
+}
+
+/// Per-socket inbound task: forwards DDP packets arriving on `sock` to the
+/// session's writer channel. Owns the `DdpSocket`; dropping it deregisters
+/// the socket from DDP. Ends when cancelled or the writer goes away.
+async fn socket_pump_inbound(
+    mut sock: DdpSocket,
+    socket_id: u8,
+    out_tx: mpsc::Sender<proto::ServerMessage>,
+    cancel: CancellationToken,
+) {
+    loop {
+        let pkt = tokio::select! {
+            _ = cancel.cancelled() => break,
+            pkt = sock.recv() => match pkt { Ok(p) => p, Err(_) => break },
+        };
+        let h = &pkt.headers;
+        let datagram = proto::ReceivedDatagram {
+            socket_id: socket_id as u32,
+            source: Some(proto::AppleTalkAddress::new(h.src_network_num, h.src_node_id)),
+            source_socket: h.src_sock_num as u32,
+            dest: Some(proto::AppleTalkAddress::new(h.dest_network_num, h.dest_node_id)),
+            dest_socket: h.dest_sock_num as u32,
+            ddp_type: u8::from(h.protocol_typ) as u32,
+            payload: pkt.payload.into_vec(),
+        };
+        if out_tx.send(proto::ServerMessage::datagram(datagram)).await.is_err() {
+            break;
+        }
+    }
+}
+
+/// Per-socket outbound task: forwards `SendDatagram`s from the client to DDP.
+/// Runs independently of inbound delivery so slow LocalTalk writes don't
+/// stall packet reception.
+async fn socket_pump_outbound(
+    sender: DdpSocketSender,
+    socket_id: u8,
+    mut outbound: mpsc::Receiver<proto::SendDatagram>,
+    cancel: CancellationToken,
+) {
+    loop {
+        let send = tokio::select! {
+            _ = cancel.cancelled() => break,
+            msg = outbound.recv() => match msg { Some(s) => s, None => break },
+        };
+        let Some(dest) = send.dest else {
+            tracing::warn!("socket {socket_id}: dropping datagram with no destination");
+            continue;
+        };
+        let addr = DdpAddress::new(
+            AppleTalkAddress {
+                network_number: dest.network as u16,
+                node_number: dest.node as u8,
+            },
+            send.dest_socket as u8,
+        );
+        if let Err(e) = sender.send_to(&send.payload, addr).await {
+            tracing::warn!("socket {socket_id}: send failed: {e}");
+        }
+    }
+}
+
+// ── Unix transport ────────────────────────────────────────────────────────────
+
+#[cfg(unix)]
+async fn run_unix_session(
+    state: Arc<DaemonState>,
+    stream: tokio::net::UnixStream,
+    token: CancellationToken,
+) {
+    let (read_half, write_half) = stream.into_split();
+    let framed_read = tokio_util::codec::FramedRead::new(read_half, proto::TailTalkCodec::<proto::ServerMessage, proto::Request>::default());
+    let framed_write = tokio_util::codec::FramedWrite::new(write_half, proto::TailTalkCodec::<proto::ServerMessage, proto::Request>::default());
+    let (out_tx, out_rx) = mpsc::channel::<proto::ServerMessage>(256);
+    tokio::spawn(unix_writer(framed_write, out_rx));
+
+    let mut session = Session::new(state, out_tx);
+    let mut routes_rx = session.state.routes_tx.subscribe();
+    tokio::pin!(framed_read);
+    use futures::StreamExt;
+    loop {
+        let msg = tokio::select! {
+            _ = token.cancelled() => break,
+            changed = routes_rx.recv() => {
+                match routes_broadcast_to_msg(changed, &session.state.route_table) {
+                    Some(msg) => {
+                        if session.out_tx.send(msg).await.is_err() {
+                            break;
+                        }
+                        continue;
+                    }
+                    None => break,
+                }
+            }
+            msg = framed_read.next() => msg.transpose(),
+        };
+        match msg {
+            Ok(Some(req)) => {
+                if let Some(reply) = session.handle(req).await
+                    && session
+                        .out_tx
+                        .send(proto::ServerMessage::reply(reply))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+            }
+            Ok(None) => break, // client hung up
+            Err(e) => {
+                tracing::warn!("client protocol error: {e}");
+                break;
+            }
+        }
+    }
+    // Dropping the session cancels every socket pump, which deregisters the
+    // session's DDP sockets.
+}
+
+#[cfg(unix)]
+async fn unix_writer(
+    mut write_half: tokio_util::codec::FramedWrite<tokio::net::unix::OwnedWriteHalf, proto::TailTalkCodec<proto::ServerMessage, proto::Request>>,
+    mut out_rx: mpsc::Receiver<proto::ServerMessage>,
+) {
+    use futures::SinkExt;
+    while let Some(msg) = out_rx.recv().await {
+        if write_half.send(msg).await.is_err() {
+            break;
+        }
+    }
+}
+
+// ── UDP transport ─────────────────────────────────────────────────────────────
+
+struct UdpSessionHandle {
+    req_tx: mpsc::Sender<proto::Request>,
+    last_seen: Instant,
+}
+
+async fn run_udp_server(
+    state: Arc<DaemonState>,
+    socket: Arc<tokio::net::UdpSocket>,
+    token: CancellationToken,
+) {
+    let mut sessions: HashMap<std::net::SocketAddr, UdpSessionHandle> = HashMap::new();
+    let mut buf = vec![0u8; proto::MAX_MESSAGE_LEN + 8];
+    let mut sweep = tokio::time::interval(Duration::from_secs(60));
+    sweep.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = token.cancelled() => break,
+            _ = sweep.tick() => {
+                sessions.retain(|peer, s| {
+                    let live = s.last_seen.elapsed() < UDP_SESSION_TIMEOUT;
+                    if !live {
+                        tracing::info!("udp session {peer} expired");
+                    }
+                    live
+                });
+            }
+            res = socket.recv_from(&mut buf) => {
+                let (n, peer) = match res {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::error!("udp receive error: {e}");
+                        continue;
+                    }
+                };
+                let requests = match proto::decode_datagram::<proto::Request>(&buf[..n]) {
+                    Ok(msgs) => msgs,
+                    Err(e) => {
+                        tracing::warn!("bad datagram from {peer}: {e}");
+                        continue;
+                    }
+                };
+                let session = sessions.entry(peer).or_insert_with(|| {
+                    tracing::info!("new udp session from {peer}");
+                    spawn_udp_session(state.clone(), socket.clone(), peer)
+                });
+                session.last_seen = Instant::now();
+                for req in requests {
+                    if session.req_tx.try_send(req).is_err() {
+                        tracing::warn!("udp session {peer}: request queue full, dropping");
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn spawn_udp_session(
+    state: Arc<DaemonState>,
+    socket: Arc<tokio::net::UdpSocket>,
+    peer: std::net::SocketAddr,
+) -> UdpSessionHandle {
+    let (req_tx, mut req_rx) = mpsc::channel::<proto::Request>(256);
+    let (out_tx, mut out_rx) = mpsc::channel::<proto::ServerMessage>(256);
+
+    tokio::spawn(async move {
+        while let Some(msg) = out_rx.recv().await {
+            if let Err(e) = socket.send_to(&proto::encode_frame(&msg), peer).await {
+                tracing::warn!("udp send to {peer} failed: {e}");
+                break;
+            }
+        }
+    });
+
+    tokio::spawn(async move {
+        let mut session = Session::new(state, out_tx);
+        let mut routes_rx = session.state.routes_tx.subscribe();
+        loop {
+            tokio::select! {
+                changed = routes_rx.recv() => {
+                    match routes_broadcast_to_msg(changed, &session.state.route_table) {
+                        Some(msg) => {
+                            if session.out_tx.send(msg).await.is_err() {
+                                break;
+                            }
+                        }
+                        None => break,
+                    }
+                }
+                req = req_rx.recv() => {
+                    let Some(req) = req else { break };
+                    if let Some(reply) = session.handle(req).await
+                        && session
+                            .out_tx
+                            .send(proto::ServerMessage::reply(reply))
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                }
+            }
+        }
+        // Session dropped: all its DDP sockets are deregistered.
+    });
+
+    UdpSessionHandle {
+        req_tx,
+        last_seen: Instant::now(),
+    }
+}

--- a/tailtalk-daemon/src/main.rs
+++ b/tailtalk-daemon/src/main.rs
@@ -1,0 +1,194 @@
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+use clap::Parser;
+use tailtalk_daemon::{Daemon, DaemonConfig};
+use tailtalk_packets::aarp::AppleTalkAddress;
+
+/// TailTalk AppleTalk underlay daemon.
+///
+/// Owns the EtherTalk / LocalTalk interfaces (AARP, LLAP, DDP) and serves
+/// them to clients over a varint-delimited protobuf protocol on a Unix
+/// domain socket and/or UDP. See tailtalk-proto/proto/tailtalk.proto for the
+/// wire protocol.
+#[derive(Parser, Debug)]
+#[command(name = "tailtalkd", version, about)]
+struct Cli {
+    /// EtherTalk network interface (e.g. en0). Requires an 'ethertalk' build.
+    #[arg(long)]
+    ethernet: Option<String>,
+
+    /// Fixed EtherTalk address as NET.NODE (e.g. 1.42) instead of AARP probing.
+    #[arg(long, value_parser = parse_address)]
+    ethernet_address: Option<AddressArg>,
+
+    /// LocalTalk TashTalk serial device (e.g. /dev/ttyUSB0).
+    #[arg(long)]
+    localtalk: Option<String>,
+
+    /// Fixed LocalTalk node number (1-254) instead of LLAP probing.
+    #[arg(long)]
+    localtalk_node: Option<u8>,
+
+    /// Unix socket path to listen on.
+    #[cfg(unix)]
+    #[arg(long, default_value = "/tmp/tailtalkd.sock")]
+    unix: PathBuf,
+
+    /// Do not listen on the Unix socket.
+    #[cfg(unix)]
+    #[arg(long)]
+    no_unix: bool,
+
+    /// UDP address to listen on (e.g. 127.0.0.1:1954).
+    #[arg(long)]
+    udp: Option<SocketAddr>,
+
+    /// Write a LocalTalk pcap capture to this path.
+    #[arg(long)]
+    pcap: Option<PathBuf>,
+
+    /// Cable range of the local segment, as LO-HI (e.g. 100-105).
+    #[arg(long, value_parser = parse_range)]
+    local_range: Option<RangeArg>,
+
+    /// Static route as LO-HI=NET.NODE (repeatable).
+    #[arg(long = "route", value_parser = parse_route)]
+    routes: Vec<RouteArg>,
+
+    /// Zone mapping as NAME=LO-HI[,LO-HI...] (repeatable).
+    #[arg(long = "zone", value_parser = parse_zone)]
+    zones: Vec<ZoneArg>,
+}
+
+#[derive(Debug, Clone)]
+struct AddressArg(u16, u8);
+
+#[derive(Debug, Clone)]
+struct RangeArg(u16, u16);
+
+#[derive(Debug, Clone)]
+struct RouteArg(u16, u16, u16, u8);
+
+#[derive(Debug, Clone)]
+struct ZoneArg(String, Vec<(u16, u16)>);
+
+fn parse_address(s: &str) -> Result<AddressArg, String> {
+    let (net, node) = s
+        .split_once('.')
+        .ok_or_else(|| format!("expected NET.NODE, got '{s}'"))?;
+    Ok(AddressArg(
+        net.parse().map_err(|_| format!("bad network number '{net}'"))?,
+        node.parse().map_err(|_| format!("bad node number '{node}'"))?,
+    ))
+}
+
+fn parse_range(s: &str) -> Result<RangeArg, String> {
+    let (lo, hi) = s
+        .split_once('-')
+        .ok_or_else(|| format!("expected LO-HI, got '{s}'"))?;
+    let lo: u16 = lo.parse().map_err(|_| format!("bad range start '{lo}'"))?;
+    let hi: u16 = hi.parse().map_err(|_| format!("bad range end '{hi}'"))?;
+    if lo > hi {
+        return Err(format!("range start {lo} is greater than end {hi}"));
+    }
+    Ok(RangeArg(lo, hi))
+}
+
+fn parse_route(s: &str) -> Result<RouteArg, String> {
+    let (range, addr) = s
+        .split_once('=')
+        .ok_or_else(|| format!("expected LO-HI=NET.NODE, got '{s}'"))?;
+    let RangeArg(lo, hi) = parse_range(range)?;
+    let AddressArg(net, node) = parse_address(addr)?;
+    Ok(RouteArg(lo, hi, net, node))
+}
+
+fn parse_zone(s: &str) -> Result<ZoneArg, String> {
+    let (name, ranges) = s
+        .split_once('=')
+        .ok_or_else(|| format!("expected NAME=LO-HI[,LO-HI...], got '{s}'"))?;
+    if name.is_empty() {
+        return Err("zone name must not be empty".to_string());
+    }
+    let ranges = ranges
+        .split(',')
+        .map(|r| parse_range(r).map(|RangeArg(lo, hi)| (lo, hi)))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(ZoneArg(name.to_string(), ranges))
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let cli = Cli::parse();
+
+    if cli.ethernet.is_none() && cli.localtalk.is_none() {
+        tracing::warn!("no interfaces configured; serving an empty underlay (use --ethernet / --localtalk)");
+    }
+    #[cfg(unix)]
+    if cli.no_unix && cli.udp.is_none() {
+        anyhow::bail!("nothing to serve: --no-unix given and no --udp address");
+    }
+    #[cfg(not(unix))]
+    if cli.udp.is_none() {
+        anyhow::bail!("nothing to serve: no --udp address (Unix sockets are unsupported on Windows)");
+    }
+
+    let daemon = Daemon::start(DaemonConfig {
+        ethernet: cli.ethernet,
+        ethernet_address: cli.ethernet_address.map(|AddressArg(net, node)| (net, node)),
+        localtalk: cli.localtalk,
+        localtalk_node: cli.localtalk_node,
+        pcap: cli.pcap,
+    })
+    .await?;
+
+    // Static routing rules from the command line. Clients can inspect and
+    // modify these later through the API.
+    let table = daemon.route_table();
+    if let Some(RangeArg(lo, hi)) = cli.local_range {
+        table.set_local_range(lo, hi);
+    }
+    for RouteArg(lo, hi, net, node) in &cli.routes {
+        table.insert_route(
+            *lo,
+            *hi,
+            AppleTalkAddress {
+                network_number: *net,
+                node_number: *node,
+            },
+        );
+    }
+    for ZoneArg(name, ranges) in &cli.zones {
+        table.insert_zone(name, ranges);
+    }
+
+    #[cfg(unix)]
+    if !cli.no_unix {
+        daemon.serve_unix(&cli.unix)?;
+    }
+    if let Some(addr) = cli.udp {
+        daemon.serve_udp(addr).await?;
+    }
+
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            tracing::info!("shutting down");
+            daemon.shutdown();
+        }
+        _ = daemon.wait_for_shutdown() => {}
+    }
+
+    #[cfg(unix)]
+    if !cli.no_unix {
+        let _ = std::fs::remove_file(&cli.unix);
+    }
+    Ok(())
+}

--- a/tailtalk-daemon/tests/integration.rs
+++ b/tailtalk-daemon/tests/integration.rs
@@ -1,0 +1,464 @@
+//! End-to-end tests: a daemon with an empty underlay served over Unix/UDP
+#![cfg(unix)]
+//! sockets, exercised both by a raw protobuf client (as a C client would)
+//! and by a full `TalkStack` in remote-daemon mode.
+
+use std::time::Duration;
+
+use tailtalk::TalkStack;
+use tailtalk::route_table::NextHop;
+use tailtalk_daemon::{Daemon, DaemonConfig};
+use tailtalk_packets::aarp::AppleTalkAddress;
+use tailtalk_packets::ddp::DdpProtocolType;
+use tailtalk_proto as proto;
+#[cfg(unix)]
+use tokio::net::UnixStream;
+use futures::StreamExt;
+
+fn addr(net: u16, node: u8) -> AppleTalkAddress {
+    AppleTalkAddress {
+        network_number: net,
+        node_number: node,
+    }
+}
+
+async fn start_daemon() -> (Daemon, tempfile::TempDir, std::path::PathBuf) {
+    let daemon = Daemon::start(DaemonConfig::default()).await.unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("tailtalkd.sock");
+    daemon.serve_unix(&path).unwrap();
+    (daemon, dir, path)
+}
+
+/// Send one request and wait for its correlated reply, skipping any
+/// interleaved datagrams.
+async fn request(
+    stream: &mut tokio_util::codec::Framed<UnixStream, proto::TailTalkCodec<proto::Request, proto::ServerMessage>>,
+    id: u64,
+    kind: proto::request::Kind,
+) -> proto::reply::Kind {
+    use futures::{SinkExt, StreamExt};
+    let req = proto::Request { id, kind: Some(kind) };
+    stream.send(req).await.unwrap();
+    loop {
+        let msg: proto::ServerMessage = stream.next()
+            .await
+            .unwrap()
+            .expect("daemon closed connection");
+        if let Some(proto::server_message::Kind::Reply(reply)) = msg.kind {
+            assert_eq!(reply.id, id, "reply correlation id mismatch");
+            return reply.kind.unwrap();
+        }
+    }
+}
+
+fn expect_ok(kind: proto::reply::Kind) {
+    assert!(
+        matches!(kind, proto::reply::Kind::Ok(_)),
+        "expected Ok reply, got {kind:?}"
+    );
+}
+
+#[tokio::test]
+async fn control_plane_over_unix_socket() {
+    let (_daemon, _dir, path) = start_daemon().await;
+    let stream = UnixStream::connect(&path).await.unwrap();
+    let mut stream = tokio_util::codec::Framed::new(stream, proto::TailTalkCodec::default());
+
+    // No interfaces configured on this daemon.
+    let kind = request(
+        &mut stream,
+        1,
+        proto::request::Kind::ListInterfaces(proto::ListInterfacesRequest {}),
+    )
+    .await;
+    let proto::reply::Kind::Interfaces(reply) = kind else {
+        panic!("expected interfaces reply");
+    };
+    assert!(reply.interfaces.is_empty());
+
+    // Ping round-trips.
+    expect_ok(request(&mut stream, 2, proto::request::Kind::Ping(proto::PingRequest {})).await);
+
+    // Setting an address on a nonexistent interface reports NotFound.
+    let kind = request(
+        &mut stream,
+        3,
+        proto::request::Kind::SetAddress(proto::SetAddressRequest {
+            interface: "en99".into(),
+            address: Some(proto::AppleTalkAddress::new(1, 42)),
+        }),
+    )
+    .await;
+    let proto::reply::Kind::Error(err) = kind else {
+        panic!("expected error reply");
+    };
+    assert_eq!(err.code, proto::ErrorCode::NotFound as i32);
+}
+
+#[tokio::test]
+async fn ddp_socket_lifecycle() {
+    let (_daemon, _dir, path) = start_daemon().await;
+    let stream = UnixStream::connect(&path).await.unwrap();
+    let mut stream = tokio_util::codec::Framed::new(stream, proto::TailTalkCodec::<proto::Request, proto::ServerMessage>::default());
+
+    // Dynamic socket allocation lands in the dynamic range.
+    let kind = request(
+        &mut stream,
+        1,
+        proto::request::Kind::OpenSocket(proto::OpenSocketRequest { socket: 0, ddp_type: 3 }),
+    )
+    .await;
+    let proto::reply::Kind::Socket(reply) = kind else {
+        panic!("expected socket reply");
+    };
+    assert!((64..=254).contains(&reply.socket_id));
+
+    // A specific socket number is honoured...
+    let kind = request(
+        &mut stream,
+        2,
+        proto::request::Kind::OpenSocket(proto::OpenSocketRequest { socket: 100, ddp_type: 3 }),
+    )
+    .await;
+    let proto::reply::Kind::Socket(reply) = kind else {
+        panic!("expected socket reply");
+    };
+    assert_eq!(reply.socket_id, 100);
+
+    // ...and taken even from a second concurrent session.
+    let stream2 = UnixStream::connect(&path).await.unwrap();
+    let mut stream2 = tokio_util::codec::Framed::new(stream2, proto::TailTalkCodec::<proto::Request, proto::ServerMessage>::default());
+    let kind = request(
+        &mut stream2,
+        1,
+        proto::request::Kind::OpenSocket(proto::OpenSocketRequest { socket: 100, ddp_type: 3 }),
+    )
+    .await;
+    let proto::reply::Kind::Error(err) = kind else {
+        panic!("expected AddrInUse error");
+    };
+    assert_eq!(err.code, proto::ErrorCode::AddrInUse as i32);
+
+    // Sending on an open socket succeeds (delivery is best-effort: with no
+    // interfaces the daemon drops the packet, exactly like local mode).
+    expect_ok(
+        request(
+            &mut stream,
+            3,
+            proto::request::Kind::Send(proto::SendDatagram {
+                socket_id: 100,
+                dest: Some(proto::AppleTalkAddress::new(0, 255)),
+                dest_socket: 2,
+                payload: vec![1, 2, 3],
+            }),
+        )
+        .await,
+    );
+
+    // Close and reopen from the other session: the number is free again.
+    expect_ok(
+        request(
+            &mut stream,
+            4,
+            proto::request::Kind::CloseSocket(proto::CloseSocketRequest { socket_id: 100 }),
+        )
+        .await,
+    );
+    // Deregistration runs in a background pump task; poll briefly.
+    let mut reopened = false;
+    for attempt in 0..50u64 {
+        let kind = request(
+            &mut stream2,
+            10 + attempt,
+            proto::request::Kind::OpenSocket(proto::OpenSocketRequest { socket: 100, ddp_type: 3 }),
+        )
+        .await;
+        if matches!(kind, proto::reply::Kind::Socket(_)) {
+            reopened = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(reopened, "socket 100 was not released after CloseSocket");
+
+    // Session teardown releases sockets too: drop session 2 and reopen 100.
+    drop(stream2);
+    let mut reopened = false;
+    for attempt in 0..50u64 {
+        let kind = request(
+            &mut stream,
+            100 + attempt,
+            proto::request::Kind::OpenSocket(proto::OpenSocketRequest { socket: 100, ddp_type: 3 }),
+        )
+        .await;
+        if matches!(kind, proto::reply::Kind::Socket(_)) {
+            reopened = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(reopened, "socket 100 was not released after session close");
+}
+
+#[tokio::test]
+async fn routing_rules_over_unix_socket() {
+    let (daemon, _dir, path) = start_daemon().await;
+    let stream = UnixStream::connect(&path).await.unwrap();
+    let mut stream = tokio_util::codec::Framed::new(stream, proto::TailTalkCodec::default());
+
+    expect_ok(
+        request(
+            &mut stream,
+            1,
+            proto::request::Kind::SetLocalRange(proto::SetLocalRangeRequest {
+                range: Some(proto::CableRange { lo: 100, hi: 105 }),
+            }),
+        )
+        .await,
+    );
+    expect_ok(
+        request(
+            &mut stream,
+            2,
+            proto::request::Kind::AddRoute(proto::AddRouteRequest {
+                route: Some(proto::Route {
+                    range: Some(proto::CableRange { lo: 200, hi: 210 }),
+                    next_hop: Some(proto::AppleTalkAddress::new(100, 1)),
+                }),
+            }),
+        )
+        .await,
+    );
+    expect_ok(
+        request(
+            &mut stream,
+            3,
+            proto::request::Kind::AddZone(proto::AddZoneRequest {
+                zone: "Engineering".into(),
+                ranges: vec![proto::CableRange { lo: 200, hi: 210 }],
+            }),
+        )
+        .await,
+    );
+
+    // The rules are visible over the API...
+    let kind = request(
+        &mut stream,
+        4,
+        proto::request::Kind::ListRoutes(proto::ListRoutesRequest {}),
+    )
+    .await;
+    let proto::reply::Kind::Routes(routes) = kind else {
+        panic!("expected routes reply");
+    };
+    assert_eq!(routes.local_range, Some(proto::CableRange { lo: 100, hi: 105 }));
+    assert_eq!(routes.routes.len(), 1);
+    assert_eq!(routes.zones.len(), 1);
+    assert_eq!(routes.zones[0].name, "Engineering");
+
+    // ...and actually applied to the daemon's forwarding table.
+    assert_eq!(
+        daemon.route_table().route_for(205),
+        Some(NextHop::Via(addr(100, 1)))
+    );
+
+    // Remove and verify.
+    expect_ok(
+        request(
+            &mut stream,
+            5,
+            proto::request::Kind::RemoveRoute(proto::RemoveRouteRequest {
+                range: Some(proto::CableRange { lo: 200, hi: 210 }),
+            }),
+        )
+        .await,
+    );
+    assert_eq!(daemon.route_table().route_for(205), None);
+}
+
+#[tokio::test]
+async fn route_changes_are_pushed_to_all_clients() {
+    let (daemon, _dir, path) = start_daemon().await;
+
+    // Client B just sits connected, never asking for routes.
+    let watch_stream = UnixStream::connect(&path).await.unwrap();
+    let mut watcher = tokio_util::codec::Framed::new(watch_stream, proto::TailTalkCodec::<proto::Request, proto::ServerMessage>::default());
+    // Client A modifies the rules.
+    let editor = UnixStream::connect(&path).await.unwrap();
+    let mut editor = tokio_util::codec::Framed::new(editor, proto::TailTalkCodec::<proto::Request, proto::ServerMessage>::default());
+    expect_ok(
+        request(
+            &mut editor,
+            1,
+            proto::request::Kind::AddRoute(proto::AddRouteRequest {
+                route: Some(proto::Route {
+                    range: Some(proto::CableRange { lo: 200, hi: 210 }),
+                    next_hop: Some(proto::AppleTalkAddress::new(100, 1)),
+                }),
+            }),
+        )
+        .await,
+    );
+
+    // The watcher receives an unsolicited routes_changed broadcast.
+    let push = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let msg: proto::ServerMessage =
+                watcher.next().await.unwrap().unwrap();
+            if let Some(proto::server_message::Kind::RoutesChanged(routes)) = msg.kind {
+                return routes;
+            }
+        }
+    })
+    .await
+    .expect("no routes_changed push received");
+    assert_eq!(push.routes.len(), 1);
+    assert_eq!(
+        push.routes[0].next_hop,
+        Some(proto::AppleTalkAddress::new(100, 1))
+    );
+
+    // Changes made directly on the daemon (e.g. its CLI) are pushed too.
+    daemon.route_table().set_local_range(10, 15);
+    let push = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let msg: proto::ServerMessage =
+                watcher.next().await.unwrap().unwrap();
+            if let Some(proto::server_message::Kind::RoutesChanged(routes)) = msg.kind
+                && routes.local_range.is_some()
+            {
+                return routes;
+            }
+        }
+    })
+    .await
+    .expect("no routes_changed push for daemon-side change");
+    assert_eq!(push.local_range, Some(proto::CableRange { lo: 10, hi: 15 }));
+}
+
+#[tokio::test]
+async fn talkstack_mirror_follows_daemon_changes() {
+    let (daemon, _dir, path) = start_daemon().await;
+    let stack = TalkStack::builder().daemon_unix(&path).build().await.unwrap();
+
+    // A rule added on the daemon after the client connected shows up in the
+    // client's route table via the push channel — no RPC from the client.
+    daemon.route_table().insert_route(200, 210, addr(100, 1));
+    let mut synced = false;
+    for _ in 0..100 {
+        if stack.route_table.route_for(205) == Some(NextHop::Via(addr(100, 1))) {
+            synced = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(synced, "daemon route change did not reach the client mirror");
+
+    // And a daemon-side removal disappears from the client too.
+    daemon.route_table().remove_route(200, 210);
+    let mut synced = false;
+    for _ in 0..100 {
+        if stack.route_table.route_for(205).is_none() {
+            synced = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(synced, "daemon route removal did not reach the client mirror");
+}
+
+#[tokio::test]
+async fn talkstack_remote_mode_over_unix() {
+    let (daemon, _dir, path) = start_daemon().await;
+
+    // Rules configured on the daemon before the client connects…
+    daemon.route_table().insert_route(200, 210, addr(100, 1));
+
+    let stack = TalkStack::builder().daemon_unix(&path).build().await.unwrap();
+
+    // …are mirrored into the client's route table at build time.
+    assert_eq!(
+        stack.route_table.route_for(205),
+        Some(NextHop::Via(addr(100, 1)))
+    );
+
+    // Client-side modifications propagate back to the daemon.
+    stack.route_table.insert_route(300, 310, addr(100, 2));
+    let mut synced = false;
+    for _ in 0..100 {
+        if daemon.route_table().route_for(305) == Some(NextHop::Via(addr(100, 2))) {
+            synced = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(synced, "client route change did not reach the daemon");
+
+    // The stack's DDP layer transparently opens sockets on the daemon.
+    let sock = stack.ddp.new_sock(DdpProtocolType::Atp, Some(42)).await.unwrap();
+    assert_eq!(sock.socket_num(), 42);
+
+    // NBP and AEP grabbed their well-known sockets (2 and 4) on the daemon:
+    // a raw client asking for them gets AddrInUse.
+    let stream = UnixStream::connect(&path).await.unwrap();
+    let mut stream = tokio_util::codec::Framed::new(stream, proto::TailTalkCodec::default());
+    for (id, well_known) in [(1u64, 2u32), (2, 4)] {
+        let kind = request(
+            &mut stream,
+            id,
+            proto::request::Kind::OpenSocket(proto::OpenSocketRequest {
+                socket: well_known,
+                ddp_type: 2,
+            }),
+        )
+        .await;
+        assert!(
+            matches!(&kind, proto::reply::Kind::Error(e) if e.code == proto::ErrorCode::AddrInUse as i32),
+            "expected socket {well_known} to be held by the remote stack, got {kind:?}"
+        );
+    }
+
+    // Dropping the client socket releases it on the daemon.
+    drop(sock);
+    let mut released = false;
+    for attempt in 0..50u64 {
+        let kind = request(
+            &mut stream,
+            10 + attempt,
+            proto::request::Kind::OpenSocket(proto::OpenSocketRequest { socket: 42, ddp_type: 3 }),
+        )
+        .await;
+        if matches!(kind, proto::reply::Kind::Socket(_)) {
+            released = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(released, "dropped client socket was not released on the daemon");
+}
+
+#[tokio::test]
+async fn talkstack_remote_mode_over_udp() {
+    let daemon = Daemon::start(DaemonConfig::default()).await.unwrap();
+    let local = daemon
+        .serve_udp("127.0.0.1:0".parse().unwrap())
+        .await
+        .unwrap();
+
+    let stack = TalkStack::builder().daemon_udp(local).build().await.unwrap();
+
+    let sock = stack.ddp.new_sock(DdpProtocolType::Adsp, None).await.unwrap();
+    assert!((64..=254).contains(&sock.socket_num()));
+
+    stack.route_table.set_local_range(50, 55);
+    let mut synced = false;
+    for _ in 0..100 {
+        if daemon.route_table().is_local(52) {
+            synced = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(synced, "local range change did not reach the daemon over UDP");
+}

--- a/tailtalk-gui/ipp_bridge.rs
+++ b/tailtalk-gui/ipp_bridge.rs
@@ -207,6 +207,7 @@ fn make_key(name: &str) -> String {
         .to_string()
 }
 
+#[allow(dead_code)]
 fn urf_string(caps: &PrinterCaps) -> String {
     // CP1 = sRGB profile 1 (required by AirPrint spec; CP255 is not valid).
     // We always advertise SRGB24 so iOS sends colour jobs; ghostscript converts to mono.
@@ -933,7 +934,7 @@ async fn urf_to_rasterizable(data: Vec<u8>, job_token: u32) -> anyhow::Result<Ve
     tokio::fs::write(&urf_path, &data).await?;
 
     #[cfg(target_os = "macos")]
-    let result: anyhow::Result<Vec<u8>> = {
+    return {
         let pdf_path = tmp.join(format!("tailtalk-{job_token}.pdf"));
         let status = tokio::process::Command::new("sips")
             .args(["--setProperty", "format", "pdf"])
@@ -952,7 +953,7 @@ async fn urf_to_rasterizable(data: Vec<u8>, job_token: u32) -> anyhow::Result<Ve
     };
 
     #[cfg(target_os = "linux")]
-    let result: anyhow::Result<Vec<u8>> = {
+    return {
         // ippeveps converts URF → PostScript; gs accepts PS from a file just as well as PDF.
         let output = tokio::process::Command::new("ippeveps")
             .arg(&urf_path)
@@ -970,12 +971,10 @@ async fn urf_to_rasterizable(data: Vec<u8>, job_token: u32) -> anyhow::Result<Ve
     // should never reach here because URF is not advertised in the mDNS record on Windows,
     // but guard against it explicitly.
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    let result: anyhow::Result<Vec<u8>> = {
+    {
         let _ = tokio::fs::remove_file(&urf_path).await;
         anyhow::bail!("URF format is not supported on this platform");
-    };
-
-    result
+    }
 }
 
 /// Return the name of the Ghostscript executable on this platform.

--- a/tailtalk-proto/Cargo.toml
+++ b/tailtalk-proto/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tailtalk-proto"
+version.workspace = true
+edition = "2024"
+license-file = "../LICENSE"
+description = "Protobuf wire protocol for the TailTalk AppleTalk daemon"
+authors = ["FeralFirmware"]
+repository = "https://github.com/feralfirmware/tailtalk"
+
+[dependencies]
+prost = { workspace = true } #unified
+tokio = { workspace = true } #unified
+bytes = { workspace = true } #unified
+tokio-util = { version = "0.7", features = ["codec"] }
+
+[build-dependencies]
+prost-build = "0.14"
+protox = "0.9"

--- a/tailtalk-proto/build.rs
+++ b/tailtalk-proto/build.rs
@@ -1,0 +1,6 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let fds = protox::compile(["proto/tailtalk.proto"], ["proto"])?;
+    prost_build::Config::new().compile_fds(fds)?;
+    println!("cargo:rerun-if-changed=proto/tailtalk.proto");
+    Ok(())
+}

--- a/tailtalk-proto/proto/tailtalk.proto
+++ b/tailtalk-proto/proto/tailtalk.proto
@@ -1,0 +1,241 @@
+// TailTalk daemon wire protocol.
+//
+// The daemon (`tailtalkd`) owns the physical AppleTalk interfaces (EtherTalk
+// and/or LocalTalk) and performs AARP/LLAP addressing and DDP send/receive on
+// behalf of its clients. Clients talk to the daemon over a SOCK_STREAM Unix
+// domain socket or over UDP.
+//
+// Framing
+// =======
+// Every message is a varint-length-delimited protobuf message: a LEB128
+// varint holding the encoded message length, immediately followed by that
+// many bytes of message body (the same framing produced by
+// `writeDelimitedTo` in protobuf-java and `encode_length_delimited` in
+// prost).
+//
+//   * Unix stream socket: messages are simply concatenated on the stream.
+//   * UDP: each datagram carries one or more complete delimited messages.
+//     A message may not span datagrams.
+//
+// Clients send `Request`, the daemon sends `ServerMessage` (a `Reply`
+// correlated by `Request.id`, an unsolicited `ReceivedDatagram` for an open
+// socket, or an unsolicited `routes_changed` broadcast). Messages larger
+// than 65535 bytes are rejected.
+//
+// Correlation
+// ===========
+// `Request.id` is chosen by the client. If it is non-zero the daemon sends
+// exactly one `Reply` with the same id. If it is zero the request is
+// fire-and-forget and no reply is sent (typical for `SendDatagram`).
+//
+// Sessions
+// ========
+// All sockets opened by a client belong to its session and are closed when
+// the session ends. A Unix-socket session ends when the connection closes.
+// A UDP session is keyed by the client's source address and expires after
+// 300 seconds without traffic; clients should send `PingRequest`
+// periodically (e.g. every 30 s) to keep the session alive.
+
+syntax = "proto3";
+
+package tailtalk.v1;
+
+// ── Common types ──────────────────────────────────────────────────────────────
+
+// A DDP network/node pair. LocalTalk nodes always have network 0.
+message AppleTalkAddress {
+  uint32 network = 1; // 0-65535
+  uint32 node = 2;    // 0-255
+}
+
+enum InterfaceType {
+  INTERFACE_TYPE_UNSPECIFIED = 0;
+  INTERFACE_TYPE_ETHERTALK = 1;
+  INTERFACE_TYPE_LOCALTALK = 2;
+}
+
+message Interface {
+  // Stable identifier: the OS network interface name for EtherTalk
+  // ("en0"), or the serial device path for LocalTalk ("/dev/ttyUSB0").
+  string name = 1;
+  InterfaceType type = 2;
+  // The interface's current AppleTalk address, once acquired.
+  AppleTalkAddress address = 3;
+}
+
+// An inclusive range of network numbers (an AppleTalk cable range).
+message CableRange {
+  uint32 lo = 1;
+  uint32 hi = 2;
+}
+
+// ── Interface management ──────────────────────────────────────────────────────
+
+message ListInterfacesRequest {}
+
+message ListInterfacesReply {
+  repeated Interface interfaces = 1;
+}
+
+// Force an interface to a specific AppleTalk address. No probe is performed;
+// the caller is responsible for avoiding conflicts. For LocalTalk the
+// network must be 0 and the node 1-254.
+message SetAddressRequest {
+  string interface = 1;
+  AppleTalkAddress address = 2;
+}
+
+// ── DDP sockets ───────────────────────────────────────────────────────────────
+
+message OpenSocketRequest {
+  // Requested DDP socket number 1-254, or 0 to let the daemon pick one
+  // from the dynamic range (64-254).
+  uint32 socket = 1;
+  // DDP protocol type stamped on outbound datagrams from this socket
+  // (1=RTMP response, 2=NBP, 3=ATP, 4=AEP, 5=RTMP request, 6=ZIP, 7=ADSP).
+  uint32 ddp_type = 2;
+}
+
+message OpenSocketReply {
+  // The DDP socket number that was bound; use it as `socket_id` in
+  // SendDatagram / CloseSocketRequest and to match ReceivedDatagram.
+  uint32 socket_id = 1;
+}
+
+message CloseSocketRequest {
+  uint32 socket_id = 1;
+}
+
+// Client → daemon datagram. Usually sent with Request.id = 0.
+message SendDatagram {
+  uint32 socket_id = 1;
+  AppleTalkAddress dest = 2;
+  uint32 dest_socket = 3; // destination DDP socket number
+  bytes payload = 4;      // max 586 bytes
+}
+
+// Daemon → client datagram, delivered for any open socket.
+message ReceivedDatagram {
+  uint32 socket_id = 1; // the local socket this arrived on
+  AppleTalkAddress source = 2;
+  uint32 source_socket = 3;
+  // Destination as seen in the DDP header; node 255 indicates a broadcast.
+  AppleTalkAddress dest = 4;
+  uint32 dest_socket = 5;
+  uint32 ddp_type = 6;
+  bytes payload = 7;
+}
+
+// ── Routing rules ─────────────────────────────────────────────────────────────
+
+message Route {
+  CableRange range = 1;
+  // Router on the local segment that forwards traffic for `range`.
+  AppleTalkAddress next_hop = 2;
+}
+
+message Zone {
+  string name = 1;
+  repeated CableRange ranges = 2;
+}
+
+message ListRoutesRequest {}
+
+message ListRoutesReply {
+  repeated Route routes = 1;
+  repeated Zone zones = 2;
+  // Cable range of our own segment, if configured.
+  CableRange local_range = 3;
+}
+
+message AddRouteRequest {
+  Route route = 1;
+}
+
+message RemoveRouteRequest {
+  // Must match an existing route's range exactly.
+  CableRange range = 1;
+}
+
+message AddZoneRequest {
+  string zone = 1;
+  repeated CableRange ranges = 2;
+}
+
+message RemoveZoneRequest {
+  string zone = 1;
+}
+
+message SetLocalRangeRequest {
+  CableRange range = 1;
+}
+
+// ── Session keepalive ─────────────────────────────────────────────────────────
+
+message PingRequest {}
+
+// ── Envelopes ─────────────────────────────────────────────────────────────────
+
+// Every client → daemon message.
+message Request {
+  // Correlation id. Non-zero: the daemon replies once with the same id.
+  // Zero: fire-and-forget, no reply (success or failure).
+  uint64 id = 1;
+
+  oneof kind {
+    ListInterfacesRequest list_interfaces = 2;
+    SetAddressRequest set_address = 3;
+    OpenSocketRequest open_socket = 4;
+    CloseSocketRequest close_socket = 5;
+    SendDatagram send = 6;
+    ListRoutesRequest list_routes = 7;
+    AddRouteRequest add_route = 8;
+    RemoveRouteRequest remove_route = 9;
+    AddZoneRequest add_zone = 10;
+    RemoveZoneRequest remove_zone = 11;
+    SetLocalRangeRequest set_local_range = 12;
+    PingRequest ping = 13;
+  }
+}
+
+enum ErrorCode {
+  ERROR_CODE_UNSPECIFIED = 0;
+  ERROR_CODE_INVALID_ARGUMENT = 1; // malformed or out-of-range field
+  ERROR_CODE_NOT_FOUND = 2;        // unknown interface / socket / route
+  ERROR_CODE_ADDR_IN_USE = 3;      // requested DDP socket already bound
+  ERROR_CODE_INTERNAL = 4;
+}
+
+message Error {
+  ErrorCode code = 1;
+  string message = 2;
+}
+
+// Empty success reply for requests that return no data.
+message Ok {}
+
+message Reply {
+  uint64 id = 1; // matches Request.id
+
+  oneof kind {
+    Error error = 2;
+    Ok ok = 3;
+    ListInterfacesReply interfaces = 4;
+    OpenSocketReply socket = 5;
+    ListRoutesReply routes = 6;
+  }
+}
+
+// Every daemon → client message.
+message ServerMessage {
+  oneof kind {
+    Reply reply = 1;
+    ReceivedDatagram datagram = 2;
+    // Unsolicited: the daemon's routing rules changed (by any client, or by
+    // the daemon itself). Carries the complete new rule set and is sent to
+    // every connected session. Routing is owned by the daemon — clients that
+    // cache rules (e.g. for NBP zone dispatch) should replace their cache
+    // with this.
+    ListRoutesReply routes_changed = 3;
+  }
+}

--- a/tailtalk-proto/src/lib.rs
+++ b/tailtalk-proto/src/lib.rs
@@ -1,0 +1,232 @@
+//! Wire protocol for the TailTalk daemon (`tailtalkd`).
+//!
+//! Message types are generated from `proto/tailtalk.proto`; see that file for
+//! the protocol documentation (framing, correlation, session semantics).
+//! This crate also provides the varint-delimited framing helpers used by both
+//! the daemon and the in-process client.
+
+use bytes::{Buf, BytesMut};
+use prost::Message;
+use std::marker::PhantomData;
+use tokio_util::codec::{Decoder, Encoder};
+
+mod generated {
+    include!(concat!(env!("OUT_DIR"), "/tailtalk.v1.rs"));
+}
+
+pub use generated::*;
+pub use prost;
+
+/// Largest accepted encoded message, matching the limit documented in the
+/// .proto file. Far above any legal DDP payload (586 bytes) plus overhead.
+pub const MAX_MESSAGE_LEN: usize = 65_535;
+
+/// Encode `msg` varint-length-delimited into a fresh buffer.
+pub fn encode_frame(msg: &impl Message) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(msg.encoded_len() + 4);
+    msg.encode_length_delimited(&mut buf)
+        .expect("Vec<u8> write cannot fail");
+    buf
+}
+
+pub struct TailTalkCodec<In, Out>(PhantomData<(In, Out)>);
+
+impl<In, Out> Default for TailTalkCodec<In, Out> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<In: Message, Out> Encoder<In> for TailTalkCodec<In, Out> {
+    type Error = std::io::Error;
+
+    fn encode(&mut self, item: In, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        item.encode_length_delimited(dst)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+    }
+}
+
+impl<In, Out: Message + Default> Decoder for TailTalkCodec<In, Out> {
+    type Item = Out;
+    type Error = std::io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        let mut len: usize = 0;
+        let mut shift = 0u32;
+        let mut prefix_len = 0;
+
+        // Decode the LEB128 length prefix
+        loop {
+            if prefix_len >= src.len() {
+                return Ok(None);
+            }
+            let byte = src[prefix_len];
+            prefix_len += 1;
+
+            len |= ((byte & 0x7f) as usize) << shift;
+            if byte & 0x80 == 0 {
+                break;
+            }
+            shift += 7;
+            if shift > 28 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "varint length prefix too long",
+                ));
+            }
+        }
+
+        if len > MAX_MESSAGE_LEN {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("frame length {len} exceeds maximum {MAX_MESSAGE_LEN}"),
+            ));
+        }
+
+        if src.len() < prefix_len + len {
+            return Ok(None);
+        }
+
+        src.advance(prefix_len);
+        let payload = src.split_to(len);
+        let msg = Out::decode(payload.freeze())
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+        Ok(Some(msg))
+    }
+}
+
+/// Decode all varint-length-delimited messages packed into one datagram.
+///
+/// Used for the UDP transport, where a datagram carries one or more complete
+/// frames. Trailing garbage or a truncated frame is an error.
+pub fn decode_datagram<M: Message + Default>(mut buf: &[u8]) -> std::io::Result<Vec<M>> {
+    let mut out = Vec::new();
+    while !buf.is_empty() {
+        let msg = M::decode_length_delimited(&mut buf)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        out.push(msg);
+    }
+    Ok(out)
+}
+
+impl AppleTalkAddress {
+    pub fn new(network: u16, node: u8) -> Self {
+        Self {
+            network: network as u32,
+            node: node as u32,
+        }
+    }
+}
+
+impl Reply {
+    /// Convenience constructor for a reply carrying the given kind.
+    pub fn new(id: u64, kind: reply::Kind) -> Self {
+        Self {
+            id,
+            kind: Some(kind),
+        }
+    }
+
+    /// A generic success reply.
+    pub fn ok(id: u64) -> Self {
+        Self::new(id, reply::Kind::Ok(Ok {}))
+    }
+
+    /// An error reply.
+    pub fn error(id: u64, code: ErrorCode, message: impl Into<String>) -> Self {
+        Self::new(
+            id,
+            reply::Kind::Error(Error {
+                code: code as i32,
+                message: message.into(),
+            }),
+        )
+    }
+}
+
+impl ServerMessage {
+    pub fn reply(reply: Reply) -> Self {
+        Self {
+            kind: Some(server_message::Kind::Reply(reply)),
+        }
+    }
+
+    pub fn datagram(datagram: ReceivedDatagram) -> Self {
+        Self {
+            kind: Some(server_message::Kind::Datagram(datagram)),
+        }
+    }
+
+    pub fn routes_changed(routes: ListRoutesReply) -> Self {
+        Self {
+            kind: Some(server_message::Kind::RoutesChanged(routes)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_request() -> Request {
+        Request {
+            id: 42,
+            kind: Some(request::Kind::Send(SendDatagram {
+                socket_id: 129,
+                dest: Some(AppleTalkAddress::new(1, 7)),
+                dest_socket: 2,
+                payload: vec![0xAA; 100],
+            })),
+        }
+    }
+
+    #[test]
+    fn frame_roundtrip_stream() {
+        let req = sample_request();
+        let mut buf = BytesMut::new();
+        let mut codec = TailTalkCodec::<Request, Request>::default();
+
+        codec.encode(req.clone(), &mut buf).unwrap();
+        codec.encode(req.clone(), &mut buf).unwrap();
+
+        let a = codec.decode(&mut buf).unwrap().unwrap();
+        let b = codec.decode(&mut buf).unwrap().unwrap();
+        
+        assert_eq!(a, req);
+        assert_eq!(b, req);
+        assert!(codec.decode(&mut buf).unwrap().is_none());
+    }
+
+    #[test]
+    fn truncated_frame_awaits_more_data() {
+        let req = sample_request();
+        let mut buf = BytesMut::new();
+        let mut codec = TailTalkCodec::<Request, Request>::default();
+
+        codec.encode(req, &mut buf).unwrap();
+        buf.truncate(buf.len() - 1);
+
+        // Decoding incomplete frame returns Ok(None) to wait for more data.
+        assert!(codec.decode(&mut buf).unwrap().is_none());
+    }
+
+    #[test]
+    fn datagram_roundtrip() {
+        let req = sample_request();
+        let mut buf = encode_frame(&req);
+        buf.extend_from_slice(&encode_frame(&req));
+        let msgs: Vec<Request> = decode_datagram(&buf).unwrap();
+        assert_eq!(msgs, vec![req.clone(), req]);
+    }
+
+    #[test]
+    fn oversize_frame_rejected() {
+        // Hand-craft a frame claiming a 1 MiB body.
+        let buf = [0x80u8, 0x80, 0x40, 0x00];
+        let mut bytes = BytesMut::from(&buf[..]);
+        let mut codec = TailTalkCodec::<Request, Request>::default();
+        let res = codec.decode(&mut bytes);
+        assert!(res.is_err());
+    }
+}

--- a/tailtalk/Cargo.toml
+++ b/tailtalk/Cargo.toml
@@ -26,6 +26,7 @@ pcap = { version = "2", features = ["capture-stream"], optional = true }
 rand = "0.10"
 sled = "0.34"
 tailtalk-packets = { workspace = true } #unified
+tailtalk-proto = { workspace = true } #unified
 tashtalk = { workspace = true } #unified
 tokio = { workspace = true, features = ["io-util"] } #unified
 tokio-serial = "5.4.4"

--- a/tailtalk/src/addressing.rs
+++ b/tailtalk/src/addressing.rs
@@ -4,9 +4,10 @@ use rand::RngExt;
 use std::sync::Arc;
 use std::{io::Error, time::Duration};
 use tailtalk_packets::aarp::*;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio_util::sync::{CancellationToken, DropGuard};
 
+use crate::remote::RemoteClient;
 use crate::{DataLinkPacket, DataLinkProtocol, OutboundHandle};
 
 #[derive(Debug, Copy, Clone)]
@@ -25,9 +26,15 @@ struct SelfAddress {
     chan: oneshot::Sender<AppleTalkAddress>,
 }
 
+struct SetAddress {
+    addr: AppleTalkAddress,
+    chan: oneshot::Sender<()>,
+}
+
 enum AarpCommand {
     Lookup(AarpRequest),
     OurAddr(SelfAddress),
+    SetAddr(SetAddress),
 }
 
 pub struct Addressing {
@@ -41,6 +48,9 @@ pub struct Addressing {
     our_mac: Option<EthernetMac>,
     phase: AddressSource,
     cancel: CancellationToken,
+    /// Publishes the settled address (and later changes via `SetAddr`) so the
+    /// data link layer can react, e.g. reprogram TashTalk node ID bits.
+    addr_tx: watch::Sender<Option<AppleTalkAddress>>,
 }
 
 impl Addressing {
@@ -80,6 +90,7 @@ impl Addressing {
         let (packet_send, packet_recv) = mpsc::channel(100);
         let (lt_ack_send, lt_ack_recv) = mpsc::channel(16);
         let (lt_enq_send, lt_enq_recv) = mpsc::channel(16);
+        let (addr_tx, addr_rx) = watch::channel(None);
         let cache = Arc::new(DashMap::new());
         let token = CancellationToken::new();
         let handle_token = token.clone();
@@ -95,18 +106,22 @@ impl Addressing {
             our_mac,
             phase,
             outbound,
+            addr_tx,
         };
 
         tokio::spawn(async move { us.run(fixed_addr).await });
 
         AddressingHandle {
-            _cancel: Arc::new(handle_token.drop_guard()),
-            request_send,
-            packet_send,
-            lt_ack_send,
-            lt_enq_send,
-            cache,
             phase,
+            inner: AddressingInner::Local {
+                _cancel: Arc::new(handle_token.drop_guard()),
+                request_send,
+                packet_send,
+                lt_ack_send,
+                lt_enq_send,
+                addr_watch: addr_rx,
+                cache,
+            },
         }
     }
 
@@ -148,7 +163,7 @@ impl Addressing {
     }
 
     async fn run(mut self, fixed_addr: Option<AppleTalkAddress>) {
-        let our_addr = if self.our_mac.is_none() {
+        let mut our_addr = if self.our_mac.is_none() {
             // LocalTalk: probe via LLAP ENQ. Send ENQ with dst=tentative, src=tentative;
             // if any node ACKs within 10 ms the address is taken — pick a new one and retry.
             let mut node_num = fixed_addr
@@ -234,6 +249,7 @@ impl Addressing {
         };
 
         // Main event loop — address is now settled.
+        let _ = self.addr_tx.send(Some(our_addr));
         loop {
             tokio::select! {
                 pkt = self.packet_recv.recv() => {
@@ -288,6 +304,16 @@ impl Addressing {
                             AarpCommand::OurAddr(req) => {
                                 req.chan.send(our_addr).expect("failed to send our_addr");
                             },
+                            AarpCommand::SetAddr(req) => {
+                                tracing::info!(
+                                    "addressing: address changed to {}.{}",
+                                    req.addr.network_number,
+                                    req.addr.node_number
+                                );
+                                our_addr = req.addr;
+                                let _ = self.addr_tx.send(Some(our_addr));
+                                let _ = req.chan.send(());
+                            },
                         }
                     }
                 }
@@ -334,28 +360,67 @@ impl Addressing {
     }
 }
 
+/// Handle to interface addressing.
 #[derive(Clone)]
 pub struct AddressingHandle {
-    request_send: mpsc::Sender<AarpCommand>,
-    packet_send: mpsc::Sender<(AarpPacket, AddressSource)>,
-    lt_ack_send: mpsc::Sender<u8>,
-    lt_enq_send: mpsc::Sender<u8>,
-    cache: Arc<DashMap<AppleTalkAddress, Node>>,
     pub phase: AddressSource,
-    _cancel: Arc<DropGuard>,
+    inner: AddressingInner,
+}
+
+#[derive(Clone)]
+enum AddressingInner {
+    Local {
+        request_send: mpsc::Sender<AarpCommand>,
+        packet_send: mpsc::Sender<(AarpPacket, AddressSource)>,
+        lt_ack_send: mpsc::Sender<u8>,
+        lt_enq_send: mpsc::Sender<u8>,
+        addr_watch: watch::Receiver<Option<AppleTalkAddress>>,
+        cache: Arc<DashMap<AppleTalkAddress, Node>>,
+        _cancel: Arc<DropGuard>,
+    },
+    Remote {
+        client: RemoteClient,
+        /// Daemon-side interface name this handle queries.
+        interface: String,
+    },
 }
 
 impl AddressingHandle {
+    /// Create a handle backed by a remote daemon's interface.
+    pub(crate) fn remote(client: RemoteClient, interface: String, phase: AddressSource) -> Self {
+        Self {
+            phase,
+            inner: AddressingInner::Remote { client, interface },
+        }
+    }
+
+    /// Watch the settled interface address; `None` until acquisition completes.
+    ///
+    /// Only available for locally-owned interfaces (used by the data link
+    /// layer to reprogram hardware when the address changes).
+    pub fn addr_watch(&self) -> Option<watch::Receiver<Option<AppleTalkAddress>>> {
+        match &self.inner {
+            AddressingInner::Local { addr_watch, .. } => Some(addr_watch.clone()),
+            AddressingInner::Remote { .. } => None,
+        }
+    }
+
     pub fn received_llap_ack(&self, src_node: u8) {
-        let _ = self.lt_ack_send.try_send(src_node);
+        if let AddressingInner::Local { lt_ack_send, .. } = &self.inner {
+            let _ = lt_ack_send.try_send(src_node);
+        }
     }
 
     pub fn received_llap_enq(&self, dst_node: u8) {
-        let _ = self.lt_enq_send.try_send(dst_node);
+        if let AddressingInner::Local { lt_enq_send, .. } = &self.inner {
+            let _ = lt_enq_send.try_send(dst_node);
+        }
     }
 
     pub fn learn(&self, addr: AppleTalkAddress, node: Node) {
-        self.cache.insert(addr, node);
+        if let AddressingInner::Local { cache, .. } = &self.inner {
+            cache.insert(addr, node);
+        }
     }
 
     pub fn try_lookup(&self, addr: &AppleTalkAddress) -> Option<Node> {
@@ -376,7 +441,11 @@ impl AddressingHandle {
             return Some(Node::LocalTalk(addr.node_number));
         }
 
-        self.cache.get(addr).map(|v| *v)
+        match &self.inner {
+            AddressingInner::Local { cache, .. } => cache.get(addr).map(|v| *v),
+            // Link-layer resolution happens inside the daemon.
+            AddressingInner::Remote { .. } => None,
+        }
     }
 
     pub async fn lookup(&self, addr: AppleTalkAddress) -> Result<Node, Error> {
@@ -384,11 +453,21 @@ impl AddressingHandle {
             return Ok(mac);
         }
 
+        let request_send = match &self.inner {
+            AddressingInner::Local { request_send, .. } => request_send,
+            AddressingInner::Remote { .. } => {
+                return Err(Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    "link-layer lookup is performed by the daemon",
+                ));
+            }
+        };
+
         let (tx, rx) = oneshot::channel();
 
         let request = AarpCommand::Lookup(AarpRequest { addr, chan: tx });
 
-        if let Err(e) = self.request_send.send(request).await {
+        if let Err(e) = request_send.send(request).await {
             return Err(Error::other(e));
         }
 
@@ -399,20 +478,53 @@ impl AddressingHandle {
     }
 
     pub async fn addr(&self) -> Result<AppleTalkAddress, Error> {
-        let (tx, rx) = oneshot::channel();
-        let request = AarpCommand::OurAddr(SelfAddress { chan: tx });
+        match &self.inner {
+            AddressingInner::Local { request_send, .. } => {
+                let (tx, rx) = oneshot::channel();
+                let request = AarpCommand::OurAddr(SelfAddress { chan: tx });
 
-        if let Err(e) = self.request_send.send(request).await {
-            return Err(Error::other(e));
+                if let Err(e) = request_send.send(request).await {
+                    return Err(Error::other(e));
+                }
+
+                match rx.await {
+                    Ok(res) => Ok(res),
+                    Err(e) => Err(Error::other(e)),
+                }
+            }
+            AddressingInner::Remote { client, interface } => {
+                client.interface_addr(interface).await
+            }
         }
+    }
 
-        match rx.await {
-            Ok(res) => Ok(res),
-            Err(e) => Err(Error::other(e)),
+    /// Force this interface to the given address, without probing.
+    ///
+    /// On LocalTalk the data link layer reprograms the TashTalk node ID bits
+    /// to match.
+    pub async fn set_addr(&self, addr: AppleTalkAddress) -> Result<(), Error> {
+        match &self.inner {
+            AddressingInner::Local { request_send, .. } => {
+                let (tx, rx) = oneshot::channel();
+                let request = AarpCommand::SetAddr(SetAddress { addr, chan: tx });
+
+                if let Err(e) = request_send.send(request).await {
+                    return Err(Error::other(e));
+                }
+
+                rx.await.map_err(Error::other)
+            }
+            AddressingInner::Remote { client, interface } => {
+                client.set_interface_addr(interface, addr).await
+            }
         }
     }
 
     pub fn received_pkt(&self, pkt: &[u8], source: AddressSource) -> Result<(), Error> {
+        let AddressingInner::Local { cache, packet_send, .. } = &self.inner else {
+            return Ok(());
+        };
+
         let headers = AarpPacket::parse(pkt).unwrap();
 
         let node = match source {
@@ -421,9 +533,9 @@ impl AddressingHandle {
             // AARP is not used on LocalTalk; address assignment uses LLAP ENQ/ACK instead.
             AddressSource::LocalTalk => return Ok(()),
         };
-        self.cache.insert(headers.sender_protocol, node);
+        cache.insert(headers.sender_protocol, node);
 
-        self.packet_send
+        packet_send
             .try_send((headers, source))
             .map_err(Error::other)?;
 

--- a/tailtalk/src/ddp.rs
+++ b/tailtalk/src/ddp.rs
@@ -15,6 +15,7 @@ use tokio::sync::{
 use crate::{
     DataLinkPacket, DataLinkProtocol, OutboundHandle,
     addressing::{Addressing, AddressingHandle, Node},
+    remote::RemoteClient,
     route_table::{NextHop, RouteTable},
 };
 
@@ -45,17 +46,72 @@ struct OutboundPacket {
     payload: Box<[u8]>,
 }
 
+#[derive(Debug, Clone)]
+enum DdpSender {
+    Local(mpsc::Sender<DdpCommand>),
+    Remote(RemoteClient),
+}
+
+/// Clone-able, send-only half of a [`DdpSocket`].
+///
+/// Obtained via [`DdpSocket::send_handle`]. Allows sending datagrams from a
+/// separate task while the socket's receive side lives elsewhere.
+#[derive(Debug, Clone)]
+pub struct DdpSocketSender {
+    sock_num: u8,
+    protocol: DdpProtocolType,
+    sender: DdpSender,
+}
+
+impl DdpSocketSender {
+    pub async fn send_to(&self, buf: &[u8], addr: DdpAddress) -> Result<(), Error> {
+        if buf.len() > 586 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "DDP payload length {} exceeds maximum allowed (586 bytes)",
+                    buf.len()
+                ),
+            ));
+        }
+        match &self.sender {
+            DdpSender::Local(sender) => {
+                let pkt = OutboundPacket {
+                    dest: addr,
+                    payload: buf.into(),
+                    src_sock: self.sock_num,
+                    protocol: self.protocol,
+                };
+                sender.send(DdpCommand::SendPkt(pkt)).await.map_err(|_| {
+                    io::Error::new(io::ErrorKind::BrokenPipe, "DDP processor shut down")
+                })?;
+            }
+            DdpSender::Remote(client) => {
+                client
+                    .send_datagram(self.sock_num, addr.addr, addr.sock, buf)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug)]
 pub struct DdpSocket {
     sock_num: u8,
     protocol: DdpProtocolType,
     receiver: mpsc::Receiver<Packet>,
-    sender: mpsc::Sender<DdpCommand>,
+    sender: DdpSender,
 }
 
 impl Drop for DdpSocket {
     fn drop(&mut self) {
-        let _ = self.sender.try_send(DdpCommand::Deregister(self.sock_num));
+        match &self.sender {
+            DdpSender::Local(sender) => {
+                let _ = sender.try_send(DdpCommand::Deregister(self.sock_num));
+            }
+            DdpSender::Remote(client) => client.close_socket(self.sock_num),
+        }
     }
 }
 
@@ -85,18 +141,38 @@ impl DdpSocket {
             ));
         }
 
-        let pkt = OutboundPacket {
-            dest: addr,
-            payload: buf.into(),
-            src_sock: self.sock_num,
-            protocol: self.protocol,
-        };
-        self.sender
-            .send(DdpCommand::SendPkt(pkt))
-            .await
-            .expect("failed to ddp send");
+        match &self.sender {
+            DdpSender::Local(sender) => {
+                let pkt = OutboundPacket {
+                    dest: addr,
+                    payload: buf.into(),
+                    src_sock: self.sock_num,
+                    protocol: self.protocol,
+                };
+                sender.send(DdpCommand::SendPkt(pkt)).await.map_err(|_| {
+                    io::Error::new(io::ErrorKind::BrokenPipe, "DDP processor shut down")
+                })?;
+            }
+            DdpSender::Remote(client) => {
+                client
+                    .send_datagram(self.sock_num, addr.addr, addr.sock, buf)
+                    .await?;
+            }
+        }
 
         Ok(())
+    }
+
+    /// Return a clone-able send-only handle for this socket.
+    ///
+    /// Use this to send datagrams from a separate task while the receive
+    /// side remains on the original `DdpSocket`.
+    pub fn send_handle(&self) -> DdpSocketSender {
+        DdpSocketSender {
+            sock_num: self.sock_num,
+            protocol: self.protocol,
+            sender: self.sender.clone(),
+        }
     }
 
     pub fn socket_num(&self) -> u8 {
@@ -138,7 +214,7 @@ impl DdpProcessor {
         tokio::spawn(async move { processor.run().await });
 
         DdpHandle {
-            command: command_tx,
+            inner: DdpHandleInner::Local(command_tx),
         }
     }
 
@@ -193,7 +269,7 @@ impl DdpProcessor {
             protocol,
             sock_num,
             receiver: rx,
-            sender: self.command_tx.clone(),
+            sender: DdpSender::Local(self.command_tx.clone()),
         };
 
         self.sockets.insert(sock_num, tx);
@@ -296,31 +372,51 @@ impl DdpProcessor {
             return;
         }
 
-        let dest_node = if packet.dest.addr.network_number == 0 {
+        // Routing happens here, not in the caller: first resolve the
+        // link-level next hop (the destination itself when it is on one of
+        // our cables or unknown, otherwise the responsible router from the
+        // route table), then pick whichever interface reaches that hop.
+        let dest = packet.dest.addr;
+        let hop = if dest.network_number == 0 {
+            // Network 0 is by definition on the local cable.
+            dest
+        } else {
+            match self.route_table.route_for(dest.network_number) {
+                Some(NextHop::Via(router)) => router,
+                // On our cable range, or no route known: try it directly.
+                Some(NextHop::Local) | None => dest,
+            }
+        };
+
+        let dest_node = if hop.network_number == 0 {
             if self.lt_addressing.is_none() {
                 tracing::error!(
-                    "DDP: dropping packet to {}.{} — LocalTalk (network 0) not configured",
-                    packet.dest.addr.network_number,
-                    packet.dest.addr.node_number,
+                    "DDP: dropping packet to {}.{} — next hop {}.{} is on LocalTalk, which is not configured",
+                    dest.network_number, dest.node_number,
+                    hop.network_number, hop.node_number,
                 );
                 return;
             }
-            Node::LocalTalk(packet.dest.addr.node_number)
+            Node::LocalTalk(hop.node_number)
         } else {
             let Some(et) = &self.et_addressing else {
                 tracing::error!(
-                    "DDP: dropping packet to {}.{} — EtherTalk not configured",
-                    packet.dest.addr.network_number,
-                    packet.dest.addr.node_number,
+                    "DDP: dropping packet to {}.{} — next hop {}.{} needs EtherTalk, which is not configured",
+                    dest.network_number, dest.node_number,
+                    hop.network_number, hop.node_number,
                 );
                 return;
             };
-            // If the route table has an explicit via-router for this network,
-            // forward to the router's address instead of resolving the destination directly.
-            let next_hop = self.route_table.route_for(packet.dest.addr.network_number);
-            match next_hop {
-                Some(NextHop::Via(router)) => et.lookup(router).await.expect("unknown router addr"),
-                _ => et.lookup(packet.dest.addr).await.expect("unknown addr"),
+            match et.lookup(hop).await {
+                Ok(node) => node,
+                Err(e) => {
+                    tracing::error!(
+                        "DDP: dropping packet to {}.{} — AARP lookup for next hop {}.{} failed: {e}",
+                        dest.network_number, dest.node_number,
+                        hop.network_number, hop.node_number,
+                    );
+                    return;
+                }
             }
         };
 
@@ -421,43 +517,64 @@ enum DdpCommand {
     Deregister(SockNum),
 }
 
+/// Handle to the DDP layer.
 #[derive(Clone)]
 pub struct DdpHandle {
-    command: mpsc::Sender<DdpCommand>,
+    inner: DdpHandleInner,
+}
+
+#[derive(Clone)]
+enum DdpHandleInner {
+    Local(mpsc::Sender<DdpCommand>),
+    Remote(RemoteClient),
 }
 
 impl DdpHandle {
+    /// Create a handle whose sockets live in a remote daemon.
+    pub(crate) fn remote(client: RemoteClient) -> Self {
+        Self {
+            inner: DdpHandleInner::Remote(client),
+        }
+    }
+
     pub async fn new_sock(
         &self,
         protocol: DdpProtocolType,
         sock_num: Option<SockNum>,
     ) -> Result<DdpSocket, Error> {
-        let (tx, rx) = oneshot::channel();
+        match &self.inner {
+            DdpHandleInner::Local(command) => {
+                let (tx, rx) = oneshot::channel();
 
-        let sock_args = SockArgs {
-            protocol,
-            sock_num,
-            response: tx,
-        };
+                let sock_args = SockArgs {
+                    protocol,
+                    sock_num,
+                    response: tx,
+                };
 
-        self.command
-            .send(DdpCommand::NewSocket(sock_args))
-            .await
-            .expect("failed to send");
+                command
+                    .send(DdpCommand::NewSocket(sock_args))
+                    .await
+                    .expect("failed to send");
 
-        rx.await.expect("no oneshot response")
+                rx.await.expect("no oneshot response")
+            }
+            DdpHandleInner::Remote(client) => {
+                let (sock_num, receiver) = client.open_socket(protocol, sock_num).await?;
+                Ok(DdpSocket {
+                    sock_num,
+                    protocol,
+                    receiver,
+                    sender: DdpSender::Remote(client.clone()),
+                })
+            }
+        }
     }
 
     pub fn received_pkt(&self, pkt: &[u8], source: AppleTalkAddressSource, source_mac: [u8; 6]) {
         if let Ok(headers) = DdpHeaders::parse(pkt) {
             let payload = pkt[DdpHeaders::LEN..headers.len.min(pkt.len())].into();
-
-            let _ = self.command.try_send(DdpCommand::ReceivedPkt(DdpPacket {
-                headers,
-                payload,
-                source,
-                source_mac,
-            }));
+            self.received_parsed_pkt(headers, payload, source, source_mac);
         }
     }
 
@@ -468,11 +585,15 @@ impl DdpHandle {
         source: AppleTalkAddressSource,
         source_mac: [u8; 6],
     ) {
-        let _ = self.command.try_send(DdpCommand::ReceivedPkt(DdpPacket {
-            headers,
-            payload,
-            source,
-            source_mac,
-        }));
+        // Only meaningful when the underlay is in-process; a remote daemon
+        // receives packets from its own interfaces.
+        if let DdpHandleInner::Local(command) = &self.inner {
+            let _ = command.try_send(DdpCommand::ReceivedPkt(DdpPacket {
+                headers,
+                payload,
+                source,
+                source_mac,
+            }));
+        }
     }
 }

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -24,6 +24,7 @@ pub mod ddp;
 pub mod echo;
 pub mod nbp;
 pub mod pap;
+pub mod remote;
 pub mod route_table;
 pub mod stylewriter;
 
@@ -303,6 +304,12 @@ impl PacketProcessor {
             let tx_watch = tashtalk_tx_watch_tx;
 
             tokio::spawn(async move {
+                // Watch for address changes (e.g. via a daemon SetAddress
+                // request) so the TashTalk node ID bits can be reprogrammed.
+                let mut addr_watch = addressing_handle
+                    .addr_watch()
+                    .expect("TashTalk requires locally-owned addressing");
+                let mut addr_watch_alive = true;
                 let mut first_connect = true;
                 loop {
                     // ── Open serial port ────────────────────────────────
@@ -358,6 +365,9 @@ impl PacketProcessor {
                             continue;
                         }
                     }
+                    // The node bits above reflect the current address; don't
+                    // replay an already-seen change notification.
+                    let _ = addr_watch.borrow_and_update();
 
                     // ── Create TX channel for this connection ────────────
                     let (tx, mut tashtalk_rx) = mpsc::channel::<Vec<u8>>(100);
@@ -369,6 +379,24 @@ impl PacketProcessor {
                     loop {
                         tokio::select! {
                             _ = tash_token.cancelled() => return,
+                            changed = addr_watch.changed(), if addr_watch_alive => {
+                                let new_addr = if changed.is_err() {
+                                    addr_watch_alive = false;
+                                    None
+                                } else {
+                                    *addr_watch.borrow_and_update()
+                                };
+                                if let Some(addr) = new_addr {
+                                    let node_id = addr.node_number;
+                                    tracing::info!("TashTalk: address changed, setting node ID bits for node {node_id}");
+                                    let mut node_bits = [0u8; 32];
+                                    node_bits[(node_id / 8) as usize] |= 1 << (node_id % 8);
+                                    if let Err(e) = tashtalk_instance.set_node_ids(node_bits).await {
+                                        tracing::error!("TashTalk set_node_ids failed: {:?}", e);
+                                        break;
+                                    }
+                                }
+                            }
                             frame_opt = tashtalk_rx.recv() => {
                                 if let Some(frame) = frame_opt {
                                     if let Err(e) = tashtalk_instance.send_frame(&frame).await {
@@ -735,7 +763,28 @@ impl TalkStack {
     }
 }
 
+/// The lower half of the stack: interfaces, addressing (AARP/LLAP), DDP and
+/// the routing table — without NBP/AEP services on top.
+///
+/// Produced by [`TalkStackBuilder::build_underlay`]. This is what the
+/// TailTalk daemon (`tailtalkd`) runs to own the interfaces on behalf of
+/// remote clients.
+pub struct Underlay {
+    pub et_addressing: Option<addressing::AddressingHandle>,
+    pub lt_addressing: Option<addressing::AddressingHandle>,
+    pub ddp: ddp::DdpHandle,
+    pub route_table: route_table::RouteTable,
+    /// Cancel to stop the transport (PacketProcessor).
+    pub transport_token: CancellationToken,
+}
+
 /// Builder for [`TalkStack`].
+///
+/// The underlay (AARP/DDP + interfaces) either runs in-process — configure
+/// [`ethernet`](Self::ethernet) and/or [`localtalk`](Self::localtalk) — or in
+/// a separate TailTalk daemon reached via [`daemon_unix`](Self::daemon_unix)
+/// or [`daemon_udp`](Self::daemon_udp). Everything above DDP behaves
+/// identically in both modes.
 pub struct TalkStackBuilder {
     #[cfg(feature = "ethertalk")]
     ethernet_intf: Option<String>,
@@ -745,6 +794,7 @@ pub struct TalkStackBuilder {
     fixed_addr: Option<tailtalk_packets::aarp::AppleTalkAddress>,
     lt_fixed_node: Option<u8>,
     pcap_path: Option<PathBuf>,
+    daemon: Option<remote::DaemonEndpoint>,
 }
 
 impl TalkStack {
@@ -758,6 +808,7 @@ impl TalkStack {
             fixed_addr: None,
             lt_fixed_node: None,
             pcap_path: None,
+            daemon: None,
         }
     }
 }
@@ -808,11 +859,45 @@ impl TalkStackBuilder {
         self
     }
 
-    /// Launch the full AppleTalk stack and return handles to each layer.
+    /// Use a remote TailTalk daemon (reached over a Unix domain socket) as the
+    /// AARP/DDP underlay instead of handling interfaces in this process.
     ///
-    /// Spawns actors for AARP/Addressing, DDP, AEP (Echo), and NBP in dependency
-    /// order, then starts the [`PacketProcessor`] background task.
-    pub async fn build(self) -> Result<TalkStack, Error> {
+    /// Mutually exclusive with [`ethernet`](Self::ethernet) /
+    /// [`localtalk`](Self::localtalk): the daemon owns the interfaces.
+    #[cfg(unix)]
+    pub fn daemon_unix(mut self, path: impl Into<PathBuf>) -> Self {
+        self.daemon = Some(remote::DaemonEndpoint::Unix(path.into()));
+        self
+    }
+
+    /// Use a remote TailTalk daemon reached over UDP as the AARP/DDP underlay.
+    ///
+    /// See [`daemon_unix`](Self::daemon_unix).
+    pub fn daemon_udp(mut self, addr: std::net::SocketAddr) -> Self {
+        self.daemon = Some(remote::DaemonEndpoint::Udp(addr));
+        self
+    }
+
+    fn has_local_transport(&self) -> bool {
+        #[cfg(feature = "ethertalk")]
+        if self.ethernet_intf.is_some() {
+            return true;
+        }
+        self.localtalk_serial_path.is_some()
+    }
+
+    /// Launch only the lower half of the stack: interfaces, AARP/LLAP
+    /// addressing, DDP and the routing table — no NBP or AEP services.
+    ///
+    /// This is what the TailTalk daemon runs; most applications want
+    /// [`build`](Self::build) instead.
+    pub async fn build_underlay(self) -> Result<Underlay, Error> {
+        if self.daemon.is_some() {
+            return Err(anyhow::anyhow!(
+                "build_underlay creates a local underlay; use build() with a daemon endpoint"
+            ));
+        }
+
         let mut pp = PacketProcessor::builder().tashtalk_features(self.tashtalk_features);
         #[cfg(feature = "ethertalk")]
         if let Some(ref intf) = self.ethernet_intf {
@@ -858,12 +943,8 @@ impl TalkStackBuilder {
 
         let route_table = route_table::RouteTable::new(route_table::LearningMode::Static);
         let ddp = ddp::DdpProcessor::spawn(et_addressing.clone(), lt_addressing.clone(), outbound, route_table.clone());
-        let echo = echo::Echo::spawn(&ddp).await;
-        let nbp = nbp::Nbp::spawn(&ddp, et_addressing.clone(), lt_addressing.clone(), route_table.clone()).await;
 
-        let service_token = CancellationToken::new();
         let transport_token = CancellationToken::new();
-        let services_done = CancellationToken::new();
         tokio::spawn(processor.run(et_addressing.clone(), lt_addressing.clone(), ddp.clone(), transport_token.clone()));
 
         // Wait until addressing has settled on all active interfaces.
@@ -872,6 +953,109 @@ impl TalkStackBuilder {
         }
         if let Some(lt) = &lt_addressing {
             lt.addr().await?;
+        }
+
+        Ok(Underlay { et_addressing, lt_addressing, ddp, route_table, transport_token })
+    }
+
+    /// Launch the full AppleTalk stack and return handles to each layer.
+    ///
+    /// With local interfaces, spawns actors for AARP/Addressing, DDP, AEP
+    /// (Echo), and NBP in dependency order, then starts the
+    /// [`PacketProcessor`] background task. With a daemon endpoint, connects
+    /// to the daemon and runs the same AEP/NBP services over its DDP layer.
+    pub async fn build(self) -> Result<TalkStack, Error> {
+        if let Some(endpoint) = self.daemon.clone() {
+            return self.build_remote(endpoint).await;
+        }
+
+        let Underlay { et_addressing, lt_addressing, ddp, route_table, transport_token } =
+            self.build_underlay().await?;
+
+        let echo = echo::Echo::spawn(&ddp).await;
+        let nbp = nbp::Nbp::spawn(&ddp, et_addressing.clone(), lt_addressing.clone(), route_table.clone()).await;
+
+        let service_token = CancellationToken::new();
+        let services_done = CancellationToken::new();
+
+        Ok(TalkStack { et_addressing, lt_addressing, ddp, nbp, echo, route_table, service_token, transport_token, services_done })
+    }
+
+    /// Build the stack on top of a remote daemon's underlay.
+    async fn build_remote(self, endpoint: remote::DaemonEndpoint) -> Result<TalkStack, Error> {
+        if self.has_local_transport() {
+            return Err(anyhow::anyhow!(
+                "cannot combine local interfaces with a remote daemon; configure the interfaces on the daemon instead"
+            ));
+        }
+
+        let client = remote::RemoteClient::connect(&endpoint).await?;
+
+        // Map the daemon's interfaces onto addressing handles. If the daemon
+        // has several interfaces of one type, the first is used — same as the
+        // local builder, which supports one of each.
+        let interfaces = client.list_interfaces().await?;
+        let mut et_addressing: Option<addressing::AddressingHandle> = None;
+        let mut lt_addressing: Option<addressing::AddressingHandle> = None;
+        for iface in &interfaces {
+            match tailtalk_proto::InterfaceType::try_from(iface.r#type) {
+                Ok(tailtalk_proto::InterfaceType::Ethertalk) if et_addressing.is_none() => {
+                    et_addressing = Some(addressing::AddressingHandle::remote(
+                        client.clone(),
+                        iface.name.clone(),
+                        aarp::AddressSource::EtherTalkPhase2,
+                    ));
+                }
+                Ok(tailtalk_proto::InterfaceType::Localtalk) if lt_addressing.is_none() => {
+                    lt_addressing = Some(addressing::AddressingHandle::remote(
+                        client.clone(),
+                        iface.name.clone(),
+                        aarp::AddressSource::LocalTalk,
+                    ));
+                }
+                _ => {}
+            }
+        }
+
+        let ddp = ddp::DdpHandle::remote(client.clone());
+
+        // Routing is daemon-owned; local table is a cache for NBP zone dispatch.
+        let route_table = route_table::RouteTable::new(route_table::LearningMode::Static);
+        client.sync_routes_to(route_table.clone());
+        let routes = client.list_routes().await?;
+        route_table.replace_contents(remote::snapshot_from_proto(&routes));
+        let (rt_tx, mut rt_rx) = tokio::sync::mpsc::unbounded_channel();
+        route_table.set_publisher(rt_tx);
+        {
+            let client = client.clone();
+            tokio::spawn(async move {
+                while let Some(change) = rt_rx.recv().await {
+                    if let Err(e) = client.apply_route_change(&change).await {
+                        tracing::error!("failed to sync route change to daemon: {e}");
+                    }
+                }
+            });
+        }
+
+        let echo = echo::Echo::spawn(&ddp).await;
+        let nbp = nbp::Nbp::spawn(&ddp, et_addressing.clone(), lt_addressing.clone(), route_table.clone()).await;
+
+        let service_token = CancellationToken::new();
+        let transport_token = CancellationToken::new();
+        let services_done = CancellationToken::new();
+
+        // The daemon connection is our transport: shutting down the stack
+        // closes the connection, and a dead connection shuts down the stack.
+        {
+            let client = client.clone();
+            let transport_token = transport_token.clone();
+            tokio::spawn(async move {
+                let closed = client.closed_token();
+                tokio::select! {
+                    _ = transport_token.cancelled() => client.shutdown(),
+                    _ = closed.cancelled() => transport_token.cancel(),
+                }
+            });
         }
 
         Ok(TalkStack { et_addressing, lt_addressing, ddp, nbp, echo, route_table, service_token, transport_token, services_done })

--- a/tailtalk/src/remote.rs
+++ b/tailtalk/src/remote.rs
@@ -1,0 +1,530 @@
+//! Client for a remote TailTalk daemon (`tailtalkd`).
+//!
+//! When a [`TalkStack`](crate::TalkStack) is built with
+//! [`daemon_unix`](crate::TalkStackBuilder::daemon_unix) or
+//! [`daemon_udp`](crate::TalkStackBuilder::daemon_udp), this module carries
+//! DDP sockets, addressing, and routing over the protobuf wire protocol.
+
+use std::collections::HashMap;
+use std::io::{self, Error};
+#[cfg(unix)]
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tailtalk_packets::aarp::AppleTalkAddress;
+use tailtalk_packets::ddp::{DdpPacket as DdpHeaders, DdpProtocolType};
+use tailtalk_proto as proto;
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
+
+use crate::ddp::Packet;
+
+/// Where to reach the daemon.
+#[derive(Debug, Clone)]
+pub enum DaemonEndpoint {
+    /// SOCK_STREAM Unix domain socket path.
+    #[cfg(unix)]
+    Unix(PathBuf),
+    /// UDP host:port.
+    Udp(std::net::SocketAddr),
+}
+
+/// Interval between keepalive pings on UDP transports (sessions expire
+/// daemon-side after 300 s idle).
+const UDP_KEEPALIVE: std::time::Duration = std::time::Duration::from_secs(30);
+
+#[derive(Debug, Default)]
+struct Shared {
+    /// In-flight requests awaiting a reply, by correlation id.
+    pending: Mutex<HashMap<u64, oneshot::Sender<proto::reply::Kind>>>,
+    /// Receive queues for open DDP sockets, by socket number.
+    sockets: Mutex<HashMap<u8, mpsc::Sender<Packet>>>,
+    /// Local cache of the daemon's authoritative routing rules; replaced
+    /// wholesale whenever the daemon pushes a `routes_changed` message.
+    route_table: Mutex<Option<crate::route_table::RouteTable>>,
+}
+
+/// Cheaply cloneable connection to the daemon.
+#[derive(Debug, Clone)]
+pub(crate) struct RemoteClient {
+    req_tx: mpsc::Sender<proto::Request>,
+    shared: Arc<Shared>,
+    next_id: Arc<AtomicU64>,
+    /// Cancelled when the connection dies (or `shutdown` is called).
+    closed: CancellationToken,
+}
+
+impl RemoteClient {
+    pub(crate) async fn connect(endpoint: &DaemonEndpoint) -> io::Result<Self> {
+        let (req_tx, req_rx) = mpsc::channel::<proto::Request>(100);
+        let shared = Arc::new(Shared::default());
+        let closed = CancellationToken::new();
+
+        let client = Self {
+            req_tx,
+            shared: shared.clone(),
+            next_id: Arc::new(AtomicU64::new(1)),
+            closed: closed.clone(),
+        };
+
+        match endpoint {
+            #[cfg(unix)]
+            DaemonEndpoint::Unix(path) => {
+                let stream = tokio::net::UnixStream::connect(path).await?;
+                let (read_half, write_half) = stream.into_split();
+                let framed_write = tokio_util::codec::FramedWrite::new(write_half, proto::TailTalkCodec::<proto::Request, proto::ServerMessage>::default());
+                tokio::spawn(unix_writer(framed_write, req_rx, closed.clone()));
+                tokio::spawn(unix_reader(read_half, shared, closed));
+            }
+            DaemonEndpoint::Udp(addr) => {
+                let bind: std::net::SocketAddr = if addr.is_ipv4() {
+                    "0.0.0.0:0".parse().unwrap()
+                } else {
+                    "[::]:0".parse().unwrap()
+                };
+                let socket = Arc::new(tokio::net::UdpSocket::bind(bind).await?);
+                socket.connect(addr).await?;
+                tokio::spawn(udp_writer(socket.clone(), req_rx, closed.clone()));
+                tokio::spawn(udp_reader(socket, shared, closed.clone()));
+                tokio::spawn(udp_keepalive(client.clone(), closed));
+            }
+        }
+
+        Ok(client)
+    }
+
+    /// Token cancelled when the daemon connection is gone.
+    pub(crate) fn closed_token(&self) -> CancellationToken {
+        self.closed.clone()
+    }
+
+    /// Register the local route-table cache to be kept in sync with the
+    /// daemon's authoritative table via `routes_changed` pushes.
+    pub(crate) fn sync_routes_to(&self, table: crate::route_table::RouteTable) {
+        *self.shared.route_table.lock().unwrap() = Some(table);
+    }
+
+    /// Tear down the connection tasks.
+    pub(crate) fn shutdown(&self) {
+        self.closed.cancel();
+    }
+
+    /// Send a request and await its reply.
+    pub(crate) async fn request(&self, kind: proto::request::Kind) -> io::Result<proto::reply::Kind> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+        self.shared.pending.lock().unwrap().insert(id, tx);
+
+        let req = proto::Request { id, kind: Some(kind) };
+        if self.req_tx.send(req).await.is_err() {
+            self.shared.pending.lock().unwrap().remove(&id);
+            return Err(Error::new(io::ErrorKind::BrokenPipe, "daemon connection closed"));
+        }
+
+        let kind = rx.await.map_err(|_| {
+            Error::new(io::ErrorKind::BrokenPipe, "daemon connection closed")
+        })?;
+
+        if let proto::reply::Kind::Error(e) = kind {
+            return Err(proto_error_to_io(&e));
+        }
+        Ok(kind)
+    }
+
+    /// Send a fire-and-forget request (id 0 — the daemon will not reply).
+    fn send_no_reply(&self, kind: proto::request::Kind) {
+        let _ = self.req_tx.try_send(proto::Request { id: 0, kind: Some(kind) });
+    }
+
+    // ── DDP sockets ──────────────────────────────────────────────────────────
+
+    /// Open a DDP socket on the daemon. Returns the bound socket number and
+    /// the receive queue that inbound datagrams are delivered on.
+    pub(crate) async fn open_socket(
+        &self,
+        protocol: DdpProtocolType,
+        sock_num: Option<u8>,
+    ) -> io::Result<(u8, mpsc::Receiver<Packet>)> {
+        let kind = self
+            .request(proto::request::Kind::OpenSocket(proto::OpenSocketRequest {
+                socket: sock_num.unwrap_or(0) as u32,
+                ddp_type: u8::from(protocol) as u32,
+            }))
+            .await?;
+
+        let proto::reply::Kind::Socket(reply) = kind else {
+            return Err(unexpected_reply());
+        };
+        let socket_id = u8::try_from(reply.socket_id)
+            .map_err(|_| Error::new(io::ErrorKind::InvalidData, "socket id out of range"))?;
+
+        let (tx, rx) = mpsc::channel(100);
+        self.shared.sockets.lock().unwrap().insert(socket_id, tx);
+        Ok((socket_id, rx))
+    }
+
+    /// Close a previously opened socket (fire-and-forget).
+    pub(crate) fn close_socket(&self, socket_id: u8) {
+        self.shared.sockets.lock().unwrap().remove(&socket_id);
+        self.send_no_reply(proto::request::Kind::CloseSocket(proto::CloseSocketRequest {
+            socket_id: socket_id as u32,
+        }));
+    }
+
+    /// Send a datagram out of an open socket. Applies channel backpressure
+    /// but, like DDP itself, gives no delivery guarantee.
+    pub(crate) async fn send_datagram(
+        &self,
+        socket_id: u8,
+        dest: AppleTalkAddress,
+        dest_socket: u8,
+        payload: &[u8],
+    ) -> io::Result<()> {
+        let req = proto::Request {
+            id: 0,
+            kind: Some(proto::request::Kind::Send(proto::SendDatagram {
+                socket_id: socket_id as u32,
+                dest: Some(proto::AppleTalkAddress::new(
+                    dest.network_number,
+                    dest.node_number,
+                )),
+                dest_socket: dest_socket as u32,
+                payload: payload.to_vec(),
+            })),
+        };
+        self.req_tx
+            .send(req)
+            .await
+            .map_err(|_| Error::new(io::ErrorKind::BrokenPipe, "daemon connection closed"))
+    }
+
+    // ── Interfaces ───────────────────────────────────────────────────────────
+
+    pub(crate) async fn list_interfaces(&self) -> io::Result<Vec<proto::Interface>> {
+        let kind = self
+            .request(proto::request::Kind::ListInterfaces(
+                proto::ListInterfacesRequest {},
+            ))
+            .await?;
+        match kind {
+            proto::reply::Kind::Interfaces(reply) => Ok(reply.interfaces),
+            _ => Err(unexpected_reply()),
+        }
+    }
+
+    pub(crate) async fn interface_addr(&self, name: &str) -> io::Result<AppleTalkAddress> {
+        let interfaces = self.list_interfaces().await?;
+        let iface = interfaces
+            .into_iter()
+            .find(|i| i.name == name)
+            .ok_or_else(|| Error::new(io::ErrorKind::NotFound, format!("interface '{name}' not found on daemon")))?;
+        let addr = iface.address.ok_or_else(|| {
+            Error::new(io::ErrorKind::NotConnected, format!("interface '{name}' has no address yet"))
+        })?;
+        Ok(AppleTalkAddress {
+            network_number: addr.network as u16,
+            node_number: addr.node as u8,
+        })
+    }
+
+    pub(crate) async fn set_interface_addr(
+        &self,
+        name: &str,
+        addr: AppleTalkAddress,
+    ) -> io::Result<()> {
+        self.request(proto::request::Kind::SetAddress(proto::SetAddressRequest {
+            interface: name.to_string(),
+            address: Some(proto::AppleTalkAddress::new(
+                addr.network_number,
+                addr.node_number,
+            )),
+        }))
+        .await?;
+        Ok(())
+    }
+
+    // ── Routing rules ────────────────────────────────────────────────────────
+
+    pub(crate) async fn list_routes(&self) -> io::Result<proto::ListRoutesReply> {
+        let kind = self
+            .request(proto::request::Kind::ListRoutes(proto::ListRoutesRequest {}))
+            .await?;
+        match kind {
+            proto::reply::Kind::Routes(reply) => Ok(reply),
+            _ => Err(unexpected_reply()),
+        }
+    }
+
+    /// Forward a local route-table mutation to the daemon.
+    pub(crate) async fn apply_route_change(
+        &self,
+        change: &crate::route_table::RouteChange,
+    ) -> io::Result<()> {
+        use crate::route_table::RouteChange;
+        let kind = match change {
+            RouteChange::SetLocalRange((lo, hi)) => {
+                proto::request::Kind::SetLocalRange(proto::SetLocalRangeRequest {
+                    range: Some(proto::CableRange { lo: *lo as u32, hi: *hi as u32 }),
+                })
+            }
+            RouteChange::InsertRoute { lo, hi, next_hop } => {
+                proto::request::Kind::AddRoute(proto::AddRouteRequest {
+                    route: Some(proto::Route {
+                        range: Some(proto::CableRange { lo: *lo as u32, hi: *hi as u32 }),
+                        next_hop: Some(proto::AppleTalkAddress::new(
+                            next_hop.network_number,
+                            next_hop.node_number,
+                        )),
+                    }),
+                })
+            }
+            RouteChange::RemoveRoute { lo, hi } => {
+                proto::request::Kind::RemoveRoute(proto::RemoveRouteRequest {
+                    range: Some(proto::CableRange { lo: *lo as u32, hi: *hi as u32 }),
+                })
+            }
+            RouteChange::InsertZone { zone, ranges } => {
+                proto::request::Kind::AddZone(proto::AddZoneRequest {
+                    zone: zone.clone(),
+                    ranges: ranges
+                        .iter()
+                        .map(|(lo, hi)| proto::CableRange { lo: *lo as u32, hi: *hi as u32 })
+                        .collect(),
+                })
+            }
+            RouteChange::RemoveZone { zone } => {
+                proto::request::Kind::RemoveZone(proto::RemoveZoneRequest { zone: zone.clone() })
+            }
+        };
+        self.request(kind).await?;
+        Ok(())
+    }
+}
+
+// ── Reply dispatch ────────────────────────────────────────────────────────────
+
+fn dispatch(shared: &Shared, msg: proto::ServerMessage) {
+    match msg.kind {
+        Some(proto::server_message::Kind::Reply(reply)) => {
+            let Some(kind) = reply.kind else { return };
+            if let Some(tx) = shared.pending.lock().unwrap().remove(&reply.id) {
+                let _ = tx.send(kind);
+            }
+        }
+        Some(proto::server_message::Kind::Datagram(dg)) => {
+            let Ok(socket_id) = u8::try_from(dg.socket_id) else { return };
+            let source = dg.source.unwrap_or_default();
+            let dest = dg.dest.unwrap_or_default();
+            let headers = DdpHeaders {
+                hop_count: 0,
+                len: dg.payload.len() + DdpHeaders::LEN,
+                chksum: 0,
+                dest_network_num: dest.network as u16,
+                src_network_num: source.network as u16,
+                dest_node_id: dest.node as u8,
+                dest_sock_num: dg.dest_socket as u8,
+                src_sock_num: dg.source_socket as u8,
+                src_node_id: source.node as u8,
+                protocol_typ: DdpProtocolType::from(dg.ddp_type as u8),
+            };
+            let packet = Packet {
+                headers,
+                payload: dg.payload.into_boxed_slice(),
+            };
+            let sockets = shared.sockets.lock().unwrap();
+            if let Some(tx) = sockets.get(&socket_id)
+                && tx.try_send(packet).is_err() {
+                    tracing::warn!("remote DDP socket {socket_id}: receive queue full, dropping");
+                }
+        }
+        Some(proto::server_message::Kind::RoutesChanged(reply)) => {
+            let table = shared.route_table.lock().unwrap().clone();
+            if let Some(table) = table {
+                tracing::debug!("daemon routing rules changed, updating local cache");
+                table.replace_contents(snapshot_from_proto(&reply));
+            }
+        }
+        None => {}
+    }
+}
+
+/// Convert the daemon's route listing into a local snapshot.
+pub(crate) fn snapshot_from_proto(
+    reply: &proto::ListRoutesReply,
+) -> crate::route_table::RouteSnapshot {
+    crate::route_table::RouteSnapshot {
+        local_range: reply
+            .local_range
+            .as_ref()
+            .map(|r| (r.lo as u16, r.hi as u16)),
+        routes: reply
+            .routes
+            .iter()
+            .filter_map(|route| {
+                let range = route.range.as_ref()?;
+                let next_hop = route.next_hop.as_ref()?;
+                Some((
+                    range.lo as u16,
+                    range.hi as u16,
+                    AppleTalkAddress {
+                        network_number: next_hop.network as u16,
+                        node_number: next_hop.node as u8,
+                    },
+                ))
+            })
+            .collect(),
+        zones: reply
+            .zones
+            .iter()
+            .map(|zone| {
+                (
+                    zone.name.clone(),
+                    zone.ranges.iter().map(|r| (r.lo as u16, r.hi as u16)).collect(),
+                )
+            })
+            .collect(),
+    }
+}
+
+/// Fail every in-flight request when the connection dies.
+fn fail_pending(shared: &Shared) {
+    shared.pending.lock().unwrap().clear();
+    shared.sockets.lock().unwrap().clear();
+}
+
+// ── Unix transport tasks ──────────────────────────────────────────────────────
+
+#[cfg(unix)]
+async fn unix_writer(
+    mut write_half: tokio_util::codec::FramedWrite<tokio::net::unix::OwnedWriteHalf, proto::TailTalkCodec<proto::Request, proto::ServerMessage>>,
+    mut req_rx: mpsc::Receiver<proto::Request>,
+    closed: CancellationToken,
+) {
+    use futures::SinkExt;
+    loop {
+        let req = tokio::select! {
+            _ = closed.cancelled() => break,
+            req = req_rx.recv() => match req { Some(r) => r, None => break },
+        };
+        if let Err(e) = write_half.send(req).await {
+            tracing::error!("daemon connection write error: {e}");
+            break;
+        }
+    }
+    closed.cancel();
+}
+
+#[cfg(unix)]
+async fn unix_reader(
+    read_half: tokio::net::unix::OwnedReadHalf,
+    shared: Arc<Shared>,
+    closed: CancellationToken,
+) {
+    use futures::StreamExt;
+    let mut reader = tokio_util::codec::FramedRead::new(read_half, proto::TailTalkCodec::<proto::Request, proto::ServerMessage>::default());
+    loop {
+        let msg = tokio::select! {
+            _ = closed.cancelled() => break,
+            msg = reader.next() => msg.transpose(),
+        };
+        match msg {
+            Ok(Some(msg)) => dispatch(&shared, msg),
+            Ok(None) => {
+                tracing::info!("daemon closed the connection");
+                break;
+            }
+            Err(e) => {
+                tracing::error!("daemon connection read error: {e}");
+                break;
+            }
+        }
+    }
+    closed.cancel();
+    fail_pending(&shared);
+}
+
+// ── UDP transport tasks ───────────────────────────────────────────────────────
+
+async fn udp_writer(
+    socket: Arc<tokio::net::UdpSocket>,
+    mut req_rx: mpsc::Receiver<proto::Request>,
+    closed: CancellationToken,
+) {
+    loop {
+        let req = tokio::select! {
+            _ = closed.cancelled() => break,
+            req = req_rx.recv() => match req { Some(r) => r, None => break },
+        };
+        if let Err(e) = socket.send(&proto::encode_frame(&req)).await {
+            tracing::error!("daemon UDP send error: {e}");
+            break;
+        }
+    }
+    closed.cancel();
+}
+
+async fn udp_reader(
+    socket: Arc<tokio::net::UdpSocket>,
+    shared: Arc<Shared>,
+    closed: CancellationToken,
+) {
+    let mut buf = vec![0u8; proto::MAX_MESSAGE_LEN + 8];
+    loop {
+        let res = tokio::select! {
+            _ = closed.cancelled() => break,
+            res = socket.recv(&mut buf) => res,
+        };
+        match res {
+            Ok(n) => match proto::decode_datagram::<proto::ServerMessage>(&buf[..n]) {
+                Ok(msgs) => {
+                    for msg in msgs {
+                        dispatch(&shared, msg);
+                    }
+                }
+                Err(e) => tracing::warn!("bad datagram from daemon: {e}"),
+            },
+            Err(e) => {
+                tracing::error!("daemon UDP receive error: {e}");
+                break;
+            }
+        }
+    }
+    closed.cancel();
+    fail_pending(&shared);
+}
+
+async fn udp_keepalive(client: RemoteClient, closed: CancellationToken) {
+    let mut interval = tokio::time::interval(UDP_KEEPALIVE);
+    interval.tick().await;
+    loop {
+        tokio::select! {
+            _ = closed.cancelled() => break,
+            _ = interval.tick() => {
+                if client
+                    .request(proto::request::Kind::Ping(proto::PingRequest {}))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+// ── Error mapping ─────────────────────────────────────────────────────────────
+
+fn proto_error_to_io(e: &proto::Error) -> Error {
+    let kind = match proto::ErrorCode::try_from(e.code) {
+        Ok(proto::ErrorCode::InvalidArgument) => io::ErrorKind::InvalidInput,
+        Ok(proto::ErrorCode::NotFound) => io::ErrorKind::NotFound,
+        Ok(proto::ErrorCode::AddrInUse) => io::ErrorKind::AddrInUse,
+        _ => io::ErrorKind::Other,
+    };
+    Error::new(kind, format!("daemon error: {}", e.message))
+}
+
+fn unexpected_reply() -> Error {
+    Error::new(io::ErrorKind::InvalidData, "unexpected reply kind from daemon")
+}

--- a/tailtalk/src/route_table.rs
+++ b/tailtalk/src/route_table.rs
@@ -143,6 +143,28 @@ impl ZipTable {
     }
 }
 
+// ── Change stream ─────────────────────────────────────────────────────────────
+
+/// A single mutation applied through the programmatic API.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RouteChange {
+    SetLocalRange(CableRange),
+    InsertRoute { lo: u16, hi: u16, next_hop: AppleTalkAddress },
+    RemoveRoute { lo: u16, hi: u16 },
+    InsertZone { zone: String, ranges: Vec<CableRange> },
+    RemoveZone { zone: String },
+}
+
+/// A point-in-time copy of the table contents, for querying over an API.
+#[derive(Debug, Clone, Default)]
+pub struct RouteSnapshot {
+    pub local_range: Option<CableRange>,
+    /// `(range_lo, range_hi, next_hop)` for every RTMP entry.
+    pub routes: Vec<(u16, u16, AppleTalkAddress)>,
+    /// `(zone name, cable ranges)` for every known zone.
+    pub zones: Vec<(String, Vec<CableRange>)>,
+}
+
 // ── Inner state ───────────────────────────────────────────────────────────────
 
 struct Inner {
@@ -150,9 +172,16 @@ struct Inner {
     local_range: Option<CableRange>,
     rtmp: RtmpTable,
     zip: ZipTable,
+    publisher: Option<tokio::sync::mpsc::UnboundedSender<RouteChange>>,
 }
 
 impl Inner {
+    fn publish(&self, change: RouteChange) {
+        if let Some(tx) = &self.publisher {
+            let _ = tx.send(change);
+        }
+    }
+
     fn is_local(&self, net: u16) -> bool {
         self.local_range.is_some_and(|(lo, hi)| lo <= net && net <= hi)
     }
@@ -210,6 +239,12 @@ impl Inner {
 #[derive(Clone)]
 pub struct RouteTable(Arc<RwLock<Inner>>);
 
+impl std::fmt::Debug for RouteTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RouteTable").finish_non_exhaustive()
+    }
+}
+
 impl RouteTable {
     pub fn new(mode: LearningMode) -> Self {
         Self(Arc::new(RwLock::new(Inner {
@@ -217,6 +252,7 @@ impl RouteTable {
             local_range: None,
             rtmp: RtmpTable::new(),
             zip: ZipTable::new(),
+            publisher: None,
         })))
     }
 
@@ -227,19 +263,33 @@ impl RouteTable {
     /// Required for [`is_local`](Self::is_local) and
     /// [`route_for`](Self::route_for) to distinguish on-segment destinations.
     pub fn set_local_range(&self, lo: u16, hi: u16) {
-        self.0.write().unwrap().local_range = Some((lo, hi));
+        let mut inner = self.0.write().unwrap();
+        inner.local_range = Some((lo, hi));
+        inner.publish(RouteChange::SetLocalRange((lo, hi)));
+    }
+
+    /// Attach a channel that receives every subsequent programmatic change.
+    ///
+    /// Seed the table *before* attaching the publisher to avoid echoing
+    /// the seed back.
+    pub fn set_publisher(&self, tx: tokio::sync::mpsc::UnboundedSender<RouteChange>) {
+        self.0.write().unwrap().publisher = Some(tx);
     }
 
     // ── Programmatic inserts ──────────────────────────────────────────────────
 
     /// Insert or replace a route: DDP packets for `[lo..=hi]` go to `next_hop`.
     pub fn insert_route(&self, lo: u16, hi: u16, next_hop: AppleTalkAddress) {
-        self.0.write().unwrap().rtmp.insert(lo, hi, next_hop, 1);
+        let mut inner = self.0.write().unwrap();
+        inner.rtmp.insert(lo, hi, next_hop, 1);
+        inner.publish(RouteChange::InsertRoute { lo, hi, next_hop });
     }
 
     /// Remove the route covering exactly `[lo..=hi]`.
     pub fn remove_route(&self, lo: u16, hi: u16) {
-        self.0.write().unwrap().rtmp.remove(lo, hi);
+        let mut inner = self.0.write().unwrap();
+        inner.rtmp.remove(lo, hi);
+        inner.publish(RouteChange::RemoveRoute { lo, hi });
     }
 
     /// Associate `zone` with one or more cable ranges.
@@ -251,11 +301,53 @@ impl RouteTable {
         for &range in ranges {
             inner.zip.insert_zone_range(zone, range);
         }
+        inner.publish(RouteChange::InsertZone {
+            zone: zone.to_string(),
+            ranges: ranges.to_vec(),
+        });
     }
 
     /// Remove all cable-range associations for `zone`.
     pub fn remove_zone(&self, zone: &str) {
-        self.0.write().unwrap().zip.remove_zone(zone);
+        let mut inner = self.0.write().unwrap();
+        inner.zip.remove_zone(zone);
+        inner.publish(RouteChange::RemoveZone { zone: zone.to_string() });
+    }
+
+    /// Replace the entire table contents with `snapshot`, without publishing.
+    pub fn replace_contents(&self, snapshot: RouteSnapshot) {
+        let mut inner = self.0.write().unwrap();
+        inner.local_range = snapshot.local_range;
+        inner.rtmp = RtmpTable::new();
+        for (lo, hi, next_hop) in snapshot.routes {
+            inner.rtmp.insert(lo, hi, next_hop, 1);
+        }
+        inner.zip = ZipTable::new();
+        for (zone, ranges) in snapshot.zones {
+            for range in ranges {
+                inner.zip.insert_zone_range(&zone, range);
+            }
+        }
+    }
+
+    /// Copy the entire table contents, for querying over an API.
+    pub fn snapshot(&self) -> RouteSnapshot {
+        let inner = self.0.read().unwrap();
+        RouteSnapshot {
+            local_range: inner.local_range,
+            routes: inner
+                .rtmp
+                .entries
+                .iter()
+                .map(|e| (e.range_lo, e.range_hi, e.next_hop))
+                .collect(),
+            zones: inner
+                .zip
+                .zone_to_ranges
+                .iter()
+                .map(|(name, ranges)| (name.clone(), ranges.clone()))
+                .collect(),
+        }
     }
 
     // ── Dynamic learning ──────────────────────────────────────────────────────


### PR DESCRIPTION
This revives the tailtalk daemon that I added _waaay_ back at the start of the project but then abandoned due to maintenance. With the project ins a more mature state I've added a well defined protobuf format for it and limited the daemon itself to only providing AARP and DDP.

The purpose of this is two fold:
- Support multiple programs running on the same TashTalk (and USB) device. Right now program use is exclusive and you cannot run another program when one is already in use.
- Possibly function as a userspace protocol frontend for Netatalk. With the Linux kernel dropping AppleTalk support and moving it in to an out-of-tree module there's a search for what could replace it. I dont know if TailTalk will ultimately end up being suitable, but have been playing with this style as a proof of concept to replace it. With this daemon I was able to get Netatalk's AFP server up and running and connect to it via my old Macs with TashTalk USB. The bonus of this is that it would give Netatalk the option to speak LocalTalk directly.

This code is not _perfect_ but is in a functional state. The TalkStack builder accepts a new arg to use the interfaces directly (like we do today) _or_ connect to the daemon and use it via a Unix sock, or a UDP sock. I've been using this as a way to verify the daemon works as expected and it seems to work pretty well.

The part that is a little fuzzy to me are the routing API additions - this is meant to target the other part of the Linux kernel APIs that were dropped with the module that Netatalk uses to program what addresses go to what interfaces / next hops and such. I believe I have covered the main functionality but it still needs thorough testing before being considered "done".