### PR TITLE
tashtalk: verify CRCs in software and stop dropping frames on errors

### DIFF
--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -409,7 +409,7 @@ impl PacketProcessor {
                             }
                             res = tashtalk_instance.receive_frame() => {
                                 match res {
-                                    Ok(Some(data)) => {
+                                    Ok(Some(tashtalk::TashTalkEvent::Frame(data))) => {
                                         if let Some(ref tx) = pcap_rx_sender {
                                             let _ = tx.try_send((SystemTime::now(), data.clone()));
                                         }
@@ -461,6 +461,10 @@ impl PacketProcessor {
                                                 _ => {}
                                             }
                                         }
+                                    }
+                                    Ok(Some(tashtalk::TashTalkEvent::Error(e))) => {
+                                        // Bad frame already discarded; keep going.
+                                        tracing::debug!("TashTalk: discarded bad frame: {}", e);
                                     }
                                     Ok(None) => break,
                                     Err(e) => {
@@ -527,12 +531,8 @@ impl PacketProcessor {
                             output_buf[header_len..header_len + payload_len]
                                 .copy_from_slice(&pkt.payload);
 
-                            let frame_end = header_len + payload_len;
-                            let crc = tashtalk::lt_crc(&output_buf[..frame_end]);
-                            output_buf[frame_end] = crc[0];
-                            output_buf[frame_end + 1] = crc[1];
-
-                            frame_end + 2
+                            // CRC is appended in send_frame.
+                            header_len + payload_len
                         }
                         #[cfg(not(feature = "ethertalk"))]
                         _ => 0,
@@ -554,10 +554,8 @@ impl PacketProcessor {
                             let header_len = llap_pkt
                                 .to_bytes(&mut output_buf)
                                 .expect("failed to frame LLAP control");
-                            let crc = tashtalk::lt_crc(&output_buf[..header_len]);
-                            output_buf[header_len] = crc[0];
-                            output_buf[header_len + 1] = crc[1];
-                            header_len + 2
+                            // CRC is appended in send_frame.
+                            header_len
                         }
                         _ => 0,
                     }
@@ -594,10 +592,9 @@ impl PacketProcessor {
                             tracing::error!("Failed to send to Tashtalk tx: {}", e);
                         }
                     }
-                    // Capture outbound frame without the trailing 2 CRC bytes.
+                    // Outbound frame has no CRC bytes, so capture it as-is.
                     if let Some(ref tx) = pcap_tx_sender {
-                        let frame_len = final_size.saturating_sub(2);
-                        let _ = tx.try_send((SystemTime::now(), output_buf[..frame_len].to_vec()));
+                        let _ = tx.try_send((SystemTime::now(), output_buf[..final_size].to_vec()));
                     }
                 }
                 #[cfg(not(feature = "ethertalk"))]

--- a/tashtalk/src/codec.rs
+++ b/tashtalk/src/codec.rs
@@ -1,6 +1,8 @@
 use bytes::{Buf, BufMut, BytesMut};
 use tokio_util::codec::{Decoder, Encoder};
 
+use crate::crc::{lt_crc, CrcCalculator};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TashTalkCommand {
     Noop,
@@ -9,18 +11,35 @@ pub enum TashTalkCommand {
     SetFeatures(u8),
 }
 
+/// A recoverable framing problem, from TashTalk or our own CRC check.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum FrameError {
+    #[error("LocalTalk framing error")]
+    FramingError,
+    #[error("LocalTalk frame aborted")]
+    FrameAborted,
+    #[error("LocalTalk CRC check failed")]
+    CrcCheckFailed,
+    #[error("unknown escape sequence 0x00 {0:#04X}")]
+    UnknownEscape(u8),
+}
+
+/// An item from the receive side of the codec. Framing problems arrive as
+/// [`TashTalkEvent::Error`] rather than terminating the stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TashTalkEvent {
+    /// A complete, CRC-valid frame (LLAP header + payload + 2 trailing CRC bytes).
+    Frame(Vec<u8>),
+    /// A bad frame; its bytes have been discarded.
+    Error(FrameError),
+}
+
+/// Fatal codec error. Framing glitches are events, not errors — only I/O
+/// failures terminate the stream.
 #[derive(Debug, thiserror::Error)]
 pub enum TashTalkError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("Framing error inside TashTalk")]
-    FramingError,
-    #[error("Frame aborted")]
-    FrameAborted,
-    #[error("CRC check failed")]
-    CrcCheckFailed,
-    #[error("Unknown escape sequence 0x00 {0:#04X}")]
-    UnknownEscape(u8),
 }
 
 pub struct TashTalkCodec;
