### PR TITLE
DDP: Support Netatalk-style clients

### DIFF
--- a/tailtalk-daemon/src/lib.rs
+++ b/tailtalk-daemon/src/lib.rs
@@ -46,6 +46,10 @@ pub struct InterfaceEntry {
     pub name: String,
     pub kind: proto::InterfaceType,
     pub addressing: AddressingHandle,
+    /// Ethernet multicast groups enabled on this interface (EtherTalk only).
+    /// The EtherTalk transport captures promiscuously, so reception already
+    /// works; this records the membership requested by clients.
+    pub multicast: std::sync::Mutex<std::collections::HashSet<[u8; 6]>>,
 }
 
 pub struct DaemonState {
@@ -103,6 +107,7 @@ impl Daemon {
                 name,
                 kind: proto::InterfaceType::Ethertalk,
                 addressing,
+                multicast: std::sync::Mutex::new(std::collections::HashSet::new()),
             });
         }
         if let (Some(name), Some(addressing)) =
@@ -112,6 +117,7 @@ impl Daemon {
                 name,
                 kind: proto::InterfaceType::Localtalk,
                 addressing,
+                multicast: std::sync::Mutex::new(std::collections::HashSet::new()),
             });
         }
 
@@ -259,6 +265,7 @@ impl Session {
         match kind {
             Kind::ListInterfaces(_) => self.list_interfaces(id).await,
             Kind::SetAddress(r) => self.set_address(id, r).await,
+            Kind::AddMulticast(r) => self.add_multicast(id, r),
             Kind::OpenSocket(r) => self.open_socket(id, r).await,
             Kind::CloseSocket(r) => {
                 match u8::try_from(r.socket_id).ok().and_then(|s| self.sockets.remove(&s)) {
@@ -360,6 +367,39 @@ impl Session {
             Ok(()) => proto::Reply::ok(id),
             Err(e) => proto::Reply::error(id, proto::ErrorCode::Internal, e.to_string()),
         }
+    }
+
+    fn add_multicast(&self, id: u64, r: proto::AddMulticastRequest) -> proto::Reply {
+        let Some(iface) = self.state.interfaces.iter().find(|i| i.name == r.interface) else {
+            return proto::Reply::error(
+                id,
+                proto::ErrorCode::NotFound,
+                format!("no interface named '{}'", r.interface),
+            );
+        };
+        // Multicast is an EtherTalk-only concept; LocalTalk has no hardware
+        // multicast, so reject it rather than silently accept.
+        if iface.kind != proto::InterfaceType::Ethertalk {
+            return invalid(id, "multicast is only supported on EtherTalk interfaces");
+        }
+        let Ok(mac) = <[u8; 6]>::try_from(r.address.as_slice()) else {
+            return invalid(id, "multicast address must be 6 bytes");
+        };
+        if mac[0] & 0x01 == 0 {
+            return invalid(id, "not a multicast address (group bit clear)");
+        }
+        // The EtherTalk capture is promiscuous, so frames for this group are
+        // already delivered; record the membership for correctness.
+        let mut groups = iface.multicast.lock().unwrap();
+        if groups.insert(mac) {
+            tracing::info!(
+                "interface {}: enabled multicast {:02x?} ({} group(s))",
+                iface.name,
+                mac,
+                groups.len()
+            );
+        }
+        proto::Reply::ok(id)
     }
 
     async fn open_socket(&mut self, id: u64, r: proto::OpenSocketRequest) -> proto::Reply {
@@ -588,7 +628,18 @@ async fn socket_pump_outbound(
             },
             send.dest_socket as u8,
         );
-        if let Err(e) = sender.send_to(&send.payload, addr).await {
+        let protocol = match u8::try_from(send.ddp_type) {
+            Ok(0) => None,
+            Ok(t) => Some(DdpProtocolType::from(t)),
+            Err(_) => {
+                tracing::warn!(
+                    "socket {socket_id}: dropping datagram with bad ddp_type {}",
+                    send.ddp_type
+                );
+                continue;
+            }
+        };
+        if let Err(e) = sender.send_to_typed(&send.payload, addr, protocol).await {
             tracing::warn!("socket {socket_id}: send failed: {e}");
         }
     }

--- a/tailtalk-daemon/tests/integration.rs
+++ b/tailtalk-daemon/tests/integration.rs
@@ -94,6 +94,21 @@ async fn control_plane_over_unix_socket() {
         panic!("expected error reply");
     };
     assert_eq!(err.code, proto::ErrorCode::NotFound as i32);
+
+    // Enabling multicast on a nonexistent interface reports NotFound.
+    let kind = request(
+        &mut stream,
+        4,
+        proto::request::Kind::AddMulticast(proto::AddMulticastRequest {
+            interface: "en99".into(),
+            address: vec![0x09, 0x00, 0x07, 0xff, 0xff, 0xff],
+        }),
+    )
+    .await;
+    let proto::reply::Kind::Error(err) = kind else {
+        panic!("expected error reply");
+    };
+    assert_eq!(err.code, proto::ErrorCode::NotFound as i32);
 }
 
 #[tokio::test]
@@ -151,6 +166,7 @@ async fn ddp_socket_lifecycle() {
                 dest: Some(proto::AppleTalkAddress::new(0, 255)),
                 dest_socket: 2,
                 payload: vec![1, 2, 3],
+                ddp_type: 0,
             }),
         )
         .await,

