### PR TITLE
IPP: Add Color StyleWriter support over ADSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2243,6 +2243,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "get_adapters_addresses"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa6d768b8f11cc8995f5c3f3f51660a50f8fa807eaeb83632d9afb4d42b0e493"
+dependencies = [
+ "thiserror 1.0.69",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6410,6 +6420,7 @@ dependencies = [
  "dashmap",
  "encoding_rs",
  "futures",
+ "get_adapters_addresses",
  "im",
  "mac_address",
  "magic-db",

--- a/examples/adsp-stylewriter/main.rs
+++ b/examples/adsp-stylewriter/main.rs
@@ -3,7 +3,11 @@ use std::io::Write;
 use tailtalk::{
     TalkStack,
     adsp::AdspAddress,
-    stylewriter::{StyleWriterEncoder, StyleWriterSession, MAX_BATCH_BYTES, SW2200_PRINT_ROWBYTES, SW2200_PRINT_WIDTH},
+    stylewriter::{
+        MAX_BATCH_BYTES, PrintQuality, SW2200_PRINT_ROWBYTES, SW2200_PRINT_WIDTH,
+        StyleWriterEncoder, StyleWriterSession, chunky_to_mono_plane, chunky_to_planes,
+        encode_page_batches,
+    },
 };
 use tailtalk_packets::nbp::EntityName;
 
@@ -42,79 +46,10 @@ struct Args {
     #[arg(long)]
     mono: bool,
 
-}
-
-/// Unpack one chunky scanline into raw (pre-RLE) CMYK planar bytes.
-fn chunky_to_planes(chunky: &[u8], planar_input_len: usize) -> [Vec<u8>; 4] {
-    let mut planes = [
-        Vec::with_capacity(planar_input_len),
-        Vec::with_capacity(planar_input_len),
-        Vec::with_capacity(planar_input_len),
-        Vec::with_capacity(planar_input_len),
-    ];
-
-    for chunk_block in chunky.chunks(4) {
-        let mut c = 0u8;
-        let mut m = 0u8;
-        let mut y = 0u8;
-        let mut k = 0u8;
-        for i in 0..4 {
-            let b = chunk_block.get(i).copied().unwrap_or(0);
-            c = (c << 2) | ((b >> 6) & 2) | ((b >> 3) & 1);
-            m = (m << 2) | ((b >> 5) & 2) | ((b >> 2) & 1);
-            y = (y << 2) | ((b >> 4) & 2) | ((b >> 1) & 1);
-            k = (k << 2) | ((b >> 3) & 2) | (b & 1);
-        }
-        planes[0].push(c);
-        planes[1].push(m);
-        planes[2].push(y);
-        planes[3].push(k);
-    }
-    planes
-}
-
-/// Unpack one chunky scanline's K-nibble bit only into a raw (pre-RLE) plane.
-fn chunky_to_mono_plane(chunky: &[u8], planar_input_len: usize) -> Vec<u8> {
-    let mut plane = Vec::with_capacity(planar_input_len);
-    for chunk_block in chunky.chunks(4) {
-        let mut k = 0u8;
-        for i in 0..4 {
-            let b = chunk_block.get(i).copied().unwrap_or(0);
-            k = (k << 2) | ((b >> 3) & 2) | (b & 1);
-        }
-        plane.push(k);
-    }
-    plane
-}
-
-/// Encode one row's plane(s) into concatenated RLE bytes. `use_delta` XORs
-/// each plane against the previous row's raw plane first (lpstyl's
-/// `appendEncode()` differencing).
-///
-/// Delta is NOT optional for color: 'c'/"m2sAH" mode reconstructs each row
-/// by XORing against the previous one, so absolute rows print as
-/// cumulative-XOR garbage. Monochrome 'R'/"m2nZAB" bands are absolute.
-///
-/// `use_delta` must be false for the first row of every rect+G block, since
-/// the printer's differencing state resets per block. Does not mutate
-/// `last` — the caller updates it once per source row, so a row re-encoded
-/// after a batch flush still deltas correctly.
-fn encode_row(planes: &[Vec<u8>], last: &[Vec<u8>], use_delta: bool, mono: bool) -> Vec<u8> {
-    let mut out = Vec::new();
-    for (i, plane) in planes.iter().enumerate() {
-        let delta;
-        let src = if use_delta {
-            delta = plane.iter().zip(last[i].iter()).map(|(c, l)| c ^ l).collect::<Vec<u8>>();
-            &delta
-        } else {
-            plane
-        };
-        // K plane (mono, or index 3 of CMYK) never uses the blank-shortcut
-        // (see encode_scanline docs); C/M/Y planes do.
-        let allow_shortcut = !mono && i != 3;
-        out.extend_from_slice(&StyleWriterEncoder::encode_scanline(src, SW2200_PRINT_ROWBYTES, allow_shortcut));
-    }
-    out
+    /// Print quality: "normal" or "best" (see PrintQuality docs for which
+    /// combinations are verified on real hardware)
+    #[arg(short, long, default_value = "normal")]
+    quality: String,
 }
 
 #[tokio::main]
@@ -123,10 +58,13 @@ async fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
 
+    let quality = match args.quality.as_str() {
+        "normal" => PrintQuality::Normal,
+        "best" => PrintQuality::Best,
+        other => anyhow::bail!("Unknown quality '{other}' (expected 'normal' or 'best')"),
+    };
+
     let raw_data = std::fs::read(&args.file)?;
-    // Color rows must be XOR-delta encoded; mono rows must be absolute
-    // (see encode_row) — this is the printer's wire format, not a choice.
-    let use_delta = !args.mono;
     let width_pixels = args.width;
     let chunky_scanline_len = width_pixels / 2;
     let planar_scanline_len = width_pixels / 8;
@@ -136,49 +74,36 @@ async fn main() -> anyhow::Result<()> {
     eprintln!("SW2200_PRINT_ROWBYTES = {}, padding {} px per plane with white",
         SW2200_PRINT_ROWBYTES, SW2200_PRINT_WIDTH - width_pixels);
 
+    // Unpack every chunky scanline into raw planar rows, then encode the
+    // whole page into rect+G bands (delta chains and band splitting live in
+    // encode_page_batches).
+    let rows: Vec<Vec<Vec<u8>>> = raw_data
+        .chunks(chunky_scanline_len)
+        .take(total_rows)
+        .map(|chunky| {
+            if args.mono {
+                vec![chunky_to_mono_plane(chunky, planar_scanline_len)]
+            } else {
+                chunky_to_planes(chunky, planar_scanline_len).into()
+            }
+        })
+        .collect();
+    let batches = encode_page_batches(&rows, args.mono);
+
     // ── Dump mode: write raster blocks to stdout for comparison with C reference ─
     if args.dump {
         let stdout = std::io::stdout();
         let mut out = stdout.lock();
-        let mut batch_start = 0usize;
-        let mut batch_data = Vec::new();
-        let mut last_planes = vec![vec![0u8; planar_scanline_len]; if args.mono { 1 } else { 4 }];
-        for (row_idx, chunky) in raw_data.chunks(chunky_scanline_len).enumerate() {
-            let planes: Vec<Vec<u8>> = if args.mono {
-                vec![chunky_to_mono_plane(chunky, planar_scanline_len)]
-            } else {
-                chunky_to_planes(chunky, planar_scanline_len).into()
-            };
-            let mut row_enc = encode_row(&planes, &last_planes, use_delta && !batch_data.is_empty(), args.mono);
-            // Flush before this row would cross the printer's buffer size:
-            // one G block must stay strictly below MAX_BATCH_BYTES.
-            if !batch_data.is_empty() && batch_data.len() + row_enc.len() >= MAX_BATCH_BYTES {
-                let rect = StyleWriterEncoder::encode_rect(
-                    batch_start as u16, 0, (row_idx - 1) as u16, SW2200_PRINT_WIDTH as u16, !args.mono,
-                );
-                let g_block = StyleWriterEncoder::wrap_raster_chunk(&batch_data);
-                out.write_all(&rect)?;
-                out.write_all(&g_block)?;
-                batch_start = row_idx;
-                batch_data.clear();
-                if use_delta {
-                    // This row now starts a new block: the delta chain resets.
-                    row_enc = encode_row(&planes, &last_planes, false, args.mono);
-                }
-            }
-            batch_data.extend_from_slice(&row_enc);
-            last_planes = planes;
-            if row_idx + 1 == total_rows {
-                // Rows are padded to the full printable width, so the rect
-                // right edge is SW2200_PRINT_WIDTH (not the source width) —
-                // keeps dump output byte-identical to what write_batch sends.
-                let rect = StyleWriterEncoder::encode_rect(
-                    batch_start as u16, 0, row_idx as u16, SW2200_PRINT_WIDTH as u16, !args.mono,
-                );
-                let g_block = StyleWriterEncoder::wrap_raster_chunk(&batch_data);
-                out.write_all(&rect)?;
-                out.write_all(&g_block)?;
-            }
+        for batch in &batches {
+            // Rows are padded to the full printable width, so the rect
+            // right edge is SW2200_PRINT_WIDTH (not the source width) —
+            // keeps dump output byte-identical to what write_batch sends.
+            let rect = StyleWriterEncoder::encode_rect(
+                batch.top, 0, batch.bottom, SW2200_PRINT_WIDTH as u16, !args.mono,
+            );
+            let g_block = StyleWriterEncoder::wrap_raster_chunk(&batch.data);
+            out.write_all(&rect)?;
+            out.write_all(&g_block)?;
         }
         return Ok(());
     }
@@ -217,44 +142,20 @@ async fn main() -> anyhow::Result<()> {
     };
 
     eprintln!("Connecting to printer...");
-    let mut session = StyleWriterSession::connect(&stack, printer_addr, &args.username).await?;
+    let mut session = StyleWriterSession::connect(&stack.ddp, printer_addr, &args.username).await?;
     eprintln!("Connected! Running setup...");
 
     // Run setup + raster transmission in a block so any failure can eject
     // the loaded page and reset the printer instead of leaving it stuck.
     let print_result: anyhow::Result<()> = async {
-        session.setup(!args.mono).await?;
+        session.setup(!args.mono, quality).await?;
 
-        eprintln!("Encoding and transmitting {} rasters ({}batched, {} bytes/batch max)...",
+        eprintln!("Transmitting {} rasters as {} delta-encoded band(s) ({} bytes/batch max)...",
             if args.mono { "monochrome" } else { "color" },
-            if use_delta { "delta-encoded, " } else { "" },
+            batches.len(),
             MAX_BATCH_BYTES);
-        let mut batch_start = 0usize;
-        let mut batch_data = Vec::new();
-        let mut last_planes = vec![vec![0u8; planar_scanline_len]; if args.mono { 1 } else { 4 }];
-        for (row_idx, chunky) in raw_data.chunks(chunky_scanline_len).enumerate() {
-            let planes: Vec<Vec<u8>> = if args.mono {
-                vec![chunky_to_mono_plane(chunky, planar_scanline_len)]
-            } else {
-                chunky_to_planes(chunky, planar_scanline_len).into()
-            };
-            let mut row_enc = encode_row(&planes, &last_planes, use_delta && !batch_data.is_empty(), args.mono);
-            // Flush before this row would cross the printer's buffer size:
-            // one G block must stay strictly below MAX_BATCH_BYTES.
-            if !batch_data.is_empty() && batch_data.len() + row_enc.len() >= MAX_BATCH_BYTES {
-                session.write_batch(batch_start as u16, (row_idx - 1) as u16, &batch_data, !args.mono).await?;
-                batch_start = row_idx;
-                batch_data.clear();
-                if use_delta {
-                    // This row now starts a new block: the delta chain resets.
-                    row_enc = encode_row(&planes, &last_planes, false, args.mono);
-                }
-            }
-            batch_data.extend_from_slice(&row_enc);
-            last_planes = planes;
-            if row_idx + 1 == total_rows {
-                session.write_batch(batch_start as u16, row_idx as u16, &batch_data, !args.mono).await?;
-            }
+        for batch in &batches {
+            session.write_batch(batch.top, batch.bottom, &batch.data, !args.mono).await?;
         }
         Ok(())
     }

--- a/tailtalk-gui/ipp_bridge.rs
+++ b/tailtalk-gui/ipp_bridge.rs
@@ -20,8 +20,19 @@ use std::{
 use axum::{Router, body::Bytes, extract::{Path, State}, routing::post};
 use ipp::{parser::IppParser, prelude::*, reader::IppReader};
 use mdns_sd::{ServiceDaemon, ServiceInfo};
-use tailtalk::{atp::{Atp, AtpAddress}, ddp::DdpHandle, nbp::NbpHandle, pap::PapClient, CancellationToken};
-use tailtalk_packets::nbp::EntityName;
+use tailtalk::{
+    CancellationToken,
+    adsp::AdspAddress,
+    atp::{Atp, AtpAddress},
+    ddp::DdpHandle,
+    nbp::NbpHandle,
+    pap::PapClient,
+    stylewriter::{
+        PrintQuality, PrinterBusy, SW2200_PRINT_ROWBYTES, SW2200_PRINT_WIDTH,
+        StyleWriterSession, encode_page_batches,
+    },
+};
+use tailtalk_packets::nbp::{EntityName, ServiceAddress};
 use tokio::sync::{Mutex, RwLock};
 
 // Standard media sizes supported by all LaserWriters.
@@ -35,6 +46,12 @@ const STANDARD_MEDIA: &[&str] = &[
     "na_monarch_3.875x7.5in",
     "iso_c5_162x229mm",
     "iso_dl_110x220mm",
+];
+
+// Extra sizes the StyleWriter's sheet feeder handles beyond STANDARD_MEDIA.
+// "invoice" is the PWG self-describing name for half letter / statement.
+const STYLEWRITER_EXTRA_MEDIA: &[&str] = &[
+    "na_invoice_5.5x8.5in",
 ];
 
 #[derive(Clone, Debug, PartialEq)]
@@ -64,6 +81,24 @@ struct JobRecord {
     created_at: u32,
 }
 
+/// Which AppleTalk print path a discovered printer uses.
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum PrinterKind {
+    /// PostScript printer driven over PAP (NBP type "LaserWriter").
+    LaserWriter,
+    /// Color StyleWriter behind an EtherTalk adapter, driven over ADSP
+    /// (NBP type "ColorStyleWriter2400AT").
+    StyleWriter,
+}
+
+/// StyleWriters print at a fixed 360 dpi.
+const SW_DPI: u32 = 360;
+/// Printable-area margins at 360 dpi (lpstyl `printerSetup()` for the CS
+/// family): 72 px (9 bytes) left, 90 px top and bottom.
+const SW_LEFT_MARGIN_PX: usize = 72;
+const SW_TOP_MARGIN_ROWS: usize = 90;
+const SW_BOTTOM_MARGIN_ROWS: usize = 90;
+
 #[derive(Clone)]
 struct PrinterCaps {
     dpi: u32,
@@ -90,10 +125,18 @@ impl Default for PrinterCaps {
 #[derive(Clone)]
 struct Printer {
     name: String,
-    addr: AtpAddress,
+    kind: PrinterKind,
+    addr: ServiceAddress,
     key: String,
     mdns_fullname: String,
     caps: PrinterCaps,
+}
+
+impl Printer {
+    /// The DDP endpoint viewed as an ADSP address (StyleWriter path).
+    fn adsp_addr(&self) -> AdspAddress {
+        self.addr.into()
+    }
 }
 
 struct BridgeState {
@@ -102,10 +145,11 @@ struct BridgeState {
     jobs: RwLock<HashMap<u32, Arc<Mutex<JobRecord>>>>,
     next_job_id: AtomicU32,
     start_time: Instant,
-    /// Per-printer locks (keyed by printer key) serialising PAP sessions:
-    /// LaserWriters accept one PAP connection at a time and connect() gives
-    /// up after 60s of busy-retries, so concurrent jobs must queue here.
-    pap_locks: std::sync::Mutex<HashMap<String, Arc<Mutex<()>>>>,
+    /// Per-printer locks (keyed by printer key) serialising print sessions:
+    /// LaserWriters accept one PAP connection at a time (and connect() gives
+    /// up after 60s of busy-retries); StyleWriters likewise hold a single
+    /// ADSP print connection. Concurrent jobs must queue here.
+    job_locks: std::sync::Mutex<HashMap<String, Arc<Mutex<()>>>>,
 }
 
 pub async fn run(nbp: NbpHandle, ddp: DdpHandle, token: CancellationToken) {
@@ -133,7 +177,7 @@ pub async fn run(nbp: NbpHandle, ddp: DdpHandle, token: CancellationToken) {
         jobs: RwLock::new(HashMap::new()),
         next_job_id: AtomicU32::new(1),
         start_time: Instant::now(),
-        pap_locks: std::sync::Mutex::new(HashMap::new()),
+        job_locks: std::sync::Mutex::new(HashMap::new()),
     });
 
     let app = Router::new()
@@ -214,27 +258,60 @@ fn urf_string(caps: &PrinterCaps) -> String {
     format!("W8,SRGB24,CP1,RS{}", caps.dpi)
 }
 
+/// IPP endpoint key for a discovered printer: name slug + AppleTalk address,
+/// plus a "-sw" tag for StyleWriters. The address keeps two identically-named
+/// devices on different nodes from colliding on one /ipp/{key} route; the tag
+/// keeps a LaserWriter and StyleWriter that share a name apart.
+fn printer_key(kind: PrinterKind, name: &str, addr: ServiceAddress) -> String {
+    let key = make_key(name);
+    let a = format!("{}-{}-{}", addr.network_number, addr.node_number, addr.socket_number);
+    match kind {
+        PrinterKind::LaserWriter => format!("{key}-{a}"),
+        PrinterKind::StyleWriter => format!("{key}-{a}-sw"),
+    }
+}
+
 async fn discover(
     nbp: &NbpHandle,
     ddp: &DdpHandle,
     printers: &Arc<RwLock<Vec<Printer>>>,
     mdns: &ServiceDaemon,
 ) {
-    let entity: EntityName = match "=:LaserWriter@*".try_into() {
-        Ok(e) => e,
-        Err(e) => { tracing::error!("IPP bridge: bad entity name: {e}"); return; }
-    };
+    // (kind, NBP type pattern) for each supported printer family.
+    let lookups: [(PrinterKind, &str); 2] = [
+        (PrinterKind::LaserWriter, "=:LaserWriter@*"),
+        (PrinterKind::StyleWriter, "=:ColorStyleWriter2400AT@*"),
+    ];
 
-    let tuples = match nbp.lookup(entity).await {
-        Ok(t) => t,
-        Err(e) => { tracing::warn!("IPP bridge: NBP lookup failed: {e}"); return; }
-    };
+    let entities: Vec<(PrinterKind, EntityName)> = lookups
+        .iter()
+        .filter_map(|(kind, pattern)| match (*pattern).try_into() {
+            Ok(e) => Some((*kind, e)),
+            Err(e) => { tracing::error!("IPP bridge: bad entity name '{pattern}': {e}"); None }
+        })
+        .collect();
 
-    tracing::info!("IPP bridge: found {} LaserWriter(s)", tuples.len());
+    let mut tuples: Vec<(PrinterKind, tailtalk_packets::nbp::NbpTuple)> = Vec::new();
+    // If the lookup errors, keep the existing registrations rather than
+    // pruning them on a transient failure.
+    let mut lookup_ok: Vec<PrinterKind> = Vec::new();
+    // Both name patterns go out as one concurrent batch, sharing a single
+    // NBP reply-collection window.
+    let names: Vec<EntityName> = entities.iter().map(|(_, e)| e.clone()).collect();
+    match nbp.lookup_many(names).await {
+        Ok(results) => {
+            for ((kind, _), found) in entities.iter().zip(results) {
+                tracing::info!("IPP bridge: found {} {kind:?}(s)", found.len());
+                lookup_ok.push(*kind);
+                tuples.extend(found.into_iter().map(|t| (*kind, t)));
+            }
+        }
+        Err(e) => tracing::warn!("IPP bridge: NBP lookup failed: {e}"),
+    }
 
     let new_keys: HashSet<String> = tuples.iter()
-        .map(|t| make_key(&t.entity_name.object))
-        .filter(|k| !k.is_empty())
+        .filter(|(_, t)| !make_key(&t.entity_name.object).is_empty())
+        .map(|(kind, t)| printer_key(*kind, &t.entity_name.object, t.service_address()))
         .collect();
 
     // Prune vanished printers under a short-lived write lock, then release it:
@@ -243,7 +320,7 @@ async fn discover(
     let mut current_keys: HashSet<String> = {
         let mut current = printers.write().await;
         current.retain(|p| {
-            if new_keys.contains(&p.key) {
+            if new_keys.contains(&p.key) || !lookup_ok.contains(&p.kind) {
                 true
             } else {
                 if let Ok(rx) = mdns.unregister(&p.mdns_fullname) { drop(rx); }
@@ -253,20 +330,48 @@ async fn discover(
         current.iter().map(|p| p.key.clone()).collect()
     };
 
-    for tuple in &tuples {
+    // Names that appear on more than one device this cycle. The mDNS instance
+    // name must be unique, so those get disambiguated by address below.
+    let mut name_counts: HashMap<&str, usize> = HashMap::new();
+    for (_, t) in &tuples {
+        *name_counts.entry(t.entity_name.object.as_str()).or_default() += 1;
+    }
+
+    for (kind, tuple) in &tuples {
+        let kind = *kind;
         let name = tuple.entity_name.object.clone();
-        let key = make_key(&name);
-        if key.is_empty() || current_keys.contains(&key) {
+        let addr = tuple.service_address();
+        let key = printer_key(kind, &name, addr);
+        if make_key(&name).is_empty() || current_keys.contains(&key) {
             continue;
         }
 
-        let addr = AtpAddress {
-            network_number: tuple.network_number,
-            node_number: tuple.node_id,
-            socket_number: tuple.socket_number,
+        let caps = match kind {
+            PrinterKind::LaserWriter => query_printer_caps(ddp, addr.into()).await,
+            PrinterKind::StyleWriter => {
+                match query_stylewriter_caps(ddp, addr.into()).await {
+                    Ok(caps) => caps,
+                    Err(e) if e.downcast_ref::<PrinterBusy>().is_some() => {
+                        // Someone is printing; retry on the next discovery
+                        // cycle rather than registering with guessed caps.
+                        tracing::info!("IPP bridge: StyleWriter '{name}' is busy, deferring registration");
+                        continue;
+                    }
+                    Err(e) => {
+                        tracing::warn!("IPP bridge: StyleWriter caps query for '{name}' failed ({e}), using defaults");
+                        default_stylewriter_caps()
+                    }
+                }
+            }
         };
 
-        let caps = query_printer_caps(ddp, addr).await;
+        // When two devices share a name, the mDNS instance name (which must be
+        // unique) gets an address tag so both show up; unique names stay clean.
+        let instance_name = if name_counts.get(name.as_str()).copied().unwrap_or(0) > 1 {
+            format!("{name} ({}-{})", addr.network_number, addr.node_number)
+        } else {
+            name.clone()
+        };
 
         let hostname = format!("tailtalk-{key}.local.");
         let rp = format!("ipp/{key}");
@@ -292,7 +397,7 @@ async fn discover(
         props.push(("pdl", "application/pdf,application/postscript"));
 
         let addrs = local_ipv4_addrs();
-        let service_info = match ServiceInfo::new("_universal._sub._ipp._tcp.local.", &name, &hostname, addrs.as_slice(), 8631u16, &props[..]) {
+        let service_info = match ServiceInfo::new("_universal._sub._ipp._tcp.local.", &instance_name, &hostname, addrs.as_slice(), 8631u16, &props[..]) {
             Ok(si) => si,
             Err(e) => { tracing::warn!("IPP bridge: ServiceInfo error for '{name}': {e}"); continue; }
         };
@@ -309,9 +414,47 @@ async fn discover(
             caps.dpi, caps.color, caps.media_default,
         );
         current_keys.insert(key.clone());
-        printers.write().await.push(Printer { name, addr, key, mdns_fullname, caps });
+        printers.write().await.push(Printer { name, kind, addr, key, mdns_fullname, caps });
     }
 
+}
+
+/// Fallback caps when a StyleWriter is discovered but its info query fails.
+/// Assume color: a color job on a black cartridge is refused cleanly at
+/// setup time ('H' check), whereas advertising mono-only would permanently
+/// hide a working color printer.
+fn default_stylewriter_caps() -> PrinterCaps {
+    PrinterCaps {
+        dpi: SW_DPI,
+        color: true,
+        model: "Apple Color StyleWriter".to_string(),
+        media_default: "na_letter_8.5x11in".to_string(),
+        tray_sources: vec!["main".into()],
+    }
+}
+
+/// Query a StyleWriter's model and installed cartridge over a short-lived
+/// ADSP session (no page is fed). Propagates [`PrinterBusy`] so the caller
+/// can defer registration instead of guessing.
+async fn query_stylewriter_caps(ddp: &DdpHandle, addr: AdspAddress) -> anyhow::Result<PrinterCaps> {
+    let mut session = StyleWriterSession::connect(ddp, addr, "TailTalk").await?;
+    let info = session.query_info().await;
+    let _ = session.abort().await;
+    let info = info?;
+
+    tracing::info!(
+        "IPP bridge: StyleWriter identity '{}' submodel {:?} cartridge={}",
+        info.identity,
+        info.submodel,
+        if info.color_cartridge { "color" } else { "black" },
+    );
+
+    Ok(PrinterCaps {
+        dpi: SW_DPI,
+        color: info.color_capable(),
+        model: info.model_name().to_string(),
+        ..default_stylewriter_caps()
+    })
 }
 
 /// Query printer capabilities via the PostScript Query Protocol.
@@ -613,49 +756,72 @@ async fn handle_ipp(
             tracing::info!("IPP: PrintJob id={job_id} fmt={fmt:?} doc_bytes={} tray={tray:?}", doc.len());
 
             let ddp = state.ddp.clone();
-            let addr = printer.addr;
-            let dpi = printer.caps.dpi;
-            let pap_lock = {
-                let mut locks = state.pap_locks.lock().unwrap();
+            let job_lock = {
+                let mut locks = state.job_locks.lock().unwrap();
                 locks.entry(printer.key.clone()).or_default().clone()
             };
-            tokio::spawn(async move {
-                job.lock().await.state_message = "Rasterizing".to_string();
-                let (ps, page_count) = match rasterize_to_ps(doc, &fmt, &tray, dpi, job_id).await {
-                    Ok(r) => r,
-                    Err(e) => {
-                        tracing::error!("IPP: rasterize failed: {e}");
-                        let mut j = job.lock().await;
-                        j.state = JobState::Aborted;
-                        j.state_message = format!("Rasterize failed: {e}");
-                        return;
-                    }
-                };
-                tracing::info!("IPP: rasterized {page_count} page(s) to {} bytes PS", ps.len());
-                job.lock().await.state_message = "Waiting for printer".to_string();
-                let _pap_guard = pap_lock.lock().await;
-                job.lock().await.state_message = "Printing".to_string();
-                match print_to_pap(ddp, addr, ps).await {
-                    Ok(printer_output) => {
-                        let mut j = job.lock().await;
-                        j.impressions_completed = page_count as i32;
-                        if let Some(err) = parse_printer_error(&printer_output) {
-                            tracing::warn!("IPP: job {job_id} printer error: {err}");
-                            j.state = JobState::Aborted;
-                            j.state_message = err;
-                        } else {
-                            j.state = JobState::Completed;
-                            j.state_message = "Completed".to_string();
+            match printer.kind {
+                PrinterKind::LaserWriter => {
+                    let addr: AtpAddress = printer.addr.into();
+                    let dpi = printer.caps.dpi;
+                    tokio::spawn(async move {
+                        job.lock().await.state_message = "Rasterizing".to_string();
+                        let (ps, page_count) = match rasterize_to_ps(doc, &fmt, &tray, dpi, job_id).await {
+                            Ok(r) => r,
+                            Err(e) => {
+                                tracing::error!("IPP: rasterize failed: {e}");
+                                let mut j = job.lock().await;
+                                j.state = JobState::Aborted;
+                                j.state_message = format!("Rasterize failed: {e}");
+                                return;
+                            }
+                        };
+                        tracing::info!("IPP: rasterized {page_count} page(s) to {} bytes PS", ps.len());
+                        job.lock().await.state_message = "Waiting for printer".to_string();
+                        let _pap_guard = job_lock.lock().await;
+                        job.lock().await.state_message = "Printing".to_string();
+                        match print_to_pap(ddp, addr, ps).await {
+                            Ok(printer_output) => {
+                                let mut j = job.lock().await;
+                                j.impressions_completed = page_count as i32;
+                                if let Some(err) = parse_printer_error(&printer_output) {
+                                    tracing::warn!("IPP: job {job_id} printer error: {err}");
+                                    j.state = JobState::Aborted;
+                                    j.state_message = err;
+                                } else {
+                                    j.state = JobState::Completed;
+                                    j.state_message = "Completed".to_string();
+                                }
+                            }
+                            Err(e) => {
+                                tracing::error!("IPP: job {job_id} PAP error: {e}");
+                                let mut j = job.lock().await;
+                                j.state = JobState::Aborted;
+                                j.state_message = format!("PAP error: {e}");
+                            }
                         }
-                    }
-                    Err(e) => {
-                        tracing::error!("IPP: job {job_id} PAP error: {e}");
-                        let mut j = job.lock().await;
-                        j.state = JobState::Aborted;
-                        j.state_message = format!("PAP error: {e}");
-                    }
+                    });
                 }
-            });
+                PrinterKind::StyleWriter => {
+                    // Mono jobs take the K-only path even on a color cartridge:
+                    // true black beats CMY-composite gray and saves the color inks.
+                    let color = printer.caps.color
+                        && job_color_mode(&parsed).as_deref() != Some("monochrome");
+                    let quality = match job_print_quality(&parsed) {
+                        Some(5) => PrintQuality::Best,
+                        _ => PrintQuality::Normal,
+                    };
+                    let username = job_user_name(&parsed)
+                        .unwrap_or_else(|| "TailTalk".to_string());
+                    let addr = printer.adsp_addr();
+                    tracing::info!(
+                        "IPP: StyleWriter job {job_id}: color={color} quality={quality:?} user={username}"
+                    );
+                    tokio::spawn(run_stylewriter_job(
+                        job, ddp, addr, doc, fmt, color, quality, username, job_lock, job_id,
+                    ));
+                }
+            }
             job_created_response(job_id, &job_uri, req_id)
         }
         op if op == Operation::ValidateJob as u16 => ipp_ok(req_id),
@@ -734,6 +900,24 @@ fn printer_attributes(printer: &Printer, req_id: u32) -> axum::response::Respons
     let uri = format!("ipp://localhost:8631/ipp/{}", printer.key);
     let caps = &printer.caps;
 
+    // A StyleWriter with a black cartridge really is monochrome-only; the
+    // LaserWriter path always accepts color input (ghostscript converts).
+    let color_modes: &[&str] = match printer.kind {
+        PrinterKind::StyleWriter if !caps.color => &["monochrome"],
+        _ => &["auto", "color", "monochrome"],
+    };
+    let color_mode_default = if printer.kind == PrinterKind::StyleWriter && caps.color {
+        "auto"
+    } else {
+        "monochrome"
+    };
+    // StyleWriter quality maps to the printer's own mode string (normal/best);
+    // draft has no known string, so it isn't offered there.
+    let qualities: &[i32] = match printer.kind {
+        PrinterKind::LaserWriter => &[3, 4, 5],
+        PrinterKind::StyleWriter => &[4, 5],
+    };
+
     let mut add = |name: &str, val: IppValue| {
         if let Ok(a) = IppAttribute::with_name(name, val) {
             resp.attributes_mut().add(DelimiterTag::PrinterAttributes, a);
@@ -771,13 +955,15 @@ fn printer_attributes(printer: &Printer, req_id: u32) -> axum::response::Respons
     if let Ok(t) = "".try_into() { add("printer-location", IppValue::TextWithoutLanguage(t)); }
     // output-mode-supported: older Apple attribute; synonym for print-color-mode-supported.
     {
-        let modes: Vec<IppValue> = ["auto", "color", "monochrome"].iter().copied()
+        let modes: Vec<IppValue> = color_modes.iter().copied()
             .filter_map(|k| k.try_into().ok())
             .map(IppValue::Keyword)
             .collect();
         add("output-mode-supported", IppValue::Array(modes));
     }
-    add("pages-per-minute", IppValue::Integer(8));
+    add("pages-per-minute", IppValue::Integer(
+        match printer.kind { PrinterKind::LaserWriter => 8, PrinterKind::StyleWriter => 1 },
+    ));
     add("pdf-k-octets-supported", IppValue::RangeOfInteger { min: 1, max: 65535 });
     add("jpeg-k-octets-supported", IppValue::RangeOfInteger { min: 1, max: 65535 });
     add("printer-state", IppValue::Enum(3)); // idle
@@ -832,7 +1018,11 @@ fn printer_attributes(printer: &Printer, req_id: u32) -> axum::response::Respons
     });
 
     {
-        let vals: Vec<IppValue> = STANDARD_MEDIA.iter().copied()
+        let mut media: Vec<&str> = STANDARD_MEDIA.to_vec();
+        if printer.kind == PrinterKind::StyleWriter {
+            media.extend_from_slice(STYLEWRITER_EXTRA_MEDIA);
+        }
+        let vals: Vec<IppValue> = media.into_iter()
             .filter_map(|m| m.try_into().ok())
             .map(IppValue::Keyword)
             .collect();
@@ -867,19 +1057,18 @@ fn printer_attributes(printer: &Printer, req_id: u32) -> axum::response::Respons
     add("sides-supported", IppValue::Keyword("one-sided".try_into().unwrap()));
     add("print-quality-default", IppValue::Enum(4)); // 4 = normal
     {
-        let vals = vec![IppValue::Enum(3), IppValue::Enum(4), IppValue::Enum(5)]; // draft/normal/high
+        let vals: Vec<IppValue> = qualities.iter().map(|&q| IppValue::Enum(q)).collect();
         add("print-quality-supported", IppValue::Array(vals));
     }
     // macOS Photos checks print-color-mode-supported before queuing photo jobs.
-    // Advertise all modes; ghostscript converts colour → mono for this printer.
     {
-        let modes: Vec<IppValue> = ["auto", "color", "monochrome"].iter().copied()
+        let modes: Vec<IppValue> = color_modes.iter().copied()
             .filter_map(|k| k.try_into().ok())
             .map(IppValue::Keyword)
             .collect();
         add("print-color-mode-supported", IppValue::Array(modes));
     }
-    if let Ok(k) = "monochrome".try_into() {
+    if let Ok(k) = color_mode_default.try_into() {
         add("print-color-mode-default", IppValue::Keyword(k));
     }
 
@@ -923,6 +1112,47 @@ fn job_media_source(parsed: &IppRequestResponse) -> String {
             }
         })
         .unwrap_or_else(|| "main".to_string())
+}
+
+/// Extract the requested color mode: `print-color-mode`, falling back to the
+/// older Apple `output-mode` synonym.
+fn job_color_mode(parsed: &IppRequestResponse) -> Option<String> {
+    let group = parsed.attributes()
+        .groups_of(DelimiterTag::JobAttributes)
+        .next()?;
+    for name in ["print-color-mode", "output-mode"] {
+        if let Some(a) = group.attributes().get(name)
+            && let IppValue::Keyword(k) = a.value() {
+                return Some(k.as_str().to_string());
+            }
+    }
+    None
+}
+
+/// Extract the `print-quality` job attribute (3=draft, 4=normal, 5=high).
+fn job_print_quality(parsed: &IppRequestResponse) -> Option<i32> {
+    parsed.attributes()
+        .groups_of(DelimiterTag::JobAttributes)
+        .next()
+        .and_then(|g| g.attributes().get("print-quality"))
+        .and_then(|a| match a.value() {
+            IppValue::Enum(v) | IppValue::Integer(v) => Some(*v),
+            _ => None,
+        })
+}
+
+/// Extract `requesting-user-name` (sent to the StyleWriter in its
+/// print-request handshake, where the real Mac driver sends the chooser name).
+fn job_user_name(parsed: &IppRequestResponse) -> Option<String> {
+    parsed.attributes()
+        .groups_of(DelimiterTag::OperationAttributes)
+        .next()
+        .and_then(|g| g.attributes().get("requesting-user-name"))
+        .and_then(|a| match a.value() {
+            IppValue::NameWithoutLanguage(n) => Some(n.as_str().to_string()),
+            IppValue::TextWithoutLanguage(t) => Some(t.to_string()),
+            _ => None,
+        })
 }
 
 /// Convert `image/urf` to a format gs can rasterize.
@@ -1033,22 +1263,20 @@ pub fn gs_probe() -> bool {
     }
 }
 
-// gs pbmraw → per-page PS Level-2 image; most reliable path for classic LaserWriter firmware.
-async fn rasterize_to_ps(mut data: Vec<u8>, fmt: &str, tray_source: &str, dpi: u32, job_token: u32) -> anyhow::Result<(Vec<u8>, usize)> {
-    if fmt == "application/postscript" || fmt == "application/vnd.cups-postscript" {
-        let page_count = data.windows(7).filter(|w| *w == b"%%Page:").count().max(1);
-        return Ok((data, page_count));
-    }
+/// Rasterize a PDF/PS/URF document with Ghostscript to a raw raster device
+/// (`pbmraw`, `ppmraw`, …) at `dpi`, returning the concatenated raw pages.
+async fn gs_raster(mut data: Vec<u8>, fmt: &str, device: &str, dpi: u32, job_token: u32) -> anyhow::Result<Vec<u8>> {
     // Track whether urf_to_rasterizable ran — on Linux it returns PostScript, not PDF.
     let is_urf = fmt == "image/urf" || data.starts_with(b"UNIRAST");
     if is_urf {
         data = urf_to_rasterizable(data, job_token).await?;
     }
 
-    // pbmraw cannot write to stdout, so use a temp file.
+    // Raw raster devices cannot write to stdout, so use a temp file.
     let tmp = std::env::temp_dir();
-    let pbm_path = tmp.join(format!("tailtalk-rip-{job_token}.pbm"));
+    let out_path = tmp.join(format!("tailtalk-rip-{job_token}.{device}"));
     let res_arg = format!("-r{dpi}");
+    let dev_arg = format!("-sDEVICE={device}");
 
     // Use .ps extension when we know the content is PostScript (Linux ippeveps output),
     // .pdf otherwise. gs content-sniffs regardless, but the correct extension avoids
@@ -1063,8 +1291,8 @@ async fn rasterize_to_ps(mut data: Vec<u8>, fmt: &str, tray_source: &str, dpi: u
     let output = tokio::process::Command::new(gs_command())
         // Pass -sOutputFile as a separate -o arg so the OS handles path quoting,
         // avoiding issues with spaces in the temp directory path on Windows.
-        .args(["-dNOPAUSE", "-dBATCH", "-dSAFER", "-sDEVICE=pbmraw", &res_arg, "-o"])
-        .arg(&pbm_path)
+        .args(["-dNOPAUSE", "-dBATCH", "-dSAFER", &dev_arg, &res_arg, "-o"])
+        .arg(&out_path)
         .arg(&input_path)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -1074,10 +1302,10 @@ async fn rasterize_to_ps(mut data: Vec<u8>, fmt: &str, tray_source: &str, dpi: u
     if !output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
-        // Keep the input file around for post-mortem; clean up the (possibly partial) pbm.
-        let _ = tokio::fs::remove_file(&pbm_path).await;
+        // Keep the input file around for post-mortem; clean up the (possibly partial) raster.
+        let _ = tokio::fs::remove_file(&out_path).await;
         anyhow::bail!(
-            "gs pbmraw exited with {} (input kept at {})\nstderr: {}\nstdout: {}",
+            "gs {device} exited with {} (input kept at {})\nstderr: {}\nstdout: {}",
             output.status,
             input_path.display(),
             stderr.trim(),
@@ -1086,15 +1314,214 @@ async fn rasterize_to_ps(mut data: Vec<u8>, fmt: &str, tray_source: &str, dpi: u
     }
     let _ = tokio::fs::remove_file(&input_path).await;
 
-    let pbm = tokio::fs::read(&pbm_path).await;
-    let _ = tokio::fs::remove_file(&pbm_path).await;
-    let pbm = pbm?;
+    let raster = tokio::fs::read(&out_path).await;
+    let _ = tokio::fs::remove_file(&out_path).await;
+    Ok(raster?)
+}
 
+// gs pbmraw → per-page PS Level-2 image; most reliable path for classic LaserWriter firmware.
+async fn rasterize_to_ps(data: Vec<u8>, fmt: &str, tray_source: &str, dpi: u32, job_token: u32) -> anyhow::Result<(Vec<u8>, usize)> {
+    if fmt == "application/postscript" || fmt == "application/vnd.cups-postscript" {
+        let page_count = data.windows(7).filter(|w| *w == b"%%Page:").count().max(1);
+        return Ok((data, page_count));
+    }
+
+    let pbm = gs_raster(data, fmt, "pbmraw", dpi, job_token).await?;
     let pages = parse_pbm_pages(&pbm)?;
     anyhow::ensure!(!pages.is_empty(), "gs produced no pages");
 
     let page_count = pages.len();
     Ok((build_ps_raster(&pages, dpi, tray_source), page_count))
+}
+
+/// One page of raw planar StyleWriter scanlines: rows → planes (1 for mono,
+/// C/M/Y/K for color) → plane bytes (1 bit per pixel, MSB first, 1 = ink).
+type PlanarPage = Vec<Vec<Vec<u8>>>;
+
+/// Rasterize a document for the StyleWriter at 360 dpi and crop each page
+/// to the printable window (lpstyl's margins for the CS family).
+async fn rasterize_for_stylewriter(data: Vec<u8>, fmt: &str, color: bool, job_token: u32) -> anyhow::Result<Vec<PlanarPage>> {
+    let device = if color { "ppmraw" } else { "pbmraw" };
+    let raster = gs_raster(data, fmt, device, SW_DPI, job_token).await?;
+    let pages: Vec<PlanarPage> = if color {
+        parse_ppm_pages(&raster)?
+            .into_iter()
+            .map(|(w, h, rgb)| ppm_page_to_planar(w, h, &rgb))
+            .collect()
+    } else {
+        parse_pbm_pages(&raster)?
+            .into_iter()
+            .map(|(w, h, bits)| pbm_page_to_planar(w, h, &bits))
+            .collect()
+    };
+    anyhow::ensure!(!pages.is_empty(), "gs produced no pages");
+    Ok(pages)
+}
+
+/// Number of printable rows for a page of `h` rows: skip the top margin and
+/// stop above the bottom margin (lpstyl: PRINT_HEIGHT = height - (TOP +
+/// BOTTOM + 1)). Returns the top offset and one-past-the-end row.
+fn sw_printable_rows(h: usize) -> (usize, usize) {
+    let top = SW_TOP_MARGIN_ROWS.min(h);
+    let bottom = h.saturating_sub(SW_BOTTOM_MARGIN_ROWS + 1).max(top);
+    (top, bottom)
+}
+
+/// Crop a full-page 360 dpi PBM raster to the printable window, returning
+/// per-row single-plane scanlines. PBM bit 1 = black = deposit ink, which is
+/// exactly the K-plane sense — no inversion needed.
+fn pbm_page_to_planar(w: u32, h: u32, bits: &[u8]) -> PlanarPage {
+    let row_bytes = (w as usize).div_ceil(8);
+    let left_bytes = SW_LEFT_MARGIN_PX / 8; // 72 px: exactly byte-aligned
+    let take = SW2200_PRINT_ROWBYTES.min(row_bytes.saturating_sub(left_bytes));
+    let (top, bottom) = sw_printable_rows(h as usize);
+    let mut rows = Vec::with_capacity(bottom - top);
+    for y in top..bottom {
+        let start = y * row_bytes + left_bytes;
+        rows.push(vec![bits[start..start + take].to_vec()]);
+    }
+    rows
+}
+
+/// Crop a full-page 360 dpi RGB raster to the printable window and
+/// Floyd–Steinberg dither it into C/M/Y 1-bit planes.
+///
+/// The K plane stays empty: with a color cartridge the printer deposits no
+/// ink for the K plane at all, so black must be composited from C+M+Y
+/// (undercolor removal 0 — see to_bitcmyk.py, verified on a real SW2200
+/// where UCR-moved black simply vanished from the page).
+fn ppm_page_to_planar(w: u32, h: u32, rgb: &[u8]) -> PlanarPage {
+    let (w, h) = (w as usize, h as usize);
+    let left = SW_LEFT_MARGIN_PX.min(w);
+    let print_w = (w - left).min(SW2200_PRINT_WIDTH);
+    let (top, bottom) = sw_printable_rows(h);
+    let plane_bytes = print_w.div_ceil(8).max(1);
+
+    // Floyd–Steinberg error buffers for the C/M/Y channels, padded one
+    // pixel each side so diffusion needs no bounds checks.
+    let mut err_cur = vec![[0.0f32; 3]; print_w + 2];
+    let mut err_next = vec![[0.0f32; 3]; print_w + 2];
+
+    let mut rows = Vec::with_capacity(bottom - top);
+    for y in top..bottom {
+        let mut planes = vec![vec![0u8; plane_bytes]; 4];
+        for x in 0..print_w {
+            let px = (y * w + left + x) * 3;
+            for ch in 0..3 {
+                // RGB → CMY: ink = 255 - value (R→C, G→M, B→Y).
+                let want = (255 - rgb[px + ch]) as f32 + err_cur[x + 1][ch];
+                let on = want >= 127.5;
+                if on {
+                    planes[ch][x / 8] |= 0x80 >> (x % 8);
+                }
+                let e = want - if on { 255.0 } else { 0.0 };
+                err_cur[x + 2][ch] += e * (7.0 / 16.0);
+                err_next[x][ch] += e * (3.0 / 16.0);
+                err_next[x + 1][ch] += e * (5.0 / 16.0);
+                err_next[x + 2][ch] += e * (1.0 / 16.0);
+            }
+        }
+        rows.push(planes);
+        std::mem::swap(&mut err_cur, &mut err_next);
+        for e in err_next.iter_mut() {
+            *e = [0.0; 3];
+        }
+    }
+    rows
+}
+
+/// Connect to a StyleWriter, retrying while it reports busy — another host
+/// may hold the print connection, or it may still be ejecting the previous
+/// page of this very job.
+async fn connect_stylewriter(ddp: &DdpHandle, addr: AdspAddress, username: &str) -> anyhow::Result<StyleWriterSession> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(300);
+    loop {
+        match StyleWriterSession::connect(ddp, addr, username).await {
+            Err(e) if e.downcast_ref::<PrinterBusy>().is_some()
+                && tokio::time::Instant::now() < deadline =>
+            {
+                tracing::debug!("IPP: StyleWriter busy, retrying in 5s");
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+            other => return other,
+        }
+    }
+}
+
+/// Print one page over a fresh ADSP session (connect → setup → bands →
+/// finish); on failure the abort path ejects any loaded page and resets the
+/// printer so the paper path isn't left wedged.
+async fn print_stylewriter_page(
+    ddp: &DdpHandle,
+    addr: AdspAddress,
+    rows: &PlanarPage,
+    color: bool,
+    quality: PrintQuality,
+    username: &str,
+) -> anyhow::Result<()> {
+    let batches = encode_page_batches(rows, !color);
+    let mut session = connect_stylewriter(ddp, addr, username).await?;
+    let result: anyhow::Result<()> = async {
+        session.setup(color, quality).await?;
+        for batch in &batches {
+            session.write_batch(batch.top, batch.bottom, &batch.data, color).await?;
+        }
+        Ok(())
+    }
+    .await;
+    match result {
+        Ok(()) => session.finish().await,
+        Err(e) => {
+            let _ = session.abort().await;
+            Err(e)
+        }
+    }
+}
+
+/// Full StyleWriter job pipeline: rasterize + dither, queue behind any job
+/// already printing (per-printer lock), then print page by page.
+#[allow(clippy::too_many_arguments)]
+async fn run_stylewriter_job(
+    job: Arc<Mutex<JobRecord>>,
+    ddp: DdpHandle,
+    addr: AdspAddress,
+    doc: Vec<u8>,
+    fmt: String,
+    color: bool,
+    quality: PrintQuality,
+    username: String,
+    job_lock: Arc<Mutex<()>>,
+    job_id: u32,
+) {
+    job.lock().await.state_message = "Rasterizing".to_string();
+    let pages = match rasterize_for_stylewriter(doc, &fmt, color, job_id).await {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!("IPP: StyleWriter job {job_id} rasterize failed: {e}");
+            let mut j = job.lock().await;
+            j.state = JobState::Aborted;
+            j.state_message = format!("Rasterize failed: {e}");
+            return;
+        }
+    };
+    tracing::info!("IPP: StyleWriter job {job_id}: {} page(s) rasterized", pages.len());
+
+    job.lock().await.state_message = "Waiting for printer".to_string();
+    let _guard = job_lock.lock().await;
+    for (i, rows) in pages.iter().enumerate() {
+        job.lock().await.state_message = format!("Printing page {} of {}", i + 1, pages.len());
+        if let Err(e) = print_stylewriter_page(&ddp, addr, rows, color, quality, &username).await {
+            tracing::error!("IPP: StyleWriter job {job_id} failed on page {}: {e:#}", i + 1);
+            let mut j = job.lock().await;
+            j.state = JobState::Aborted;
+            j.state_message = format!("Print failed on page {}: {e:#}", i + 1);
+            return;
+        }
+        job.lock().await.impressions_completed = (i + 1) as i32;
+    }
+    let mut j = job.lock().await;
+    j.state = JobState::Completed;
+    j.state_message = "Completed".to_string();
 }
 
 /// Parse one or more concatenated P4 (binary PBM) images from `data`.
@@ -1114,9 +1541,36 @@ fn parse_pbm_pages(data: &[u8]) -> anyhow::Result<Vec<(u32, u32, Vec<u8>)>> {
     Ok(pages)
 }
 
+/// Parse one or more concatenated P6 (binary PPM, maxval 255) images from `data`.
+fn parse_ppm_pages(data: &[u8]) -> anyhow::Result<Vec<(u32, u32, Vec<u8>)>> {
+    let mut pages = Vec::new();
+    let mut pos = 0;
+    while pos < data.len() {
+        let Some((w, h, header_len)) = parse_ppm_header(&data[pos..]) else { break };
+        let page_bytes = w as usize * h as usize * 3;
+        let data_start = pos + header_len;
+        let data_end = data_start + page_bytes;
+        if data_end > data.len() { break; }
+        pages.push((w, h, data[data_start..data_end].to_vec()));
+        pos = data_end;
+    }
+    Ok(pages)
+}
+
 /// Parse a P4 (binary PBM) header starting at `data[0]`.
 fn parse_pbm_header(data: &[u8]) -> Option<(u32, u32, usize)> {
-    if data.get(0..2) != Some(b"P4") { return None; }
+    parse_pnm_header(data, b'4', false)
+}
+
+/// Parse a P6 (binary PPM) header starting at `data[0]`; only maxval 255 is accepted.
+fn parse_ppm_header(data: &[u8]) -> Option<(u32, u32, usize)> {
+    parse_pnm_header(data, b'6', true)
+}
+
+/// Parse a binary PNM header (`P<magic>`, width, height, optional maxval)
+/// starting at `data[0]`, returning (width, height, header length).
+fn parse_pnm_header(data: &[u8], magic: u8, has_maxval: bool) -> Option<(u32, u32, usize)> {
+    if data.first() != Some(&b'P') || data.get(1) != Some(&magic) { return None; }
     let mut pos = 2;
 
     let skip = |data: &[u8], pos: &mut usize| {
@@ -1142,8 +1596,9 @@ fn parse_pbm_header(data: &[u8]) -> Option<(u32, u32, usize)> {
 
     let w = read_u32(data, &mut pos)?;
     let h = read_u32(data, &mut pos)?;
+    if has_maxval && read_u32(data, &mut pos)? != 255 { return None; }
     if pos >= data.len() { return None; }
-    pos += 1; // mandatory single whitespace after height
+    pos += 1; // mandatory single whitespace after the last header field
     Some((w, h, pos))
 }
 
@@ -1264,4 +1719,88 @@ fn parse_printer_error(output: &str) -> Option<String> {
         .map(|l| l.trim())
         .find(|l| l.starts_with("%%[ Error:"))
         .map(|l| l.trim_start_matches("%%[").trim_end_matches("]%%").trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_ppm_pages_concatenated() {
+        // Header shape matches real gs ppmraw output, including the comment
+        // line between the magic and the dimensions.
+        let mut data = Vec::new();
+        for fill in [0u8, 255u8] {
+            data.extend_from_slice(b"P6\n# Image generated by GPL Ghostscript (device=ppmraw)\n4 2\n255\n");
+            data.extend_from_slice(&[fill; 4 * 2 * 3]);
+        }
+        let pages = parse_ppm_pages(&data).unwrap();
+        assert_eq!(pages.len(), 2);
+        assert_eq!((pages[0].0, pages[0].1), (4, 2));
+        assert!(pages[0].2.iter().all(|&b| b == 0));
+        assert!(pages[1].2.iter().all(|&b| b == 255));
+    }
+
+    #[test]
+    fn test_sw_printable_rows() {
+        // Letter at 360 dpi: 3960 rows → lpstyl's PRINT_HEIGHT = 3960 - 181.
+        let (top, bottom) = sw_printable_rows(3960);
+        assert_eq!(top, SW_TOP_MARGIN_ROWS);
+        assert_eq!(bottom - top, 3960 - 181);
+        // Degenerate tiny page must not underflow.
+        let (top, bottom) = sw_printable_rows(50);
+        assert!(bottom >= top);
+    }
+
+    #[test]
+    fn test_pbm_page_to_planar_crop() {
+        // 2 printable rows on a page just tall enough to have them; row bytes
+        // beyond the left margin land at byte offset 9.
+        let w = 3060u32; // letter width at 360 dpi
+        let h = (SW_TOP_MARGIN_ROWS + SW_BOTTOM_MARGIN_ROWS + 3) as u32;
+        let row_bytes = (w as usize).div_ceil(8);
+        let mut bits = vec![0u8; row_bytes * h as usize];
+        let printable_row = SW_TOP_MARGIN_ROWS;
+        bits[printable_row * row_bytes + SW_LEFT_MARGIN_PX / 8] = 0xAB;
+        let rows = pbm_page_to_planar(w, h, &bits);
+        assert_eq!(rows.len(), 2); // h - (top + bottom + 1)
+        assert_eq!(rows[0].len(), 1); // single K plane
+        assert_eq!(rows[0][0].len(), SW2200_PRINT_ROWBYTES.min(row_bytes - 9));
+        assert_eq!(rows[0][0][0], 0xAB);
+        assert!(rows[1][0].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn test_ppm_page_to_planar_dither_extremes() {
+        let w = 200u32;
+        let h = (SW_TOP_MARGIN_ROWS + SW_BOTTOM_MARGIN_ROWS + 5) as u32;
+        // Pure black page: every C/M/Y bit inside the printable window must
+        // be set (composite black), and the K plane must stay empty.
+        let black = vec![0u8; (w * h * 3) as usize];
+        let rows = pbm_like_bits(&ppm_page_to_planar(w, h, &black), w as usize);
+        for (c, m, y, k) in rows {
+            assert!(c && m && y, "black page must dither to solid CMY");
+            assert!(!k, "K plane must stay empty in color mode");
+        }
+        // Pure white page: no ink anywhere.
+        let white = vec![255u8; (w * h * 3) as usize];
+        for planes in ppm_page_to_planar(w, h, &white) {
+            for plane in planes {
+                assert!(plane.iter().all(|&b| b == 0));
+            }
+        }
+    }
+
+    /// Collapse a dithered page to per-plane "any ink missing / any ink present"
+    /// flags over the printable pixel span (ignores byte padding bits).
+    fn pbm_like_bits(page: &PlanarPage, w: usize) -> Vec<(bool, bool, bool, bool)> {
+        let print_w = (w - SW_LEFT_MARGIN_PX).min(SW2200_PRINT_WIDTH);
+        page.iter()
+            .map(|planes| {
+                let all_set = |p: &Vec<u8>| (0..print_w).all(|x| p[x / 8] & (0x80 >> (x % 8)) != 0);
+                let any_set = |p: &Vec<u8>| (0..print_w).any(|x| p[x / 8] & (0x80 >> (x % 8)) != 0);
+                (all_set(&planes[0]), all_set(&planes[1]), all_set(&planes[2]), any_set(&planes[3]))
+            })
+            .collect()
+    }
 }

--- a/tailtalk-packets/src/nbp.rs
+++ b/tailtalk-packets/src/nbp.rs
@@ -55,6 +55,27 @@ pub struct NbpTuple {
     pub entity_name: EntityName, // The entity name (object, type, zone)
 }
 
+/// The AppleTalk address (network, node, socket) an NBP-registered service
+/// lives at. The transport layered on top can be ATP, ADSP, PAP, etc., so
+/// this is deliberately transport-agnostic rather than an `AtpAddress`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ServiceAddress {
+    pub network_number: u16,
+    pub node_number: u8,
+    pub socket_number: u8,
+}
+
+impl NbpTuple {
+    /// The address this tuple points at.
+    pub fn service_address(&self) -> ServiceAddress {
+        ServiceAddress {
+            network_number: self.network_number,
+            node_number: self.node_id,
+            socket_number: self.socket_number,
+        }
+    }
+}
+
 /// Represents an entity name in NBP.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct EntityName {

--- a/tailtalk/src/adsp.rs
+++ b/tailtalk/src/adsp.rs
@@ -24,6 +24,16 @@ pub struct AdspAddress {
     pub socket_number: u8,
 }
 
+impl From<tailtalk_packets::nbp::ServiceAddress> for AdspAddress {
+    fn from(a: tailtalk_packets::nbp::ServiceAddress) -> Self {
+        AdspAddress {
+            network_number: a.network_number,
+            node_number: a.node_number,
+            socket_number: a.socket_number,
+        }
+    }
+}
+
 fn ddp_dest(addr: AdspAddress) -> DdpAddress {
     DdpAddress::new(
         tailtalk_packets::aarp::AppleTalkAddress {

--- a/tailtalk/src/atp.rs
+++ b/tailtalk/src/atp.rs
@@ -37,6 +37,16 @@ pub struct AtpAddress {
     pub socket_number: u8,
 }
 
+impl From<tailtalk_packets::nbp::ServiceAddress> for AtpAddress {
+    fn from(a: tailtalk_packets::nbp::ServiceAddress) -> Self {
+        AtpAddress {
+            network_number: a.network_number,
+            node_number: a.node_number,
+            socket_number: a.socket_number,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct AtpSendRequest {
     pub address: AtpAddress,

--- a/tailtalk/src/nbp.rs
+++ b/tailtalk/src/nbp.rs
@@ -371,4 +371,39 @@ impl NbpHandle {
 
         rx.await.map_err(io::Error::other)?
     }
+
+    /// Look up several entity names at once. Returns one result vector per
+    /// request, in request order.
+    ///
+    /// All lookups run as concurrent NBP transactions (each with its own
+    /// transaction ID), so N names share a single reply-collection window
+    /// instead of waiting out one window per name.
+    ///
+    /// This is deliberately *not* a single multi-tuple LkUp packet: the NBP
+    /// header's 4-bit tuple count would allow one, and our own responder
+    /// even answers such packets, but Inside AppleTalk specifies that a
+    /// LkUp request carries exactly one tuple — real devices only match
+    /// against the first and would silently drop the rest of the query.
+    pub async fn lookup_many(
+        &self,
+        requests: impl IntoIterator<Item = EntityName>,
+    ) -> Result<Vec<Vec<NbpTuple>>, io::Error> {
+        // Fire every request before awaiting any reply so their collection
+        // windows overlap.
+        let mut pending = Vec::new();
+        for request in requests {
+            let (tx, rx) = oneshot::channel();
+            self.request_send
+                .send(NbpCommand::Lookup(NbpLookupRequest { request, chan: tx }))
+                .await
+                .map_err(io::Error::other)?;
+            pending.push(rx);
+        }
+
+        let mut results = Vec::with_capacity(pending.len());
+        for rx in pending {
+            results.push(rx.await.map_err(io::Error::other)??);
+        }
+        Ok(results)
+    }
 }

--- a/tailtalk/src/stylewriter.rs
+++ b/tailtalk/src/stylewriter.rs
@@ -1,6 +1,6 @@
 use crate::{
-    TalkStack,
-    adsp::{AdspAddress, AdspStream},
+    adsp::{Adsp, AdspAddress, AdspStream},
+    ddp::DdpHandle,
 };
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -10,16 +10,25 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 pub const SW2200_PRINT_WIDTH: usize = 2919;
 pub const SW2200_PRINT_ROWBYTES: usize = SW2200_PRINT_WIDTH.div_ceil(8); // 365
 
-/// The printer's internal raster buffer size (lpstyl `MAX_BUFFER` for the
-/// CS family). It holds one whole rect+G block before printing the band, so
-/// a block must stay *strictly smaller* than this or the printer stalls with
-/// 'B' = 0x00 (buffer full) and ejects blank — confirmed with a 32863-byte
-/// block. Callers must flush before a row would cross this limit, carrying
-/// it over to the next block (lpstyl does the same).
+/// Max compressed bytes in one rect+G band.
 ///
-/// A rect+G block must also span many rows, not one block per row — the
-/// latter never printed anything despite being byte-correct.
-pub const MAX_BATCH_BYTES: usize = 0x8000;
+/// The printer's raster buffer holds 0x8000 bytes (lpstyl's `MAX_BUFFER` for
+/// the CS family). Hand it a block that size or larger and it stalls with
+/// 'B' = 0x00 and ejects a blank page — we saw this with a 32863-byte block —
+/// so a band has to stay under 0x8000. We cap well under it, at 8 KB, to match
+/// the native Mac driver, whose bands never run much larger. Dense pages just
+/// split into more bands; sparse ones hit the row cap first (see
+/// [`MAX_BAND_ROWS`]).
+///
+/// A band also has to cover many rows. One block per row is byte-correct but
+/// never actually prints.
+pub const MAX_BATCH_BYTES: usize = 0x2000;
+
+/// Max scanlines in one rect+G band.
+///
+/// [`MAX_BATCH_BYTES`] only limits the compressed size. The native Mac driver
+/// also caps mono bands at 400 rows, so we do the same.
+pub const MAX_BAND_ROWS: usize = 400;
 
 // SW2200 is idle when 'B' has both 0x80 and 0x20 set: 0xA2 (no paper) and
 // 0xA3 (paper loaded) are the observed idle values; mid-page 'B' is a
@@ -35,6 +44,78 @@ const SW2200_IDLE_MASK: u8 = 0xA0;
 /// by observing the eject command fire while paper was visibly still being
 /// pulled in. A short fixed settle delay avoids racing ahead of the hardware.
 const MECHANISM_SETTLE_DELAY: Duration = Duration::from_secs(3);
+
+/// The printer answered the 0x000b print request with a "busy" result:
+/// another host holds the print connection. Retry later. Carried inside the
+/// `anyhow::Error` returned by [`StyleWriterSession::connect`] so callers can
+/// distinguish "queue behind someone else" from a hard failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PrinterBusy(pub u16);
+
+impl std::fmt::Display for PrinterBusy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Printer busy (result 0x{:04X}); retry later", self.0)
+    }
+}
+
+impl std::error::Error for PrinterBusy {}
+
+/// Print quality selector, mapped onto the mode string sent during `setup()`.
+///
+/// Verified against real SW2200 captures: mono-normal is `"m2nZAH"` and colour
+/// is `"m2sAH"`. A native Mac driver capture shows Best-quality sends
+/// byte-identical raster to Normal — the printer just runs more/slower passes —
+/// so Best only flips the quality character in the mode string, not the raster.
+///
+/// Mode-string grammar: `m2 <n|s> [Z] A <B|H>`. `n`=normal / `s`=superior
+/// (best), `Z` marks the mono/K path, and the final letter is head direction:
+/// `H`=unidirectional (ink only on the left→right pass), `B`=bidirectional
+/// (ink both ways, with the right→left rows reversed pixel-wise). We always
+/// use `H`, so no row reversal is needed. Mono-best `"m2sZAH"` is derived from
+/// this grammar and not yet hardware-confirmed; mono-normal and colour are.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PrintQuality {
+    #[default]
+    Normal,
+    Best,
+}
+
+/// Identity of the attached printer, gathered by [`StyleWriterSession::query_info`].
+#[derive(Debug, Clone)]
+pub struct StyleWriterInfo {
+    /// Raw reply to the `?` identify command ("IJ10", "SW", "SW3", "CS", …).
+    pub identity: String,
+    /// CS-family submodel from status query 'p' (0x01=2400, 0x02=2200,
+    /// 0x04=1500, 0x05=2500); `None` for non-CS printers or no reply.
+    pub submodel: Option<u8>,
+    /// Status 'H' bit 0x80: a color ink cartridge is installed.
+    pub color_cartridge: bool,
+}
+
+impl StyleWriterInfo {
+    /// Human-readable model name (lpstyl's identify tables).
+    pub fn model_name(&self) -> &'static str {
+        match self.identity.as_str() {
+            "IJ10" => "Apple StyleWriter",
+            "SW" => "Apple StyleWriter II",
+            "SW3" => "Apple StyleWriter 1200",
+            "CS" => match self.submodel {
+                Some(0x01) => "Apple Color StyleWriter 2400",
+                Some(0x02) => "Apple Color StyleWriter 2200",
+                Some(0x04) => "Apple Color StyleWriter 1500",
+                Some(0x05) => "Apple Color StyleWriter 2500",
+                _ => "Apple Color StyleWriter",
+            },
+            _ => "Apple StyleWriter",
+        }
+    }
+
+    /// CS-family printers are the only ones that can print color at all
+    /// (and only with a color cartridge installed).
+    pub fn color_capable(&self) -> bool {
+        self.identity == "CS" && self.color_cartridge
+    }
+}
 
 /// Build the attention payload for the 0x000b print-request message
 /// (lpstyl §at_printer_open): `struct printRequest { u_int32_t port; char string[66]; }`.
@@ -70,11 +151,10 @@ async fn write_flush(data: &mut AdspStream, bytes: &[u8]) -> anyhow::Result<()> 
 /// - Raster data must be batched (`write_batch`) as one rect+G block spanning
 ///   many rows, not one block per row — the latter looked byte-correct but
 ///   the printer silently never printed anything.
-/// - Color ('c'/"m2sAH") scanlines must be XOR-delta encoded against the
-///   previous row, restarting absolute at each rect+G block; the printer
-///   XOR-reconstructs rows, so absolute color rows print as cumulative-XOR
-///   noise. Monochrome ('R'/"m2nZAB") scanlines are absolute. See
-///   `encode_row` in the adsp-stylewriter example.
+/// - Both colour ('c'/"m2sAH") and mono ('R'/"m2nZAH") scanlines are XOR-delta
+///   encoded against the previous row, restarting from absolute at each rect+G
+///   block. The printer XOR-reconstructs each row, so a non-delta'd row prints
+///   as cumulative-XOR noise. See `encode_page_batches`.
 /// - `finish()`'s teardown replicates lpstyl's `at_printer_kill(), whose own
 ///   comment warns: "If you don't get it just right, after the disconnect
 ///   the printer tries to open a new connection to the original control
@@ -89,13 +169,13 @@ impl StyleWriterSession {
     /// ATTN 0x000b print request, close the control connection on success,
     /// then accept the printer's reverse connection on our data socket.
     pub async fn connect(
-        stack: &TalkStack,
+        ddp: &DdpHandle,
         printer_addr: AdspAddress,
         username: &str,
     ) -> anyhow::Result<Self> {
-        let (data_socket_num, mut data_listener) = stack.listen_adsp(None).await?;
+        let (data_socket_num, mut data_listener) = Adsp::bind(ddp, None).await?;
 
-        let mut ctrl = stack.connect_adsp(printer_addr).await?;
+        let mut ctrl = Adsp::connect(ddp, printer_addr).await?;
         let req_payload = build_print_request(data_socket_num, username);
         ctrl.send_attention(0x000b, &req_payload).await?;
 
@@ -105,7 +185,7 @@ impl StyleWriterSession {
         match result {
             0 => ctrl.close().await?,
             0xFFFF => anyhow::bail!("Printer rejected the print request (0xFFFF)"),
-            _ => anyhow::bail!("Printer busy (result 0x{:04X}); retry later", result),
+            _ => return Err(anyhow::Error::new(PrinterBusy(result))),
         }
 
         let data = data_listener.accept().await?;
@@ -147,6 +227,57 @@ impl StyleWriterSession {
                 Err(_) => {} // no reply yet, retry
             }
         }
+    }
+
+    /// Identify the attached printer and its cartridge without starting a
+    /// page (no 'L' is sent, so no paper feeds). Mirrors lpstyl's
+    /// `printerSetup()` identify path: write `?`, read the CR-terminated
+    /// identity string, then for CS-family printers query submodel ('p') and
+    /// cartridge ('D' + 'H').
+    ///
+    /// Intended for a dedicated capability-probe session: connect, call
+    /// this, then `abort()` (whose 'I' reset is a no-op with no page loaded).
+    pub async fn query_info(&mut self) -> anyhow::Result<StyleWriterInfo> {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+
+        self.drain_stale_input().await;
+        write_flush(&mut self.data, b"?").await?;
+        let mut identity = Vec::new();
+        loop {
+            let mut b = [0u8; 1];
+            match tokio::time::timeout(Duration::from_secs(5), self.data.read_exact(&mut b)).await {
+                Ok(Ok(_)) if b[0] == 0x0D => break,
+                Ok(Ok(_)) if identity.len() < 32 => identity.push(b[0]),
+                Ok(Ok(_)) => break,
+                Ok(Err(e)) => return Err(e.into()),
+                // lpstyl's identify reply is CR-terminated, but tolerate a
+                // printer that stops without the CR.
+                Err(_) if !identity.is_empty() => break,
+                Err(_) => anyhow::bail!("No reply to printer identify query '?'"),
+            }
+        }
+        let identity = String::from_utf8_lossy(&identity).trim().to_string();
+
+        let submodel = if identity == "CS" {
+            self.poll_status(b'p', deadline).await
+        } else {
+            None
+        };
+
+        // 'D' then 'H' is lpstyl's cartridge probe; non-CS printers have no
+        // color cartridge to report, so skip the query (and its 'D') there.
+        let color_cartridge = if identity == "CS" {
+            write_flush(&mut self.data, b"D").await?;
+            let h = self
+                .poll_status(b'H', deadline)
+                .await
+                .ok_or_else(|| anyhow::anyhow!("No reply to cartridge query 'H'"))?;
+            h & 0x80 != 0
+        } else {
+            false
+        };
+
+        Ok(StyleWriterInfo { identity, submodel, color_cartridge })
     }
 
     /// Poll until status 'B' reports idle (lpstyl `waitStatus()`/`waitNonBusy()`),
@@ -193,12 +324,11 @@ impl StyleWriterSession {
 
         // lpstyl's AppleTalk waitNonBusy() follows the idle wait with two
         // ADSP attention 0x0006 "buffer ready" queries, each answered by two
-        // in-band bytes (0xFFFF in a real Mac driver capture); real Mac
-        // drivers send the same pairs before each band. A missing reply is
-        // non-fatal — and if a reply arrives late, drain_stale_input
-        // discards it before the next status poll, so this can no longer
-        // desync the query/reply pairing (the likely reason earlier attempts
-        // to send this query seemed to get no answer).
+        // in-band bytes (0xFFFF per a native Mac driver capture); the native
+        // driver sends the same pairs before each band. A missing reply is
+        // non-fatal, and a late reply is harmless too: drain_stale_input
+        // discards it before the next status poll, so it can't desync the
+        // query/reply pairing.
         for _ in 0..2 {
             self.data.send_attention(0x0006, &[0x00]).await?;
             let mut reply = [0u8; 2];
@@ -217,11 +347,11 @@ impl StyleWriterSession {
     /// 'H', quality string, 'L' (page start), then wait for paper feed to
     /// settle and the printer to report idle.
     ///
-    /// `color` selects the quality string: monochrome uses `"m2nZAB"`, color
-    /// uses `"m2sAH"` (from real driver captures) — the string must match
-    /// the raster tag ('R'/'c') or the printer's configured mode disagrees
-    /// with the data it's told to expect.
-    pub async fn setup(&mut self, color: bool) -> anyhow::Result<()> {
+    /// `color` and `quality` select the mode string: mono-normal `"m2nZAH"`,
+    /// mono-best `"m2sZAH"`, colour `"m2sAH"` (colour ignores quality). Its tag
+    /// must match the raster tag ('R' for mono, 'c' for colour) or the printer
+    /// misreconstructs every row. See [`PrintQuality`] for the grammar.
+    pub async fn setup(&mut self, color: bool, quality: PrintQuality) -> anyhow::Result<()> {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
 
         write_flush(&mut self.data, b"D").await?;
@@ -241,8 +371,15 @@ impl StyleWriterSession {
             );
         }
 
-        let quality = if color { b"m2sAH".as_slice() } else { b"m2nZAB".as_slice() };
-        write_flush(&mut self.data, quality).await?;
+        // Only the mode string changes between normal and best; the raster is
+        // byte-identical (per a native Mac driver capture), the printer just
+        // runs more passes. See [`PrintQuality`] for the grammar.
+        let mode_string: &[u8] = match (color, quality) {
+            (true, _) => b"m2sAH",                       // colour (verified)
+            (false, PrintQuality::Best) => b"m2sZAH",    // mono best (derived, HW-unverified)
+            (false, PrintQuality::Normal) => b"m2nZAH",  // mono normal (verified)
+        };
+        write_flush(&mut self.data, mode_string).await?;
         write_flush(&mut self.data, b"L").await?;
 
         tokio::time::sleep(MECHANISM_SETTLE_DELAY).await;
@@ -258,8 +395,13 @@ impl StyleWriterSession {
     /// rows' worth of already-RLE-encoded plane(s) — claiming more rows than
     /// supplied leaves the printer waiting for the missing scanlines.
     ///
-    /// Waits for a fully-idle 'B' status before sending, since the previous
-    /// band must be completely drained first (see `SW2200_IDLE_MASK`).
+    /// Does a light paper/error check between bands (like the native driver)
+    /// but does NOT wait for full idle. Flow control is the ADSP receive
+    /// window: `flush()` blocks until the whole band has been accepted into the
+    /// printer's buffer, and the printer advertises a shrinking window (down to
+    /// 0) as its buffer fills, so we can never overflow it. The native driver
+    /// streams bands back-to-back the same way; with bands capped well under
+    /// the buffer ([`MAX_BATCH_BYTES`]) it always has several buffered ahead.
     pub async fn write_batch(
         &mut self,
         top: u16,
@@ -273,15 +415,41 @@ impl StyleWriterSession {
             encoded_planes.len(),
             MAX_BATCH_BYTES
         );
-        self.wait_ready()
+        self.check_paper()
             .await
-            .map_err(|e| e.context("waiting for printer to drain before raster block"))?;
+            .map_err(|e| e.context("checking printer status before raster block"))?;
         let rect = StyleWriterEncoder::encode_rect(top, 0, bottom, SW2200_PRINT_WIDTH as u16, color);
         let g_block = StyleWriterEncoder::wrap_raster_chunk(encoded_planes);
         self.data.write_all(&rect).await?;
         self.data.write_all(&g_block).await?;
         self.data.flush().await?;
         Ok(())
+    }
+
+    /// Light between-band status check matching the real driver, which polls
+    /// '1' and '2' once each and moves straight on — no wait for idle. '2' ==
+    /// 0x04 means out of paper: send the `S` retry and wait, as
+    /// [`Self::wait_ready`] does. Everything else proceeds immediately; the
+    /// ADSP window (not a status poll) paces delivery to the printer's drain
+    /// rate.
+    async fn check_paper(&mut self) -> anyhow::Result<()> {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(180);
+        loop {
+            let _c1 = self.poll_status(b'1', deadline).await;
+            match self.poll_status(b'2', deadline).await {
+                Some(0x04) => {
+                    tracing::warn!("Printer is out of paper; sending retry ('S') and waiting...");
+                    write_flush(&mut self.data, &[0xFF, 0xFF, 0xFF, b'S']).await?;
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                    continue;
+                }
+                Some(c2) if c2 != 0x00 && c2 != 0x80 => {
+                    tracing::warn!("Unexpected printer error status 2=0x{c2:02X}");
+                    return Ok(());
+                }
+                _ => return Ok(()),
+            }
+        }
     }
 
     /// Finish the page: wait for the last raster batch to fully drain, form
@@ -340,6 +508,144 @@ impl StyleWriterSession {
     }
 }
 
+/// One rect+G raster band covering scanlines `top..=bottom`, ready for
+/// [`StyleWriterSession::write_batch`].
+#[derive(Debug, Clone)]
+pub struct RasterBatch {
+    pub top: u16,
+    pub bottom: u16,
+    /// Concatenated RLE-encoded plane data for every row in the band.
+    pub data: Vec<u8>,
+}
+
+/// Unpack one chunky (4bpp, nibble bits 8=C 4=M 2=Y 1=K) scanline into raw
+/// (pre-RLE) CMYK planar bytes.
+pub fn chunky_to_planes(chunky: &[u8], planar_input_len: usize) -> [Vec<u8>; 4] {
+    let mut planes = [
+        Vec::with_capacity(planar_input_len),
+        Vec::with_capacity(planar_input_len),
+        Vec::with_capacity(planar_input_len),
+        Vec::with_capacity(planar_input_len),
+    ];
+
+    for chunk_block in chunky.chunks(4) {
+        let mut c = 0u8;
+        let mut m = 0u8;
+        let mut y = 0u8;
+        let mut k = 0u8;
+        for i in 0..4 {
+            let b = chunk_block.get(i).copied().unwrap_or(0);
+            c = (c << 2) | ((b >> 6) & 2) | ((b >> 3) & 1);
+            m = (m << 2) | ((b >> 5) & 2) | ((b >> 2) & 1);
+            y = (y << 2) | ((b >> 4) & 2) | ((b >> 1) & 1);
+            k = (k << 2) | ((b >> 3) & 2) | (b & 1);
+        }
+        planes[0].push(c);
+        planes[1].push(m);
+        planes[2].push(y);
+        planes[3].push(k);
+    }
+    planes
+}
+
+/// Unpack one chunky scanline's K-nibble bit only into a raw (pre-RLE) plane.
+pub fn chunky_to_mono_plane(chunky: &[u8], planar_input_len: usize) -> Vec<u8> {
+    let mut plane = Vec::with_capacity(planar_input_len);
+    for chunk_block in chunky.chunks(4) {
+        let mut k = 0u8;
+        for i in 0..4 {
+            let b = chunk_block.get(i).copied().unwrap_or(0);
+            k = (k << 2) | ((b >> 3) & 2) | (b & 1);
+        }
+        plane.push(k);
+    }
+    plane
+}
+
+/// Encode one row's plane(s) into concatenated RLE bytes. `use_delta` XORs
+/// each plane against the previous row's raw plane first (lpstyl's
+/// `appendEncode()` differencing).
+///
+/// Delta is not optional: both colour ('c'/"m2sAH") and mono ('R'/"m2nZAH")
+/// mode reconstruct each row by XORing against the previous one, so a
+/// non-delta'd row prints as cumulative-XOR garbage.
+///
+/// `use_delta` must be false for the first row of every rect+G block, since
+/// the printer's differencing state resets per block. Does not mutate
+/// `last` — the caller updates it once per source row, so a row re-encoded
+/// after a batch flush still deltas correctly.
+fn encode_row(planes: &[Vec<u8>], last: &[Vec<u8>], use_delta: bool, mono: bool) -> Vec<u8> {
+    let mut out = Vec::new();
+    for (i, plane) in planes.iter().enumerate() {
+        let delta;
+        let src = if use_delta {
+            delta = plane.iter().zip(last[i].iter()).map(|(c, l)| c ^ l).collect::<Vec<u8>>();
+            &delta
+        } else {
+            plane
+        };
+        // Whether a blank row can collapse to a single 0x80 ("rest of the row
+        // is white") depends on the path, matching the native Mac driver:
+        //  - mono 'R': yes. The driver encodes almost all of its white rows
+        //    that way, so we do too.
+        //  - colour 'c': yes for C/M/Y, but not the K plane (index 3), which
+        //    the driver always spells out even when it's blank.
+        let allow_shortcut = mono || i != 3;
+        out.extend_from_slice(&StyleWriterEncoder::encode_scanline(src, SW2200_PRINT_ROWBYTES, allow_shortcut));
+    }
+    out
+}
+
+/// Encode a whole page of raw planar scanlines into rect+G bands.
+///
+/// `rows` holds one entry per scanline: 4 CMYK planes for color, 1 K plane
+/// for mono (all planes the same length, at most [`SW2200_PRINT_ROWBYTES`];
+/// shorter planes are padded to the printable width with white). Handles the
+/// XOR-delta chain (restarting it at each band boundary, where the printer's
+/// differencing state resets) and splits bands so each stays strictly below
+/// [`MAX_BATCH_BYTES`].
+pub fn encode_page_batches(rows: &[Vec<Vec<u8>>], mono: bool) -> Vec<RasterBatch> {
+    let mut batches = Vec::new();
+    let plane_len = rows.first().map(|planes| planes[0].len()).unwrap_or(0);
+    let num_planes = if mono { 1 } else { 4 };
+    let mut batch_start = 0usize;
+    let mut batch_data = Vec::new();
+    let mut last_planes = vec![vec![0u8; plane_len]; num_planes];
+    for (row_idx, planes) in rows.iter().enumerate() {
+        // The first row of every band is absolute; the rest delta against the
+        // previous row (the printer resets its differencing state per band).
+        let mut row_enc = encode_row(planes, &last_planes, !batch_data.is_empty(), mono);
+        // Flush before this row would cross *either* printer limit: the
+        // compressed G block must stay strictly below MAX_BATCH_BYTES, and
+        // the band must stay within MAX_BAND_ROWS scanlines (compressible
+        // mono pages hit the row cap long before the byte cap).
+        let rows_in_band = row_idx - batch_start;
+        let over_compressed = batch_data.len() + row_enc.len() >= MAX_BATCH_BYTES;
+        let over_rows = rows_in_band + 1 > MAX_BAND_ROWS;
+        if !batch_data.is_empty() && (over_compressed || over_rows) {
+            batches.push(RasterBatch {
+                top: batch_start as u16,
+                bottom: (row_idx - 1) as u16,
+                data: std::mem::take(&mut batch_data),
+            });
+            batch_start = row_idx;
+            // This row now starts a new band, so re-encode it absolute.
+            row_enc = encode_row(planes, &last_planes, false, mono);
+        }
+        batch_data.extend_from_slice(&row_enc);
+        last_planes = planes.clone();
+        if row_idx + 1 == rows.len() {
+            batches.push(RasterBatch {
+                top: batch_start as u16,
+                bottom: row_idx as u16,
+                data: batch_data,
+            });
+            break;
+        }
+    }
+    batches
+}
+
 pub struct StyleWriterEncoder;
 
 // StyleWriter Encoding Protocol Constants
@@ -352,7 +658,11 @@ pub const MASK_RUNWHT: u8 = 0x80;
 pub const MASK_RUNBLK: u8 = 0xC0;
 
 impl StyleWriterEncoder {
-    /// Create the bounding box header (`R` for monochrome, `c` for color)
+    /// Create the bounding-box header (`R` for monochrome, `c` for color)
+    /// that precedes each `G` raster block: tag byte, then little-endian
+    /// left, top, right, bottom. Both `'R'` and `'c'` rects are 9 bytes, with
+    /// the `G` block immediately after (verified against real Mac driver
+    /// captures).
     pub fn encode_rect(top: u16, left: u16, bottom: u16, right: u16, is_color: bool) -> Vec<u8> {
         let mut buf = Vec::with_capacity(9);
         if is_color {
@@ -495,7 +805,9 @@ mod tests {
 
     #[test]
     fn test_encode_rect() {
-        // R (0x52) or c (0x63), then little-endian left, top, right, bottom
+        // R (0x52) or c (0x63), then little-endian left, top, right, bottom.
+        // Both tags produce a 9-byte rect (verified against real Mac driver
+        // captures).
         let bw = StyleWriterEncoder::encode_rect(10, 20, 30, 40, false);
         assert_eq!(bw, vec![b'R', 20, 0, 10, 0, 40, 0, 30, 0]);
 
@@ -536,6 +848,64 @@ mod tests {
         assert_eq!(encoded[0], 3); // 3 bytes of raw data
         assert_eq!(&encoded[1..4], &[0x11, 0x22, 0x33]);
         assert_eq!(encoded[4], MASK_RUNWHT + 2); // 2 bytes of white
+    }
+
+    #[test]
+    fn test_encode_page_batches_bands() {
+        // Rows of incompressible data force multiple bands; every band must
+        // stay strictly below MAX_BATCH_BYTES and the bands must tile the
+        // page contiguously.
+        let plane_len = SW2200_PRINT_ROWBYTES;
+        let rows: Vec<Vec<Vec<u8>>> = (0..400)
+            .map(|r| {
+                (0..4)
+                    .map(|p| (0..plane_len).map(|i| ((r * 31 + p * 7 + i * 13) % 251) as u8 + 1).collect())
+                    .collect()
+            })
+            .collect();
+        let batches = encode_page_batches(&rows, false);
+        assert!(batches.len() > 1, "expected multiple bands, got {}", batches.len());
+        assert_eq!(batches[0].top, 0);
+        assert_eq!(batches.last().unwrap().bottom as usize, rows.len() - 1);
+        for pair in batches.windows(2) {
+            assert_eq!(pair[1].top, pair[0].bottom + 1, "bands must be contiguous");
+        }
+        for b in &batches {
+            assert!(b.data.len() < MAX_BATCH_BYTES);
+            assert!(b.top <= b.bottom);
+        }
+    }
+
+    #[test]
+    fn test_encode_page_batches_row_cap() {
+        // A tall, highly-compressible mono page (all white) compresses to a
+        // few bytes per row, so the 32 KB *compressed* cap alone would let one
+        // band span hundreds of rows — taller than the printer's paper feed
+        // tracks, which shears the page (the vertical-streak bug). Every band
+        // must stay within MAX_BAND_ROWS scanlines.
+        let rows: Vec<Vec<Vec<u8>>> =
+            (0..MAX_BAND_ROWS * 3 + 17).map(|_| vec![vec![0u8; SW2200_PRINT_ROWBYTES]]).collect();
+        let batches = encode_page_batches(&rows, true);
+        assert!(batches.len() >= 4, "row cap must split the page into several bands");
+        for b in &batches {
+            let band_rows = (b.bottom - b.top + 1) as usize;
+            assert!(band_rows <= MAX_BAND_ROWS, "band of {band_rows} rows exceeds MAX_BAND_ROWS");
+        }
+        // Bands must still tile the page contiguously with no gaps.
+        assert_eq!(batches[0].top, 0);
+        assert_eq!(batches.last().unwrap().bottom as usize, rows.len() - 1);
+        for pair in batches.windows(2) {
+            assert_eq!(pair[1].top, pair[0].bottom + 1, "bands must be contiguous");
+        }
+    }
+
+    #[test]
+    fn test_encode_page_batches_mono_single_band() {
+        // A small all-white mono page fits in a single band.
+        let rows: Vec<Vec<Vec<u8>>> = (0..10).map(|_| vec![vec![0u8; 100]]).collect();
+        let batches = encode_page_batches(&rows, true);
+        assert_eq!(batches.len(), 1);
+        assert_eq!((batches[0].top, batches[0].bottom), (0, 9));
     }
 
     #[test]


### PR DESCRIPTION
Discover ColorStyleWriter2400AT printers and expose them as AirPrint queues, driving them over ADSP alongside the existing LaserWriter/PAP path. Just like the PostScript support for LaserWriters we also use GhostScript here to convert the pages over. The NBP string we look up should match LocalTalk and EtherTalk adapters for these which work with the 2200, 2400, and 2500. It might support others but I cannot remember.

Move the raster-encoding pipeline out of the adsp-stylewriter example into the library so the bridge can reuse it, and fixes the really bad shearing/banding on black and white prints. I mistakenly thought H and B meant different things in the StyleWriter setup modes, but now we can happily support both colour and b&w prints.

We also autodiscover the installed cartridge type and expose this as an IPP attribute so a printer with only one type installed only allows that job type to be printed.