@@ -51,62 +70,84 @@ impl Encoder<TashTalkCommand> for TashTalkCodec {
     }
 }
 
+/// Minimum length of a well-formed LocalTalk frame: a 3-byte control frame plus
+/// its two trailing CRC bytes.
+const MIN_FRAME_LEN: usize = 5;
+
+/// Undo TashTalk's `0x00 0xFF` escaping. The result still includes the CRC bytes.
+fn unescape(frame: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(frame.len());
+    let mut j = 0;
+    while j < frame.len() {
+        if frame[j] == 0x00 {
+            out.push(0x00);
+            j += 2; // skip the trailing 0xFF marker
+        } else {
+            out.push(frame[j]);
+            j += 1;
+        }
+    }
+    out
+}
+
+/// Verify a frame's CRC in software. `frame` must include the two CRC bytes.
+fn crc_ok(frame: &[u8]) -> bool {
+    let mut crc = CrcCalculator::new();
+    crc.feed(frame);
+    crc.is_okay()
+}
+
 impl Decoder for TashTalkCodec {
-    type Item = Vec<u8>;
+    type Item = TashTalkEvent;
     type Error = TashTalkError;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         let mut i = 0;
 
         while i < src.len() {
-            if src[i] == 0x00 {
-                // Need at least one more byte for the escape sequence
-                if i + 1 >= src.len() {
-                    return Ok(None);
-                }
-
-                match src[i + 1] {
-                    0xFF => {
-                        i += 2; // Skip literal 0x00
-                    }
-                    0xFD | 0xFE | 0xFA | 0xFC => {
-                        // Found end of frame marker
-                        let end_index = i + 2;
-                        let frame_slice = &src[..i]; // everything up to the 0x00 escape
-                        let code = src[i + 1];
-
-                        // Unescape the slice
-                        let mut unescaped = Vec::with_capacity(frame_slice.len());
-                        let mut j = 0;
-                        while j < frame_slice.len() {
-                            if frame_slice[j] == 0x00 {
-                                unescaped.push(0x00);
-                                j += 2; // skip 0xFF
-                            } else {
-                                unescaped.push(frame_slice[j]);
-                                j += 1;
-                            }
-                        }
-
-                        // Consume from buffer
-                        src.advance(end_index);
-
-                        return match code {
-                            0xFD => Ok(Some(unescaped)),
-                            0xFE => { tracing::warn!("LocalTalk framing error"); Ok(None) }
-                            0xFA => { tracing::warn!("LocalTalk frame aborted"); Ok(None) }
-                            0xFC => { tracing::warn!("LocalTalk CRC check failed"); Ok(None) }
-                            _ => unreachable!(),
-                        };
-                    }
-                    unknown => {
-                        src.advance(i + 2);
-                        tracing::warn!("LocalTalk unknown escape sequence: {:#04X}", unknown);
-                        return Ok(None);
-                    }
-                }
-            } else {
+            if src[i] != 0x00 {
                 i += 1;
+                continue;
+            }
+
+            // Need the escape's argument byte.
+            if i + 1 >= src.len() {
+                return Ok(None);
+            }
+
+            match src[i + 1] {
+                // Escaped literal 0x00 — frame data, keep scanning.
+                0xFF => i += 2,
+
+                // Frame Done: the bytes before the marker are a complete frame.
+                0xFD => {
+                    let frame = unescape(&src[..i]);
+                    src.advance(i + 2);
+
+                    // Verify in software; the device only checks when its
+                    // CRC-checking feature is enabled.
+                    if frame.len() < MIN_FRAME_LEN || !crc_ok(&frame) {
+                        return Ok(Some(TashTalkEvent::Error(FrameError::CrcCheckFailed)));
+                    }
+                    return Ok(Some(TashTalkEvent::Frame(frame)));
+                }
+
+                // Framing error / abort / CRC failure: discard the frame but keep
+                // the stream alive so a following buffered frame is still delivered.
+                marker @ (0xFE | 0xFA | 0xFC) => {
+                    src.advance(i + 2);
+                    let err = match marker {
+                        0xFE => FrameError::FramingError,
+                        0xFA => FrameError::FrameAborted,
+                        _ => FrameError::CrcCheckFailed,
+                    };
+                    return Ok(Some(TashTalkEvent::Error(err)));
+                }
+
+                unknown => {
+                    src.advance(i + 2);
+                    return Ok(Some(TashTalkEvent::Error(FrameError::UnknownEscape(unknown))));
+                }
             }
         }
 
@@ -114,9 +155,39 @@ impl Decoder for TashTalkCodec {
     }
 }
 
+/// Append the LocalTalk CRC to a frame. `frame` is the LLAP header and payload
+/// without CRC bytes.
+pub fn frame_with_crc(frame: &[u8]) -> Vec<u8> {
+    let crc = lt_crc(frame);
+    let mut out = Vec::with_capacity(frame.len() + 2);
+    out.extend_from_slice(frame);
+    out.extend_from_slice(&crc);
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Encode a frame (CRC included) as TashTalk would send it: escape 0x00,
+    /// then append the Frame-Done marker.
+    fn to_wire(frame_with_crc: &[u8]) -> BytesMut {
+        let mut w = BytesMut::new();
+        for &b in frame_with_crc {
+            if b == 0x00 {
+                w.extend_from_slice(&[0x00, 0xFF]);
+            } else {
+                w.put_u8(b);
+            }
+        }
+        w.extend_from_slice(&[0x00, 0xFD]);
+        w
+    }
+
+    /// A valid 3-byte control frame plus its computed CRC.
+    fn sample_frame() -> Vec<u8> {
+        frame_with_crc(&[0x01, 0x02, 0x81])
+    }
 
     #[test]
     fn test_encode() {
@@ -148,45 +219,111 @@ mod tests {
     }
 
     #[test]
-    fn test_decode() {
+    fn decode_good_frame() {
+        let mut codec = TashTalkCodec;
+        let frame = sample_frame();
+        let mut buf = to_wire(&frame);
+        let ev = codec.decode(&mut buf).unwrap().unwrap();
+        assert_eq!(ev, TashTalkEvent::Frame(frame));
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn decode_unescapes_literal_zero() {
+        let mut codec = TashTalkCodec;
+        // A frame whose data contains a 0x00 byte, forcing 0x00 0xFF escaping.
+        let frame = frame_with_crc(&[0x00, 0x02, 0x81]);
+        let mut buf = to_wire(&frame);
+        let ev = codec.decode(&mut buf).unwrap().unwrap();
+        assert_eq!(ev, TashTalkEvent::Frame(frame));
+    }
+
+    #[test]
+    fn decode_rejects_bad_crc() {
+        let mut codec = TashTalkCodec;
+        let mut frame = sample_frame();
+        *frame.last_mut().unwrap() ^= 0xFF; // corrupt the CRC
+        let mut buf = to_wire(&frame);
+        assert_eq!(
+            codec.decode(&mut buf).unwrap(),
+            Some(TashTalkEvent::Error(FrameError::CrcCheckFailed))
+        );
+    }
+
+    #[test]
+    fn decode_rejects_runt_frame() {
+        let mut codec = TashTalkCodec;
+        // Fewer than MIN_FRAME_LEN bytes before the marker.
+        let mut buf = BytesMut::from(&[0xAA, 0xBB, 0x00, 0xFD][..]);
+        assert_eq!(
+            codec.decode(&mut buf).unwrap(),
+            Some(TashTalkEvent::Error(FrameError::CrcCheckFailed))
+        );
+    }
+
+    #[test]
+    fn decode_error_markers() {
         let mut codec = TashTalkCodec;
 
-        // Normal frame end
-        let mut buf = BytesMut::from(&[0xAA, 0xBB, 0x00, 0xFD][..]);
-        let res = codec.decode(&mut buf).unwrap().unwrap();
-        assert_eq!(res, vec![0xAA, 0xBB]);
-
-        // Escape 0x00 literal
-        let mut buf = BytesMut::from(&[0xAA, 0x00, 0xFF, 0xBB, 0x00, 0xFD][..]);
-        let res = codec.decode(&mut buf).unwrap().unwrap();
-        assert_eq!(res, vec![0xAA, 0x00, 0xBB]);
-
-        // Framing error, frame aborted, CRC failure — all return Ok(None) and consume the frame
         let mut buf = BytesMut::from(&[0x00, 0xFE][..]);
-        assert_eq!(codec.decode(&mut buf).unwrap(), None);
+        assert_eq!(
+            codec.decode(&mut buf).unwrap(),
+            Some(TashTalkEvent::Error(FrameError::FramingError))
+        );
         assert!(buf.is_empty());
 
         let mut buf = BytesMut::from(&[0xAA, 0xBB, 0x00, 0xFA][..]);
-        assert_eq!(codec.decode(&mut buf).unwrap(), None);
+        assert_eq!(
+            codec.decode(&mut buf).unwrap(),
+            Some(TashTalkEvent::Error(FrameError::FrameAborted))
+        );
         assert!(buf.is_empty());
 
         let mut buf = BytesMut::from(&[0xAA, 0xBB, 0x00, 0xFC][..]);
-        assert_eq!(codec.decode(&mut buf).unwrap(), None);
+        assert_eq!(
+            codec.decode(&mut buf).unwrap(),
+            Some(TashTalkEvent::Error(FrameError::CrcCheckFailed))
+        );
         assert!(buf.is_empty());
 
-        // Unknown escape — returns Ok(None) and advances past the two bytes
         let mut buf = BytesMut::from(&[0x00, 0x01][..]);
-        assert_eq!(codec.decode(&mut buf).unwrap(), None);
+        assert_eq!(
+            codec.decode(&mut buf).unwrap(),
+            Some(TashTalkEvent::Error(FrameError::UnknownEscape(0x01)))
+        );
         assert!(buf.is_empty());
+    }
 
-        // Incomplete
+    /// A bad frame must not stall a good one buffered behind it: the good frame
+    /// is delivered on the next `decode` call, with no further I/O.
+    #[test]
+    fn error_does_not_swallow_following_frame() {
+        let mut codec = TashTalkCodec;
+        let mut buf = BytesMut::new();
+        buf.extend_from_slice(&[0xDE, 0xAD, 0x00, 0xFA]); // aborted frame
+        let frame = sample_frame();
+        buf.extend_from_slice(&to_wire(&frame));
+
+        assert_eq!(
+            codec.decode(&mut buf).unwrap(),
+            Some(TashTalkEvent::Error(FrameError::FrameAborted))
+        );
+        assert_eq!(
+            codec.decode(&mut buf).unwrap(),
+            Some(TashTalkEvent::Frame(frame))
+        );
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn decode_incomplete() {
+        let mut codec = TashTalkCodec;
+
         let mut buf = BytesMut::from(&[0xAA, 0xBB][..]);
-        let res = codec.decode(&mut buf).unwrap();
-        assert_eq!(res, None);
+        assert_eq!(codec.decode(&mut buf).unwrap(), None);
 
-        // Incomplete escape
+        // Escape start with no argument byte yet.
         let mut buf = BytesMut::from(&[0xAA, 0x00][..]);
-        let res = codec.decode(&mut buf).unwrap();
-        assert_eq!(res, None);
+        assert_eq!(codec.decode(&mut buf).unwrap(), None);
     }
 }

--- a/tashtalk/src/lib.rs
+++ b/tashtalk/src/lib.rs
@@ -3,7 +3,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::Framed;
 
 pub mod codec;
-pub use codec::{TashTalkCodec, TashTalkCommand, TashTalkError};
+pub use codec::{FrameError, TashTalkCodec, TashTalkCommand, TashTalkError, TashTalkEvent};
 
 pub mod crc;
 pub use crc::{lt_crc, CrcCalculator};
@@ -75,12 +75,12 @@ impl<T: AsyncRead + AsyncWrite + Unpin> TashTalk<T> {
     }
 
     /// Transmit a frame.
-    /// `frame` must include the LLAP header and the 2 CRC bytes at the end.
-    /// Note: if SetFeatures bit 7 (CRC Calculation) is enabled on TashTalk,
-    /// it will overwrite the 2 CRC bytes with the correct values.
+    /// `frame` is the LLAP header and payload without CRC bytes; the CRC is
+    /// computed in software and appended here. (If SetFeatures bit 7 is also
+    /// enabled, TashTalk recomputes the same value — harmless.)
     pub async fn send_frame(&mut self, frame: &[u8]) -> Result<(), std::io::Error> {
         self.framed
-            .send(TashTalkCommand::TransmitFrame(frame.to_vec()))
+            .send(TashTalkCommand::TransmitFrame(codec::frame_with_crc(frame)))
             .await
     }
 
@@ -107,8 +107,9 @@ impl<T: AsyncRead + AsyncWrite + Unpin> TashTalk<T> {
             .await
     }
 
-    /// Wait for and receive the next frame from the LocalTalk bus.
-    pub async fn receive_frame(&mut self) -> Result<Option<Vec<u8>>, TashTalkError> {
+    /// Wait for and receive the next event from the LocalTalk bus.
+    /// `Ok(None)` means end of stream; `Err` is reserved for fatal I/O errors.
+    pub async fn receive_frame(&mut self) -> Result<Option<TashTalkEvent>, TashTalkError> {
         self.framed.next().await.transpose()
     }
 }


### PR DESCRIPTION
Inbound frames were never CRC-checked unless the firmware's CRC-checking feature was on (off by default), so corrupt bus frames got parsed as DDP. Verify every frame's CRC in software on receive, and generate the CRC in send_frame instead of at each call site.

Also fix the decoder returning Ok(None) after a bad frame, which stalled any good frame buffered behind it until more bytes arrived. Framing errors now come back as a TashTalkEvent::Error the caller can log and skip, keeping the stream alive rather than tearing it down.