--- a/tailtalk-proto/proto/tailtalk.proto
+++ b/tailtalk-proto/proto/tailtalk.proto
@@ -85,6 +85,16 @@ message SetAddressRequest {
   AppleTalkAddress address = 2;
 }
 
+// Enable reception of an Ethernet multicast address on an interface, e.g.
+// the hardware multicast group a zone's NBP lookups are sent to. Only
+// meaningful on EtherTalk; LocalTalk has no hardware multicast, so calling
+// this on a LocalTalk interface fails with INVALID_ARGUMENT. Clients should
+// not issue it for LocalTalk interfaces.
+message AddMulticastRequest {
+  string interface = 1;
+  bytes address = 2; // 6-byte Ethernet multicast MAC (group bit set)
+}
+
 // ── DDP sockets ───────────────────────────────────────────────────────────────
 
 message OpenSocketRequest {
@@ -112,6 +122,10 @@ message SendDatagram {
   AppleTalkAddress dest = 2;
   uint32 dest_socket = 3; // destination DDP socket number
   bytes payload = 4;      // max 586 bytes
+  // DDP protocol type stamped on this datagram. 0 means use the ddp_type
+  // the socket was opened with. Clients whose socket API carries the DDP
+  // type per datagram (e.g. Netatalk's netddp) set this on every send.
+  uint32 ddp_type = 5;
 }
 
 // Daemon → client datagram, delivered for any open socket.
@@ -195,6 +209,7 @@ message Request {
     RemoveZoneRequest remove_zone = 11;
     SetLocalRangeRequest set_local_range = 12;
     PingRequest ping = 13;
+    AddMulticastRequest add_multicast = 14;
   }
 }
 

--- a/tailtalk-proto/src/lib.rs
+++ b/tailtalk-proto/src/lib.rs
@@ -177,6 +177,7 @@ mod tests {
                 dest: Some(AppleTalkAddress::new(1, 7)),
                 dest_socket: 2,
                 payload: vec![0xAA; 100],
+                ddp_type: 0,
             })),
         }
     }

--- a/tailtalk/src/addressing.rs
+++ b/tailtalk/src/addressing.rs
@@ -436,8 +436,12 @@ impl AddressingHandle {
             });
         }
 
-        // Network 0 unicast: LocalTalk — node number is the link-layer address directly.
-        if addr.network_number == 0 {
+        // Network 0 unicast: on a LocalTalk handle, the node number is the
+        // link-layer address directly. Nonextended EtherTalk (Phase 1) nodes
+        // also address themselves on network 0, so an EtherTalk handle can't
+        // take this shortcut — it must fall through to the learned-address
+        // cache below like any other lookup.
+        if addr.network_number == 0 && self.phase == AddressSource::LocalTalk {
             return Some(Node::LocalTalk(addr.node_number));
         }
 

--- a/tailtalk/src/ddp.rs
+++ b/tailtalk/src/ddp.rs
@@ -65,6 +65,18 @@ pub struct DdpSocketSender {
 
 impl DdpSocketSender {
     pub async fn send_to(&self, buf: &[u8], addr: DdpAddress) -> Result<(), Error> {
+        self.send_to_typed(buf, addr, None).await
+    }
+
+    /// Like [`Self::send_to`], but stamps `protocol` on this datagram instead
+    /// of the type the socket was opened with. Used to serve clients whose
+    /// socket API carries the DDP type per datagram rather than per socket.
+    pub async fn send_to_typed(
+        &self,
+        buf: &[u8],
+        addr: DdpAddress,
+        protocol: Option<DdpProtocolType>,
+    ) -> Result<(), Error> {
         if buf.len() > 586 {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -80,7 +92,7 @@ impl DdpSocketSender {
                     dest: addr,
                     payload: buf.into(),
                     src_sock: self.sock_num,
-                    protocol: self.protocol,
+                    protocol: protocol.unwrap_or(self.protocol),
                 };
                 sender.send(DdpCommand::SendPkt(pkt)).await.map_err(|_| {
                     io::Error::new(io::ErrorKind::BrokenPipe, "DDP processor shut down")
@@ -346,6 +358,40 @@ impl DdpProcessor {
         }
     }
 
+    /// Hand an outbound packet addressed to ourselves straight to the target
+    /// local socket, synthesizing the headers a wire reception would carry.
+    fn deliver_local(&mut self, packet: &OutboundPacket, our_addr: AppleTalkAddress) {
+        let headers = DdpHeaders {
+            hop_count: 0,
+            len: packet.payload.len() + DdpHeaders::LEN,
+            chksum: 0,
+            dest_network_num: packet.dest.addr.network_number,
+            dest_sock_num: packet.dest.sock,
+            dest_node_id: packet.dest.addr.node_number,
+            src_network_num: our_addr.network_number,
+            src_sock_num: packet.src_sock,
+            src_node_id: our_addr.node_number,
+            protocol_typ: packet.protocol,
+        };
+        let sock_num = packet.dest.sock;
+        if let Some(socket) = self.sockets.get(&sock_num) {
+            match socket.try_send(Packet {
+                headers,
+                payload: packet.payload.clone(),
+            }) {
+                Ok(_) => {}
+                Err(TrySendError::Closed(_)) => {
+                    self.sockets.remove(&sock_num);
+                }
+                Err(TrySendError::Full(_)) => {
+                    tracing::error!("sock is full!");
+                }
+            }
+        } else {
+            tracing::debug!("DDP: dropping loopback packet, no socket {}", sock_num);
+        }
+    }
+
     async fn handle_outbound(&mut self, packet: OutboundPacket) {
         // Network-wide broadcast {0, 255}: send on every configured interface so
         // all nodes on each cable receive it, regardless of their network number.
@@ -372,11 +418,37 @@ impl DdpProcessor {
             return;
         }
 
+        // A datagram addressed to one of our own interface addresses never
+        // comes back off the wire (interfaces don't receive their own
+        // frames), so deliver it to the local socket directly. Local clients
+        // rely on this, e.g. to reach an NBP responder on their own node.
+        // Address {0,0} ("any net, any node") conventionally means the node
+        // itself — the kernel AppleTalk stacks loop it back the same way.
+        let dest = packet.dest.addr;
+        let to_self = dest.network_number == 0 && dest.node_number == 0;
+        if let Some(et) = &self.et_addressing
+            && let Ok(our) = et.addr().await
+            && (to_self
+                || (dest.node_number == our.node_number
+                    && (dest.network_number == our.network_number || dest.network_number == 0)))
+        {
+            self.deliver_local(&packet, our);
+            return;
+        }
+        if let Some(lt) = &self.lt_addressing
+            && let Ok(our) = lt.addr().await
+            && (to_self
+                || (dest.node_number == our.node_number
+                    && (dest.network_number == our.network_number || dest.network_number == 0)))
+        {
+            self.deliver_local(&packet, our);
+            return;
+        }
+
         // Routing happens here, not in the caller: first resolve the
         // link-level next hop (the destination itself when it is on one of
         // our cables or unknown, otherwise the responsible router from the
         // route table), then pick whichever interface reaches that hop.
-        let dest = packet.dest.addr;
         let hop = if dest.network_number == 0 {
             // Network 0 is by definition on the local cable.
             dest
@@ -389,15 +461,35 @@ impl DdpProcessor {
         };
 
         let dest_node = if hop.network_number == 0 {
-            if self.lt_addressing.is_none() {
-                tracing::error!(
-                    "DDP: dropping packet to {}.{} — next hop {}.{} is on LocalTalk, which is not configured",
-                    dest.network_number, dest.node_number,
-                    hop.network_number, hop.node_number,
-                );
-                return;
+            // Network 0 is ambiguous between LocalTalk and nonextended
+            // (Phase 1) EtherTalk. With only one of the two configured,
+            // there's nothing to disambiguate — it must be that one. With
+            // both configured, check whether this node has actually been
+            // learned as an EtherTalk Phase 1 peer (e.g. from a packet it
+            // sent us); only fall back to LocalTalk if it hasn't.
+            match (&self.lt_addressing, &self.et_addressing) {
+                (Some(_), None) => Node::LocalTalk(hop.node_number),
+                (None, Some(et)) => match et.try_lookup(&hop) {
+                    Some(node) => node,
+                    None => {
+                        tracing::error!(
+                            "DDP: dropping packet to {}.{} — next hop {}.{} is on network 0 but no EtherTalk Phase 1 binding is cached for it",
+                            dest.network_number, dest.node_number,
+                            hop.network_number, hop.node_number,
+                        );
+                        return;
+                    }
+                },
+                (Some(_), Some(et)) => et.try_lookup(&hop).unwrap_or(Node::LocalTalk(hop.node_number)),
+                (None, None) => {
+                    tracing::error!(
+                        "DDP: dropping packet to {}.{} — next hop {}.{} is on network 0, but no interfaces are configured",
+                        dest.network_number, dest.node_number,
+                        hop.network_number, hop.node_number,
+                    );
+                    return;
+                }
             }
-            Node::LocalTalk(hop.node_number)
         } else {
             let Some(et) = &self.et_addressing else {
                 tracing::error!(

--- a/tailtalk/src/nbp.rs
+++ b/tailtalk/src/nbp.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::io;
 use std::time::Duration;
 use tailtalk_packets::{
+    aarp::AppleTalkAddress,
     ddp::{DdpPacket, DdpProtocolType},
     nbp::{EntityName, NbpOperation, NbpPacket, NbpTuple},
 };
@@ -235,7 +236,7 @@ impl Nbp {
 
         match packet.operation {
             NbpOperation::Lookup => {
-                let response = self.generate_response(&packet, ddp.src_network_num).await;
+                let response = self.generate_response(&packet, ddp.src_network_num, ddp.src_node_id).await;
 
                 // Only send a reply if we have at least one matching tuple
                 if !response.tuples.is_empty() {
@@ -284,13 +285,26 @@ impl Nbp {
         }
     }
 
-    async fn generate_response(&self, nbp: &NbpPacket, source_network: u16) -> NbpPacket {
+    async fn generate_response(&self, nbp: &NbpPacket, source_network: u16, source_node: u8) -> NbpPacket {
         // Respond with the address on the same interface the lookup arrived from.
         let our_addr = if source_network == 0 {
-            if let Some(lt) = &self.lt_addressing {
-                lt.addr().await.expect("failed to get LT addr")
-            } else {
-                self.et_addressing.as_ref().expect("no addressing").addr().await.expect("failed to get ET addr")
+            // Network 0 is ambiguous between LocalTalk and nonextended
+            // EtherTalk (Phase 1). With only one interface configured, it
+            // must be that one. With both, check whether the requester has
+            // been learned as an EtherTalk Phase 1 peer before assuming
+            // LocalTalk.
+            match (&self.lt_addressing, &self.et_addressing) {
+                (Some(lt), None) => lt.addr().await.expect("failed to get LT addr"),
+                (None, Some(et)) => et.addr().await.expect("failed to get ET addr"),
+                (Some(lt), Some(et)) => {
+                    let peer = AppleTalkAddress { network_number: 0, node_number: source_node };
+                    if et.try_lookup(&peer).is_some() {
+                        et.addr().await.expect("failed to get ET addr")
+                    } else {
+                        lt.addr().await.expect("failed to get LT addr")
+                    }
+                }
+                (None, None) => panic!("no addressing configured"),
             }
         } else if let Some(et) = &self.et_addressing {
             et.addr().await.expect("failed to get ET addr")

--- a/tailtalk/src/remote.rs
+++ b/tailtalk/src/remote.rs
@@ -191,6 +191,7 @@ impl RemoteClient {
                 )),
                 dest_socket: dest_socket as u32,
                 payload: payload.to_vec(),
+                ddp_type: 0, // use the type the socket was opened with
             })),
         };
         self.req_tx


### PR DESCRIPTION
Netatalk's netddp underlay needs a few things TailTalk didn't provide: enabling reception of Ethernet multicast groups, stamping the DDP protocol type per-send rather than per-socket, and delivering datagrams addressed to our own node straight to the local socket instead of expecting them back off the wire. Also disambiguate network 0 between LocalTalk and nonextended (Phase 1) EtherTalk when both are configured, using the learned-peer cache to tell them apart in DDP routing and NBP lookup responses.

This commit marks the bare minimum needed to get Netatalk off the ground using entirely userspace networking via TailTalk.