### PR TITLE
Add printer emulator and modern printer sharing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4498,6 +4498,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
+name = "pap-capture-example"
+version = "0.7.2"
+dependencies = [
+ "anyhow",
+ "clap",
+ "tailtalk",
+ "tailtalk-packets",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "pap-print-example"
 version = "0.7.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "examples/nbp-lookup",
   "examples/aep-echo",
   "examples/pap-print",
+  "examples/pap-capture",
   "examples/afp-server",
   "examples/adsp-stylewriter",
   "examples/sw-rename",

--- a/examples/pap-capture/Cargo.toml
+++ b/examples/pap-capture/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "pap-capture-example"
+version.workspace = true
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "pap-capture"
+path = "main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+tailtalk = { workspace = true, features = ["ethertalk"] }
+tailtalk-packets = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/pap-capture/main.rs
+++ b/examples/pap-capture/main.rs
@@ -1,0 +1,73 @@
+use anyhow::Result;
+use clap::Parser;
+use tailtalk::{
+    TalkStack,
+    pap::{FileSink, PaperSize, PrinterAttributes},
+};
+
+#[derive(Parser, Debug)]
+#[command(about = "Emulate a PAP LaserWriter and capture incoming PostScript jobs to disk")]
+struct Args {
+    /// Network interface to bind to (EtherTalk)
+    #[arg(short, long)]
+    interface: Option<String>,
+
+    /// TashTalk serial port path (LocalTalk)
+    #[arg(short, long)]
+    tashtalk: Option<String>,
+
+    /// Printer name to advertise in NBP, e.g. "Color LaserWriter 12/600"
+    #[arg(short, long, default_value = "Color LaserWriter 12/600")]
+    name: String,
+
+    /// Directory to write captured PostScript files into
+    #[arg(short, long, default_value = ".")]
+    output: String,
+
+    /// Write a pcap capture to this file
+    #[arg(long)]
+    pcap: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt().init();
+
+    let args = Args::parse();
+
+    if args.interface.is_none() && args.tashtalk.is_none() {
+        anyhow::bail!("at least one of --interface or --tashtalk is required");
+    }
+
+    let mut builder = TalkStack::builder();
+    if let Some(ref intf) = args.interface {
+        builder = builder.ethernet(intf);
+    }
+    if let Some(ref tty) = args.tashtalk {
+        builder = builder.localtalk(tty);
+    }
+    if let Some(ref path) = args.pcap {
+        builder = builder.pcap_capture(path);
+    }
+    let stack = builder.build().await?;
+
+    let attrs = PrinterAttributes {
+        status: "%%[ status: idle; source: EtherTalk ]%%".to_string(),
+        product_name: args.name.clone(),
+        language_level: 2,
+        color: true,
+        resolutions_dpi: vec![600],
+        paper_sizes: vec![PaperSize::Letter, PaperSize::A4],
+    };
+
+    let mut server = stack
+        .add_printer(&args.name, attrs, FileSink::new(&args.output))
+        .await?;
+
+    println!(
+        "Advertising \"{}\" on socket {} — saving jobs to: {}",
+        args.name, server.socket_number, args.output
+    );
+
+    server.run().await
+}

--- a/tailtalk-daemon/src/lib.rs
+++ b/tailtalk-daemon/src/lib.rs
@@ -265,6 +265,7 @@ impl Session {
         match kind {
             Kind::ListInterfaces(_) => self.list_interfaces(id).await,
             Kind::SetAddress(r) => self.set_address(id, r).await,
+            Kind::ProbeAddress(r) => self.probe_address(id, r).await,
             Kind::AddMulticast(r) => self.add_multicast(id, r),
             Kind::OpenSocket(r) => self.open_socket(id, r).await,
             Kind::CloseSocket(r) => {
@@ -365,6 +366,43 @@ impl Session {
             .await
         {
             Ok(()) => proto::Reply::ok(id),
+            Err(e) => proto::Reply::error(id, proto::ErrorCode::Internal, e.to_string()),
+        }
+    }
+
+    async fn probe_address(&self, id: u64, r: proto::ProbeAddressRequest) -> proto::Reply {
+        let Some(iface) = self.state.interfaces.iter().find(|i| i.name == r.interface) else {
+            return proto::Reply::error(
+                id,
+                proto::ErrorCode::NotFound,
+                format!("no interface named '{}'", r.interface),
+            );
+        };
+        let Some(addr) = r.address else {
+            return invalid(id, "probe_address requires an address");
+        };
+        let (Ok(network), Ok(node)) = (u16::try_from(addr.network), u8::try_from(addr.node)) else {
+            return invalid(id, "address out of range");
+        };
+        if node == 0 || node == 255 {
+            return invalid(id, "node must be 1-254");
+        }
+        if iface.kind == proto::InterfaceType::Localtalk && network != 0 {
+            return invalid(id, "LocalTalk network number must be 0");
+        }
+
+        match iface
+            .addressing
+            .probe(AppleTalkAddress {
+                network_number: network,
+                node_number: node,
+            })
+            .await
+        {
+            Ok(available) => proto::Reply::new(
+                id,
+                proto::reply::Kind::ProbeAddress(proto::ProbeAddressReply { available }),
+            ),
             Err(e) => proto::Reply::error(id, proto::ErrorCode::Internal, e.to_string()),
         }
     }

--- a/tailtalk-gui/ipp_bridge.rs
+++ b/tailtalk-gui/ipp_bridge.rs
@@ -152,7 +152,12 @@ struct BridgeState {
     job_locks: std::sync::Mutex<HashMap<String, Arc<Mutex<()>>>>,
 }
 
-pub async fn run(nbp: NbpHandle, ddp: DdpHandle, token: CancellationToken) {
+pub async fn run(
+    nbp: NbpHandle,
+    ddp: DdpHandle,
+    token: CancellationToken,
+    bridged_names: crate::lw_bridge::BridgedNames,
+) {
     let printers: Arc<RwLock<Vec<Printer>>> = Arc::new(RwLock::new(Vec::new()));
 
     let mdns = match ServiceDaemon::new() {
@@ -168,8 +173,9 @@ pub async fn run(nbp: NbpHandle, ddp: DdpHandle, token: CancellationToken) {
     let printers2 = printers.clone();
     let mdns2 = mdns.clone();
     let token2 = token.clone();
+    let bridged2 = bridged_names.clone();
 
-    discover(&nbp, &ddp, &printers, &mdns).await;
+    discover(&nbp, &ddp, &printers, &mdns, &bridged_names).await;
 
     let state = Arc::new(BridgeState {
         printers: printers.clone(),
@@ -205,7 +211,7 @@ pub async fn run(nbp: NbpHandle, ddp: DdpHandle, token: CancellationToken) {
         loop {
             tokio::select! {
                 _ = token2.cancelled() => break,
-                _ = interval.tick() => discover(&nbp2, &ddp2, &printers2, &mdns2).await,
+                _ = interval.tick() => discover(&nbp2, &ddp2, &printers2, &mdns2, &bridged2).await,
             }
         }
     });
@@ -276,6 +282,7 @@ async fn discover(
     ddp: &DdpHandle,
     printers: &Arc<RwLock<Vec<Printer>>>,
     mdns: &ServiceDaemon,
+    bridged_names: &crate::lw_bridge::BridgedNames,
 ) {
     // (kind, NBP type pattern) for each supported printer family.
     let lookups: [(PrinterKind, &str); 2] = [
@@ -307,6 +314,13 @@ async fn discover(
             }
         }
         Err(e) => tracing::warn!("IPP bridge: NBP lookup failed: {e}"),
+    }
+
+    // Names lw_bridge registered are modern IPP devices already on mDNS;
+    // re-exporting them here would advertise a duplicate.
+    {
+        let bridged = bridged_names.lock().unwrap();
+        tuples.retain(|(_, t)| !bridged.contains(&(t.entity_name.object.clone(), t.socket_number)));
     }
 
     let new_keys: HashSet<String> = tuples.iter()
@@ -1210,7 +1224,7 @@ async fn urf_to_rasterizable(data: Vec<u8>, job_token: u32) -> anyhow::Result<Ve
 /// Return the name of the Ghostscript executable on this platform.
 /// On Windows, Ghostscript may be installed as `gswin64c` or `gswin32c`
 /// rather than `gs`; try each in order and return the first one found.
-fn gs_command() -> &'static str {
+pub(crate) fn gs_command() -> &'static str {
     #[cfg(target_os = "windows")]
     {
         for candidate in &["gswin64c", "gswin32c", "gs"] {

--- a/tailtalk-gui/lw_bridge.rs
+++ b/tailtalk-gui/lw_bridge.rs
@@ -1,0 +1,670 @@
+/// The reverse of ipp_bridge: discovers modern IPP printers via mDNS/Bonjour and
+/// exposes each one on AppleTalk as an emulated LaserWriter, so old Macs can print
+/// to them from the Chooser. The real printer's name, make/model, colour capability,
+/// resolution and paper sizes are passed through to the Chooser name and the PAP
+/// emulator's PostScript query answers (`*Product`, `*ColorDevice`, `*?Resolution`, …).
+///
+/// Jobs arrive as PostScript from the LaserWriter driver and are submitted with IPP
+/// Print-Job: passed through untouched if the printer accepts PostScript, otherwise
+/// converted with Ghostscript (PDF, or URF/PWG raster for driverless-only printers).
+use std::{
+    collections::{HashMap, HashSet},
+    future::Future,
+    io::Cursor,
+    pin::Pin,
+    sync::{
+        Arc, Mutex as StdMutex,
+        atomic::{AtomicU32, AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+pub(crate) static GS_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+use ipp::prelude::*;
+use mdns_sd::{ServiceDaemon, ServiceEvent};
+use tailtalk::{
+    CancellationToken,
+    atp::Atp,
+    ddp::DdpHandle,
+    nbp::{NbpHandle, RegisteredName},
+    pap::{PapServer, PaperSize, PrintJob, PrintSink, PrinterAttributes},
+};
+use tailtalk_packets::nbp::EntityName;
+use tokio::sync::Mutex;
+
+/// Names this bridge has registered on NBP. Shared with ipp_bridge so it can skip
+/// them during its own discovery — otherwise a bridged printer would be re-exported
+/// over mDNS as a duplicate of the real device.
+pub type BridgedNames = Arc<StdMutex<HashSet<(String, u8)>>>;
+
+/// Document format jobs are forwarded in, in order of preference. PostScript is a
+/// pass-through; everything else is converted with Ghostscript.
+#[derive(Clone, Copy, Debug)]
+enum ForwardFormat {
+    Postscript,
+    Pdf,
+    Urf,
+    PwgRaster,
+}
+
+impl ForwardFormat {
+    fn mime(self) -> &'static str {
+        match self {
+            Self::Postscript => "application/postscript",
+            Self::Pdf => "application/pdf",
+            Self::Urf => "image/urf",
+            Self::PwgRaster => "image/pwg-raster",
+        }
+    }
+}
+
+/// Capabilities pulled from the real printer via Get-Printer-Attributes.
+#[derive(Debug)]
+struct IppCaps {
+    make_and_model: String,
+    color: bool,
+    dpi: u32,
+    paper_sizes: Vec<PaperSize>,
+    format: ForwardFormat,
+}
+
+impl Default for IppCaps {
+    /// Fallback when the attribute query fails: nearly every IPP printer accepts
+    /// PDF, and assuming colour avoids degrading colour jobs (a mono printer
+    /// grayscales them itself).
+    fn default() -> Self {
+        Self {
+            make_and_model: String::new(),
+            color: true,
+            dpi: 300,
+            paper_sizes: vec![PaperSize::Letter, PaperSize::A4],
+            format: ForwardFormat::Pdf,
+        }
+    }
+}
+
+struct BridgedPrinter {
+    uri: String,
+    nbp_name: String,
+    registration: RegisteredName,
+    task: tokio::task::JoinHandle<()>,
+}
+
+struct ResolvedPrinter {
+    fullname: String,
+    printer: BridgedPrinter,
+}
+
+pub async fn run(
+    nbp: NbpHandle,
+    ddp: DdpHandle,
+    token: CancellationToken,
+    bridged_names: BridgedNames,
+) {
+    let mdns = ServiceDaemon::new().expect("LW bridge: failed to create mDNS daemon");
+    let receiver = match mdns.browse("_ipp._tcp.local.") {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("LW bridge: mDNS browse failed: {e}");
+            let _ = mdns.shutdown();
+            return;
+        }
+    };
+
+    tracing::info!("LW bridge: browsing for IPP printers");
+
+    let mut printers: HashMap<String, BridgedPrinter> = HashMap::new();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ResolvedPrinter>();
+
+    loop {
+        tokio::select! {
+            _ = token.cancelled() => break,
+            Some(res) = rx.recv() => {
+                printers.insert(res.fullname, res.printer);
+            }
+            ev = receiver.recv_async() => {
+                let Ok(ev) = ev else { break };
+                match ev {
+                    ServiceEvent::ServiceResolved(info) => {
+                        let fullname = info.get_fullname().to_string();
+                        let instance = fullname
+                            .strip_suffix("._ipp._tcp.local.")
+                            .unwrap_or(&fullname)
+                            .to_string();
+
+                        if info.get_hostname().starts_with("tailtalk-") || info.get_port() == 8631 {
+                            tracing::debug!("LW bridge: ignoring TailTalk-published service '{instance}'");
+                            continue;
+                        }
+
+                        let Some(ip) = info.get_addresses_v4().into_iter().min() else {
+                            tracing::debug!("LW bridge: no IPv4 address for '{instance}', skipping");
+                            continue;
+                        };
+                        let rp = info.get_property_val_str("rp").unwrap_or("");
+                        let uri_str = format!("ipp://{ip}:{}/{rp}", info.get_port());
+
+                        match printers.get(&fullname) {
+                            Some(existing) if existing.uri == uri_str => continue,
+                            Some(_) => remove_printer(&nbp, &mut printers, &bridged_names, &fullname).await,
+                            None => {}
+                        }
+
+                        let taken: HashSet<String> = printers.values().map(|p| p.nbp_name.clone()).collect();
+                        let nbp = nbp.clone();
+                        let ddp = ddp.clone();
+                        let bridged_names = bridged_names.clone();
+                        let tx = tx.clone();
+                        let _info = info.clone();
+
+                        tokio::spawn(async move {
+                            let uri: Uri = match uri_str.parse() {
+                                Ok(u) => u,
+                                Err(e) => {
+                                    tracing::warn!("LW bridge: bad URI '{uri_str}': {e}");
+                                    return;
+                                }
+                            };
+
+                            let caps = match query_ipp_caps(&uri).await {
+                                Ok(c) => c,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "LW bridge: attribute query for '{instance}' failed ({e}), using defaults"
+                                    );
+                                    IppCaps {
+                                        make_and_model: instance.clone(),
+                                        ..IppCaps::default()
+                                    }
+                                }
+                            };
+
+                            let mut nbp_name = unique_nbp_name(&instance, &taken.iter().map(|s| s.as_str()).collect());
+                            if nbp_name.is_empty() {
+                                tracing::warn!("LW bridge: '{instance}' has no NBP-representable name, skipping");
+                                return;
+                            }
+
+                            let mut suffix = 2;
+                            loop {
+                                let entity: EntityName = match format!("{nbp_name}:LaserWriter@*").as_str().try_into() {
+                                    Ok(e) => e,
+                                    Err(_) => return,
+                                };
+                                if let Ok(res) = nbp.lookup(entity).await {
+                                    if res.is_empty() { break; }
+                                } else {
+                                    break;
+                                }
+
+                                let base = nbp_safe_name(&instance);
+                                let s = format!(" {suffix}");
+                                nbp_name = base.chars().take(32 - s.len()).collect::<String>().trim_end().to_string() + &s;
+                                suffix += 1;
+                                if suffix > 100 { return; }
+                            }
+
+                            let attrs = PrinterAttributes {
+                                product_name: if caps.make_and_model.is_empty() {
+                                    nbp_name.clone()
+                                } else {
+                                    caps.make_and_model.clone()
+                                },
+                                color: caps.color,
+                                resolutions_dpi: vec![caps.dpi],
+                                paper_sizes: caps.paper_sizes.clone(),
+                                ..PrinterAttributes::default()
+                            };
+
+                            let sink = IppForwardSink {
+                                uri,
+                                format: caps.format,
+                                dpi: caps.dpi,
+                                color: caps.color,
+                                printer: nbp_name.clone(),
+                                serial: Arc::new(tokio::sync::Mutex::new(())),
+                                counter: std::sync::atomic::AtomicU32::new(0),
+                            };
+
+                            let (socket_num, _requestor, responder) = Atp::spawn(&ddp, None).await;
+                            let mut server = PapServer::new(
+                                responder,
+                                ddp,
+                                socket_num,
+                                attrs,
+                                Box::new(sink),
+                            );
+
+                            let entity: EntityName = match format!("{nbp_name}:LaserWriter@*").as_str().try_into() {
+                                Ok(e) => e,
+                                Err(e) => {
+                                    tracing::warn!("LW bridge: invalid NBP name '{nbp_name}': {e}");
+                                    return;
+                                }
+                            };
+                            let registration = RegisteredName {
+                                name: entity,
+                                sock_num: socket_num,
+                            };
+                            
+                            bridged_names.lock().unwrap().insert((nbp_name.clone(), socket_num));
+                            if let Err(e) = nbp.register(registration.clone()).await {
+                                tracing::warn!("LW bridge: NBP registration for '{nbp_name}' failed: {e}");
+                                bridged_names.lock().unwrap().remove(&(nbp_name, socket_num));
+                                return;
+                            }
+
+                            let task_name = nbp_name.clone();
+                            let task = tokio::spawn(async move {
+                                if let Err(e) = server.run().await {
+                                    tracing::warn!("LW bridge: PAP server for '{task_name}' stopped: {e}");
+                                }
+                            });
+
+                            tracing::info!(
+                                "LW bridge: bridged '{instance}' → \"{nbp_name}:LaserWriter\" \
+                                 ({}, {}dpi, color={}, sending {})",
+                                if caps.make_and_model.is_empty() { "unknown model" } else { &caps.make_and_model },
+                                caps.dpi,
+                                caps.color,
+                                caps.format.mime(),
+                            );
+
+                            let printer = BridgedPrinter {
+                                uri: uri_str,
+                                nbp_name,
+                                registration,
+                                task,
+                            };
+                            let _ = tx.send(ResolvedPrinter { fullname, printer });
+                        });
+                    }
+                    ServiceEvent::ServiceRemoved(_, fullname) => {
+                        remove_printer(&nbp, &mut printers, &bridged_names, &fullname).await;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    for (_, p) in printers.drain() {
+        p.task.abort();
+        let _ = nbp.unregister(p.registration.clone()).await;
+        bridged_names.lock().unwrap().remove(&(p.nbp_name.clone(), p.registration.sock_num));
+    }
+    let _ = mdns.shutdown();
+}
+
+async fn remove_printer(
+    nbp: &NbpHandle,
+    printers: &mut HashMap<String, BridgedPrinter>,
+    bridged_names: &BridgedNames,
+    fullname: &str,
+) {
+    let Some(p) = printers.remove(fullname) else { return };
+    tracing::info!("LW bridge: '{}' vanished, unregistering", p.nbp_name);
+    p.task.abort();
+    if let Err(e) = nbp.unregister(p.registration.clone()).await {
+        tracing::warn!("LW bridge: NBP unregister for '{}' failed: {e}", p.nbp_name);
+    }
+    bridged_names.lock().unwrap().remove(&(p.nbp_name.clone(), p.registration.sock_num));
+}
+
+/// Make a printer's mDNS instance name safe for NBP: ASCII only (NBP names are
+/// MacRoman on the wire; non-ASCII would mojibake in the Chooser), no NBP
+/// metacharacters, at most 32 characters.
+fn nbp_safe_name(s: &str) -> String {
+    let cleaned: String = s
+        .chars()
+        .map(|c| match c {
+            ':' | '@' | '=' | '*' => ' ',
+            c if c.is_ascii_graphic() || c == ' ' => c,
+            _ => ' ',
+        })
+        .collect();
+    let cleaned = cleaned.split_whitespace().collect::<Vec<_>>().join(" ");
+    cleaned.chars().take(32).collect::<String>().trim_end().to_string()
+}
+
+/// NBP-safe name, disambiguated with a numeric suffix if another bridged
+/// printer already claimed it.
+fn unique_nbp_name(instance: &str, taken: &HashSet<&str>) -> String {
+    let base = nbp_safe_name(instance);
+    if base.is_empty() || !taken.contains(base.as_str()) {
+        return base;
+    }
+    for n in 2..100 {
+        let suffix = format!(" {n}");
+        let candidate: String = base
+            .chars()
+            .take(32 - suffix.len())
+            .collect::<String>()
+            .trim_end()
+            .to_string()
+            + &suffix;
+        if !taken.contains(candidate.as_str()) {
+            return candidate;
+        }
+    }
+    String::new()
+}
+
+// ── IPP attribute query ───────────────────────────────────────────────────────
+
+fn attr_string(v: &IppValue) -> Option<String> {
+    match v {
+        IppValue::NameWithoutLanguage(s) | IppValue::Keyword(s) => Some(s.to_string()),
+        IppValue::TextWithoutLanguage(s) => Some(s.to_string()),
+        _ => None,
+    }
+}
+
+/// Iterate an attribute's values whether it's a single value or a 1setOf array.
+fn attr_values(v: &IppValue) -> Vec<&IppValue> {
+    match v {
+        IppValue::Array(vals) => vals.iter().collect(),
+        other => vec![other],
+    }
+}
+
+async fn query_ipp_caps(uri: &Uri) -> anyhow::Result<IppCaps> {
+    let client = AsyncIppClient::new(uri.clone());
+    let op = IppOperationBuilder::get_printer_attributes(uri.clone())
+        .attributes([
+            "printer-make-and-model",
+            "color-supported",
+            "printer-resolution-default",
+            "media-supported",
+            "document-format-supported",
+        ])
+        .build()?;
+    let resp = tokio::time::timeout(Duration::from_secs(15), client.send(op))
+        .await
+        .map_err(|_| anyhow::anyhow!("Get-Printer-Attributes timed out"))??;
+
+    let status = resp.header().operation_or_status;
+    anyhow::ensure!(status < 0x100, "Get-Printer-Attributes failed: 0x{status:04x}");
+
+    let group = resp
+        .attributes()
+        .groups_of(DelimiterTag::PrinterAttributes)
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("response has no printer attributes"))?;
+    let attrs = group.attributes();
+
+    let make_and_model = attrs
+        .get("printer-make-and-model")
+        .and_then(|a| attr_string(a.value()))
+        .unwrap_or_default();
+
+    let color = attrs
+        .get("color-supported")
+        .and_then(|a| match a.value() {
+            IppValue::Boolean(b) => Some(*b),
+            _ => None,
+        })
+        .unwrap_or(false);
+
+    let dpi = attrs
+        .get("printer-resolution-default")
+        .and_then(|a| match a.value() {
+            IppValue::Resolution { cross_feed, units, .. } if *cross_feed > 0 => {
+                if *units == 4 {
+                    Some((*cross_feed as f64 * 2.54).round() as u32)
+                } else {
+                    Some(*cross_feed as u32)
+                }
+            }
+            _ => None,
+        })
+        .unwrap_or(300);
+
+    let mut paper_sizes: Vec<PaperSize> = Vec::new();
+    if let Some(a) = attrs.get("media-supported") {
+        for v in attr_values(a.value()) {
+            let Some(media) = attr_string(v) else { continue };
+            let size = if media.starts_with("na_letter") {
+                Some(PaperSize::Letter)
+            } else if media.starts_with("na_legal") {
+                Some(PaperSize::Legal)
+            } else if media.starts_with("iso_a4") {
+                Some(PaperSize::A4)
+            } else if media.starts_with("iso_a3") {
+                Some(PaperSize::A3)
+            } else if media.starts_with("iso_b5") || media.starts_with("jis_b5") {
+                Some(PaperSize::B5)
+            } else if media.starts_with("na_executive") {
+                Some(PaperSize::Executive)
+            } else {
+                None
+            };
+            if let Some(s) = size
+                && !paper_sizes.contains(&s)
+            {
+                paper_sizes.push(s);
+            }
+        }
+    }
+    if paper_sizes.is_empty() {
+        paper_sizes = vec![PaperSize::Letter, PaperSize::A4];
+    }
+
+    let mut formats: HashSet<String> = HashSet::new();
+    if let Some(a) = attrs.get("document-format-supported") {
+        for v in attr_values(a.value()) {
+            if let IppValue::MimeMediaType(m) = v {
+                formats.insert(m.to_string());
+            }
+        }
+    }
+    let format = if formats.contains("application/postscript") {
+        ForwardFormat::Postscript
+    } else if formats.contains("application/pdf") {
+        ForwardFormat::Pdf
+    } else if formats.contains("image/urf") {
+        ForwardFormat::Urf
+    } else if formats.contains("image/pwg-raster") {
+        ForwardFormat::PwgRaster
+    } else {
+        // Nothing recognised (or the attribute was withheld); PDF is the safest bet.
+        ForwardFormat::Pdf
+    };
+
+    Ok(IppCaps {
+        make_and_model,
+        color,
+        dpi,
+        paper_sizes,
+        format,
+    })
+}
+
+// ── Print sink: PostScript → IPP Print-Job ────────────────────────────────────
+
+struct IppForwardSink {
+    uri: Uri,
+    format: ForwardFormat,
+    dpi: u32,
+    color: bool,
+    printer: String,
+    /// Serialises forwarded jobs so two quick prints can't arrive out of order.
+    serial: Arc<Mutex<()>>,
+    counter: AtomicU32,
+}
+
+impl PrintSink for IppForwardSink {
+    fn receive_job(
+        &self,
+        job: PrintJob,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + '_>> {
+        let uri = self.uri.clone();
+        let format = self.format;
+        let dpi = self.dpi;
+        let color = self.color;
+        let printer = self.printer.clone();
+        let serial = self.serial.clone();
+        let n = self.counter.fetch_add(1, Ordering::Relaxed) + 1;
+        Box::pin(async move {
+            // Forward in the background so the PAP session keeps answering the Mac's
+            // status polls; the Mac considers the job delivered at PAP EOF, so a
+            // failure here can only be logged.
+            tokio::spawn(async move {
+                let _guard = serial.lock().await;
+                match forward_job(&uri, format, dpi, color, job.data, n).await {
+                    Ok(job_id) => tracing::info!(
+                        "LW bridge: job {n} for '{printer}' submitted (IPP job {job_id})"
+                    ),
+                    Err(e) => tracing::error!("LW bridge: job {n} for '{printer}' failed: {e}"),
+                }
+            });
+            Ok(())
+        })
+    }
+}
+
+/// Extract the `%%Title:` DSC comment from a PostScript job for the IPP job name.
+fn ps_title(data: &[u8]) -> Option<String> {
+    let head = &data[..data.len().min(4096)];
+    let text = String::from_utf8_lossy(head);
+    for line in text.split(['\r', '\n']) {
+        if let Some(title) = line.strip_prefix("%%Title:") {
+            let title = title.trim().trim_matches(|c| c == '(' || c == ')').trim();
+            if !title.is_empty() {
+                return Some(title.chars().take(255).collect());
+            }
+        }
+    }
+    None
+}
+
+async fn forward_job(
+    uri: &Uri,
+    format: ForwardFormat,
+    dpi: u32,
+    color: bool,
+    ps: Vec<u8>,
+    n: u32,
+) -> anyhow::Result<i32> {
+    let title = ps_title(&ps).unwrap_or_else(|| format!("TailTalk job {n}"));
+
+    let doc = match format {
+        ForwardFormat::Postscript => ps,
+        ForwardFormat::Pdf => gs_convert(&ps, "pdfwrite", &[]).await?,
+        ForwardFormat::Urf => {
+            let device = if color { "urfrgb" } else { "urfgray" };
+            gs_convert(&ps, device, &[format!("-r{dpi}")]).await?
+        }
+        ForwardFormat::PwgRaster => {
+            gs_convert(&ps, "pwgraster", &[format!("-r{dpi}")]).await?
+        }
+    };
+
+    let payload = IppPayload::new(Cursor::new(doc));
+    let op = IppOperationBuilder::print_job(uri.clone(), payload)
+        .user_name("TailTalk")
+        .job_title(&title)
+        .document_format(format.mime())
+        .build()?;
+
+    let client = AsyncIppClient::new(uri.clone());
+    let resp = tokio::time::timeout(Duration::from_secs(300), client.send(op))
+        .await
+        .map_err(|_| anyhow::anyhow!("Print-Job timed out"))??;
+
+    let status = resp.header().operation_or_status;
+    anyhow::ensure!(status < 0x100, "Print-Job failed: 0x{status:04x}");
+
+    let job_id = resp
+        .attributes()
+        .groups_of(DelimiterTag::JobAttributes)
+        .next()
+        .and_then(|g| g.attributes().get("job-id"))
+        .and_then(|a| match a.value() {
+            IppValue::Integer(id) => Some(*id),
+            _ => None,
+        })
+        .unwrap_or(0);
+    Ok(job_id)
+}
+
+/// Run Ghostscript over a PostScript job with the given output device.
+pub(crate) async fn gs_convert(
+    ps: &[u8],
+    device: &str,
+    extra_args: &[String],
+) -> anyhow::Result<Vec<u8>> {
+    let id = GS_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let tmp = std::env::temp_dir();
+    let in_path = tmp.join(format!("tailtalk-gs-{id}.ps"));
+    let out_path = tmp.join(format!("tailtalk-gs-{id}.out"));
+    tokio::fs::write(&in_path, ps).await?;
+
+    let output = tokio::process::Command::new(crate::ipp_bridge::gs_command())
+        .args(["-dNOPAUSE", "-dBATCH", "-dSAFER"])
+        .arg(format!("-sDEVICE={device}"))
+        .args(extra_args)
+        .arg("-o")
+        .arg(&out_path)
+        .arg(&in_path)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await?;
+
+    let _ = tokio::fs::remove_file(&in_path).await;
+
+    if !output.status.success() {
+        let _ = tokio::fs::remove_file(&out_path).await;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("gs {device} exited with {}: {}", output.status, stderr.trim());
+    }
+
+    let out = tokio::fs::read(&out_path).await?;
+    let _ = tokio::fs::remove_file(&out_path).await;
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nbp_names_sanitized() {
+        assert_eq!(nbp_safe_name("HP LaserJet Pro"), "HP LaserJet Pro");
+        assert_eq!(nbp_safe_name("Foo: Bar @ Home"), "Foo Bar Home");
+        assert_eq!(
+            nbp_safe_name("A very long printer name that exceeds limits"),
+            "A very long printer name that ex"
+        );
+        assert_eq!(nbp_safe_name("Caf\u{e9} Printer"), "Caf Printer");
+    }
+
+    #[test]
+    fn nbp_names_disambiguated() {
+        let mut taken = HashSet::new();
+        assert_eq!(unique_nbp_name("Printer", &taken), "Printer");
+        taken.insert("Printer");
+        assert_eq!(unique_nbp_name("Printer", &taken), "Printer 2");
+    }
+
+    /// Live query against a real printer, e.g.:
+    ///   TAILTALK_TEST_IPP_URI=ipp://printer.local:631/ipp/print \
+    ///     cargo test -p tailtalk-gui live_ipp_caps -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore]
+    async fn live_ipp_caps() {
+        let uri = std::env::var("TAILTALK_TEST_IPP_URI")
+            .expect("set TAILTALK_TEST_IPP_URI to run this test");
+        let caps = query_ipp_caps(&uri.parse().unwrap()).await.unwrap();
+        println!("caps: {caps:?}");
+    }
+
+    #[test]
+    fn ps_title_extracted() {
+        let ps = b"%!PS-Adobe-3.0\r%%Title: (My Document)\r%%EndComments\r";
+        assert_eq!(ps_title(ps).as_deref(), Some("My Document"));
+        assert_eq!(ps_title(b"%!PS-Adobe-3.0\n"), None);
+    }
+}

--- a/tailtalk-gui/main.rs
+++ b/tailtalk-gui/main.rs
@@ -17,6 +17,7 @@ use tracing_subscriber::{EnvFilter, prelude::*};
 slint::include_modules!();
 
 mod ipp_bridge;
+mod lw_bridge;
 
 // ── Persisted user configuration ──────────────────────────────────────────────
 
@@ -32,6 +33,11 @@ struct AppConfig {
     pcap_enabled: bool,
     pcap_path: Option<String>,
     ipp_bridge_enabled: bool,
+    lw_bridge_enabled: bool,
+    laserwriter_enabled: bool,
+    laserwriter_name: Option<String>,
+    laserwriter_output_path: Option<String>,
+    laserwriter_convert_pdf: bool,
 }
 
 fn config_path() -> Option<PathBuf> {
@@ -68,6 +74,12 @@ fn save_config(config: &AppConfig) {
 
 // ── Commands sent from the UI thread to the tokio server task ─────────────────
 
+struct LaserWriterConfig {
+    name: String,
+    output_path: PathBuf,
+    convert_to_pdf: bool,
+}
+
 enum ServerCommand {
     Start {
         server_name: String,
@@ -79,6 +91,8 @@ enum ServerCommand {
         volume: PathBuf,
         pcap_path: Option<PathBuf>,
         ipp_bridge_enabled: bool,
+        lw_bridge_enabled: bool,
+        laserwriter: Option<LaserWriterConfig>,
     },
     Stop,
 }
@@ -272,6 +286,16 @@ fn main() -> anyhow::Result<()> {
         model
     };
 
+    // Default LaserWriter save location, used unless overridden by a saved config.
+    ui.set_laserwriter_output_path(
+        dirs::document_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("TailTalk Print Jobs")
+            .to_string_lossy()
+            .into_owned()
+            .into(),
+    );
+
     // Restore previously saved settings
     {
         let config = load_config();
@@ -302,6 +326,15 @@ fn main() -> anyhow::Result<()> {
             ui.set_pcap_path(path.as_str().into());
         }
         ui.set_ipp_bridge_enabled(config.ipp_bridge_enabled);
+        ui.set_lw_bridge_enabled(config.lw_bridge_enabled);
+        ui.set_laserwriter_enabled(config.laserwriter_enabled);
+        if let Some(ref v) = config.laserwriter_name {
+            ui.set_laserwriter_name(v.as_str().into());
+        }
+        if let Some(ref v) = config.laserwriter_output_path {
+            ui.set_laserwriter_output_path(v.as_str().into());
+        }
+        ui.set_laserwriter_convert_pdf(config.laserwriter_convert_pdf);
     }
 
     let ui_handle = ui.as_weak();
@@ -369,17 +402,10 @@ fn main() -> anyhow::Result<()> {
             }
 
             if ui.get_ipp_bridge_enabled() {
-                let gs_ok = ipp_bridge::gs_probe();
-                if !gs_ok {
-                    #[cfg(target_os = "macos")]
-                    let hint = "Please install it via \"brew install ghostscript\".";
-                    #[cfg(target_os = "linux")]
-                    let hint = "Please install it via \"sudo apt install ghostscript\" or your distro's equivalent.";
-                    #[cfg(target_os = "windows")]
-                    let hint = "Please install it from https://www.ghostscript.com/releases/gsdnld.html and ensure gswin64c or gs is in your PATH.";
+                if !ipp_bridge::gs_probe() {
                     show_error(
                         ui_weak.clone(),
-                        format!("Ghostscript is required for the LaserWriter printing bridge but was not found.\n{hint}"),
+                        ghostscript_missing_message("for the LaserWriter printing bridge"),
                     );
                     return;
                 }
@@ -403,6 +429,42 @@ fn main() -> anyhow::Result<()> {
                 }
             }
 
+            if ui.get_lw_bridge_enabled() && !ipp_bridge::gs_probe() {
+                show_error(
+                    ui_weak.clone(),
+                    ghostscript_missing_message("to print to network printers"),
+                );
+                return;
+            }
+
+            let laserwriter = if ui.get_laserwriter_enabled() {
+                let name = ui.get_laserwriter_name().to_string();
+                if name.trim().is_empty() {
+                    show_error(ui_weak.clone(), "LaserWriter is enabled but no printer name is set.".to_string());
+                    return;
+                }
+                let output_str = ui.get_laserwriter_output_path().to_string();
+                if output_str.trim().is_empty() {
+                    show_error(ui_weak.clone(), "LaserWriter is enabled but no folder to save jobs is selected.".to_string());
+                    return;
+                }
+                let convert_to_pdf = ui.get_laserwriter_convert_pdf();
+                if convert_to_pdf && !ipp_bridge::gs_probe() {
+                    show_error(
+                        ui_weak.clone(),
+                        ghostscript_missing_message("to auto-convert LaserWriter jobs to PDF"),
+                    );
+                    return;
+                }
+                Some(LaserWriterConfig {
+                    name,
+                    output_path: PathBuf::from(shellexpand::tilde(&output_str).as_ref()),
+                    convert_to_pdf,
+                })
+            } else {
+                None
+            };
+
             save_config(&AppConfig {
                 server_name: Some(ui.get_server_name().to_string()),
                 volume_name: Some(ui.get_volume_name().to_string()),
@@ -425,6 +487,17 @@ fn main() -> anyhow::Result<()> {
                     if s.is_empty() { None } else { Some(s) }
                 },
                 ipp_bridge_enabled: ui.get_ipp_bridge_enabled(),
+                lw_bridge_enabled: ui.get_lw_bridge_enabled(),
+                laserwriter_enabled: ui.get_laserwriter_enabled(),
+                laserwriter_name: {
+                    let s = ui.get_laserwriter_name().to_string();
+                    if s.is_empty() { None } else { Some(s) }
+                },
+                laserwriter_output_path: {
+                    let s = ui.get_laserwriter_output_path().to_string();
+                    if s.is_empty() { None } else { Some(s) }
+                },
+                laserwriter_convert_pdf: ui.get_laserwriter_convert_pdf(),
             });
 
             let pcap_path: Option<PathBuf> = if ui.get_pcap_enabled() {
@@ -447,6 +520,8 @@ fn main() -> anyhow::Result<()> {
                 volume,
                 pcap_path,
                 ipp_bridge_enabled: ui.get_ipp_bridge_enabled(),
+                lw_bridge_enabled: ui.get_lw_bridge_enabled(),
+                laserwriter,
             });
             if send_result.is_err() {
                 tracing::warn!("Server command queue full; ignoring Start");
@@ -489,6 +564,24 @@ fn main() -> anyhow::Result<()> {
                 slint::invoke_from_event_loop(move || {
                     if let Some(ui) = ui_weak.upgrade() {
                         ui.set_pcap_path(path_str);
+                    }
+                })
+                .ok();
+            }
+        });
+    });
+
+    let ui_weak = ui.as_weak();
+    let rt_handle_blw = rt_handle.clone();
+    ui.on_browse_laserwriter_output(move || {
+        let ui_weak = ui_weak.clone();
+        rt_handle_blw.spawn(async move {
+            if let Some(handle) = rfd::AsyncFileDialog::new().pick_folder().await {
+                let path_str: slint::SharedString =
+                    handle.path().to_string_lossy().into_owned().into();
+                slint::invoke_from_event_loop(move || {
+                    if let Some(ui) = ui_weak.upgrade() {
+                        ui.set_laserwriter_output_path(path_str);
                     }
                 })
                 .ok();
@@ -798,6 +891,8 @@ async fn server_loop(
                 volume,
                 pcap_path,
                 ipp_bridge_enabled,
+                lw_bridge_enabled,
+                laserwriter,
             } => {
                 if let Some(h) = shutdown_handle.take() {
                     active.lock().await.take();
@@ -816,6 +911,8 @@ async fn server_loop(
                     volume,
                     pcap_path,
                     ipp_bridge_enabled,
+                    lw_bridge_enabled,
+                    laserwriter,
                     ready_tx,
                     ui_w.clone(),
                 ));
@@ -856,6 +953,16 @@ async fn server_loop(
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn ghostscript_missing_message(context: &str) -> String {
+    #[cfg(target_os = "macos")]
+    let hint = "Please install it via \"brew install ghostscript\".";
+    #[cfg(target_os = "linux")]
+    let hint = "Please install it via \"sudo apt install ghostscript\" or your distro's equivalent.";
+    #[cfg(target_os = "windows")]
+    let hint = "Please install it from https://www.ghostscript.com/releases/gsdnld.html and ensure gswin64c or gs is in your PATH.";
+    format!("Ghostscript is required {context} but was not found.\n{hint}")
+}
 
 fn show_error(ui_weak: slint::Weak<AppWindow>, message: String) {
     slint::invoke_from_event_loop(move || {
@@ -1652,6 +1759,75 @@ async fn extract_hfs_image(img_path: &Path, volume_path: &Path) -> Result<(usize
     Ok((file_count, skipped))
 }
 
+// ── LaserWriter print sink ────────────────────────────────────────────────────
+
+
+/// Saves each job as a numbered file, optionally converting PostScript to PDF
+/// first. Falls back to saving the raw PostScript if conversion fails.
+struct LaserWriterSink {
+    dir: PathBuf,
+    convert_to_pdf: bool,
+    counter: std::sync::atomic::AtomicU32,
+}
+
+impl LaserWriterSink {
+    fn new(dir: impl Into<PathBuf>, convert_to_pdf: bool) -> Self {
+        Self {
+            dir: dir.into(),
+            convert_to_pdf,
+            counter: std::sync::atomic::AtomicU32::new(0),
+        }
+    }
+}
+
+impl tailtalk::pap::PrintSink for LaserWriterSink {
+    fn receive_job(
+        &self,
+        job: tailtalk::pap::PrintJob,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + '_>> {
+        let dir = self.dir.clone();
+        let n = self.counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+        let convert_to_pdf = self.convert_to_pdf;
+        Box::pin(async move {
+            use std::time::{SystemTime, UNIX_EPOCH};
+            let ts = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            tokio::fs::create_dir_all(&dir).await?;
+
+            if convert_to_pdf {
+                match lw_bridge::gs_convert(&job.data, "pdfwrite", &[]).await {
+                    Ok(pdf) => {
+                        let path = dir.join(format!("job_{n:04}_{ts}.pdf"));
+                        tokio::fs::write(&path, &pdf).await?;
+                        tracing::info!(
+                            "LaserWriter: saved job {n} ({} bytes) → {}",
+                            pdf.len(),
+                            path.display()
+                        );
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "LaserWriter: PDF conversion failed for job {n}, saving raw PostScript instead: {e}"
+                        );
+                    }
+                }
+            }
+
+            let path = dir.join(format!("job_{n:04}_{ts}.ps"));
+            tokio::fs::write(&path, &job.data).await?;
+            tracing::info!(
+                "LaserWriter: saved job {n} ({} bytes) → {}",
+                job.data.len(),
+                path.display()
+            );
+            Ok(())
+        })
+    }
+}
+
 // ── AFP server task ───────────────────────────────────────────────────────────
 
 #[allow(clippy::too_many_arguments)]
@@ -1663,6 +1839,8 @@ async fn run_server(
     volume: PathBuf,
     pcap_path: Option<PathBuf>,
     ipp_bridge_enabled: bool,
+    lw_bridge_enabled: bool,
+    laserwriter: Option<LaserWriterConfig>,
     ready_tx: tokio::sync::oneshot::Sender<(ShutdownHandle, ShutdownHandle)>,
     ui_weak: slint::Weak<AppWindow>,
 ) {
@@ -1774,12 +1952,62 @@ async fn run_server(
         return;
     }
 
+    let bridged_names: lw_bridge::BridgedNames = Default::default();
+
     if ipp_bridge_enabled {
         tokio::spawn(ipp_bridge::run(
             stack.nbp.clone(),
             stack.ddp.clone(),
             stack.token(),
+            bridged_names.clone(),
         ));
+    }
+
+    if lw_bridge_enabled {
+        tokio::spawn(lw_bridge::run(
+            stack.nbp.clone(),
+            stack.ddp.clone(),
+            stack.token(),
+            bridged_names.clone(),
+        ));
+    }
+
+    if let Some(cfg) = laserwriter {
+        use tailtalk::pap::{PaperSize, PrinterAttributes};
+
+        let attrs = PrinterAttributes {
+            product_name: cfg.name.clone(),
+            color: true,
+            resolutions_dpi: vec![600],
+            paper_sizes: vec![PaperSize::Letter, PaperSize::A4],
+            ..PrinterAttributes::default()
+        };
+
+        let sink = LaserWriterSink::new(&cfg.output_path, cfg.convert_to_pdf);
+
+        match stack.add_printer(&cfg.name, attrs, sink).await {
+            Ok(mut server) => {
+                tracing::info!(
+                    "LaserWriter emulator advertising \"{}\"; jobs saved to {}",
+                    cfg.name,
+                    cfg.output_path.display()
+                );
+                // Ends when the stack shuts down (the listener socket closes).
+                tokio::spawn(async move {
+                    if let Err(e) = server.run().await {
+                        tracing::warn!("LaserWriter emulator stopped: {e}");
+                    }
+                });
+            }
+            Err(e) => {
+                let msg = format!("Failed to start LaserWriter emulator:\n{e}");
+                tracing::error!("{msg}");
+                show_error(ui_weak.clone(), msg);
+                stack.shutdown_handle().shutdown();
+                set_stopped(ui_weak);
+                return;
+            }
+        }
     }
 
     #[cfg(any(feature = "ethertalk", feature = "tashtalk"))]

--- a/tailtalk-gui/ui/app.slint
+++ b/tailtalk-gui/ui/app.slint
@@ -25,6 +25,11 @@ export component AppWindow inherits Window {
     in-out property <bool> pcap-enabled: false;
     in-out property <string> pcap-path;
     in-out property <bool> ipp-bridge-enabled: false;
+    in-out property <bool> lw-bridge-enabled: false;
+    in-out property <bool> laserwriter-enabled: false;
+    in-out property <string> laserwriter-name: "Color LaserWriter 12/600";
+    in-out property <string> laserwriter-output-path;
+    in-out property <bool> laserwriter-convert-pdf: false;
     in-out property <string> info-message: "";
 
     in-out property <bool> import-progress-visible: false;
@@ -45,6 +50,7 @@ export component AppWindow inherits Window {
     callback start-stop();
     callback browse-volume();
     callback browse-pcap();
+    callback browse-laserwriter-output();
     callback import-files();
     callback inspect-finder-info();
     callback save-finder-info();
@@ -196,6 +202,66 @@ export component AppWindow inherits Window {
                         enabled: !root.running;
                     }
                     Text { text: "Expose printers via IPP (port 8631)"; vertical-alignment: center; }
+                    Rectangle { horizontal-stretch: 1; }
+                }
+
+                HorizontalBox {
+                    padding-top: 0; padding-bottom: 0;
+                    Text { text: "Network Printers"; min-width: 140px; vertical-alignment: center; }
+                    CheckBox {
+                        checked <=> root.lw-bridge-enabled;
+                        enabled: !root.running;
+                    }
+                    Text { text: "Print to modern network printers (requires Ghostscript)"; vertical-alignment: center; }
+                    Rectangle { horizontal-stretch: 1; }
+                }
+
+                HorizontalBox {
+                    padding-top: 0; padding-bottom: 0;
+                    Text { text: "LaserWriter"; min-width: 140px; vertical-alignment: center; }
+                    CheckBox {
+                        checked <=> root.laserwriter-enabled;
+                        enabled: !root.running;
+                    }
+                    Text { text: "Emulate a LaserWriter printer"; vertical-alignment: center; }
+                    Rectangle { horizontal-stretch: 1; }
+                }
+
+                if root.laserwriter-enabled : HorizontalBox {
+                    padding-top: 0; padding-bottom: 0;
+                    Text { text: "Printer Name"; min-width: 140px; vertical-alignment: center; }
+                    LineEdit {
+                        text <=> root.laserwriter-name;
+                        placeholder-text: "Color LaserWriter 12/600";
+                        horizontal-stretch: 1;
+                        enabled: !root.running;
+                    }
+                }
+
+                if root.laserwriter-enabled : HorizontalBox {
+                    padding-top: 0; padding-bottom: 0;
+                    Text { text: "Save Jobs To"; min-width: 140px; vertical-alignment: center; }
+                    LineEdit {
+                        text <=> root.laserwriter-output-path;
+                        placeholder-text: "Path to save print jobs";
+                        horizontal-stretch: 1;
+                        enabled: !root.running;
+                    }
+                    Button {
+                        text: "Browse…";
+                        enabled: !root.running;
+                        clicked => { root.browse-laserwriter-output(); }
+                    }
+                }
+
+                if root.laserwriter-enabled : HorizontalBox {
+                    padding-top: 0; padding-bottom: 0;
+                    Text { text: "Convert to PDF"; min-width: 140px; vertical-alignment: center; }
+                    CheckBox {
+                        checked <=> root.laserwriter-convert-pdf;
+                        enabled: !root.running;
+                    }
+                    Text { text: "Requires Ghostscript"; vertical-alignment: center; }
                     Rectangle { horizontal-stretch: 1; }
                 }
             }

--- a/tailtalk-packets/src/pap.rs
+++ b/tailtalk-packets/src/pap.rs
@@ -47,8 +47,9 @@ impl TryFrom<u8> for PapFunction {
 /// PAP packets are sent over ATP. For Data/SendData the ATP user bytes are:
 /// - Byte 0: Connection ID
 /// - Byte 1: Function code
-/// - Byte 2: EOF flag (Data only; 0 = more data, non-zero = end of job)
-/// - Byte 3: Sequence number (Data and SendData; wraps mod 256)
+/// - Byte 2: EOF flag (Data only; 0 = more data, non-zero = end of job);
+///   high byte of sequence number (SendData only)
+/// - Byte 3: Low byte of sequence number (SendData only; always 0 for Data)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PapPacket {
     pub connection_id: u8,
@@ -77,7 +78,8 @@ impl PapPacket {
         let connection_id = buf[0];
         let function = PapFunction::try_from(buf[1])?;
 
-        // Data and SendData carry a sequence number in byte 3; Data also has an EOF flag in byte 2.
+        // SendData carries a sequence number in bytes 2-3 (big-endian u16).
+        // Data carries the EOF flag in byte 2; byte 3 is unused.
         let (sequence_num, eof, data_start) = match function {
             PapFunction::SendData | PapFunction::Data => {
                 if buf.len() < 4 {
@@ -87,7 +89,12 @@ impl PapPacket {
                     });
                 }
                 let eof = function == PapFunction::Data && buf[2] != 0;
-                (buf[3] as u16, eof, 4)
+                let seq = if function == PapFunction::SendData {
+                    ((buf[2] as u16) << 8) | buf[3] as u16
+                } else {
+                    0
+                };
+                (seq, eof, 4)
             }
             _ => (0, false, 2),
         };
@@ -121,9 +128,15 @@ impl PapPacket {
         buf[1] = self.function as u8;
 
         if has_seq_num {
-            // Byte 2: EOF flag (Data only), byte 3: sequence number (mod 256).
-            buf[2] = if self.function == PapFunction::Data { self.eof as u8 } else { 0 };
-            buf[3] = self.sequence_num as u8;
+            // Data: byte 2 = EOF flag, byte 3 unused (Data has no sequence number).
+            // SendData: bytes 2-3 = sequence number big-endian.
+            if self.function == PapFunction::Data {
+                buf[2] = self.eof as u8;
+                buf[3] = 0;
+            } else {
+                buf[2] = (self.sequence_num >> 8) as u8;
+                buf[3] = self.sequence_num as u8;
+            }
             buf[4..total_len].copy_from_slice(&self.data);
         } else {
             buf[2..total_len].copy_from_slice(&self.data);
@@ -159,12 +172,12 @@ impl PapPacket {
 
         match self.function {
             PapFunction::Data => {
-                // Byte 2: EOF flag, byte 3: sequence number (mod 256).
+                // Byte 2: EOF flag; byte 3 unused (Data has no sequence number).
                 user_bytes[2] = self.eof as u8;
-                user_bytes[3] = self.sequence_num as u8;
             }
             PapFunction::SendData => {
-                // Byte 2: reserved (0), byte 3: sequence number (mod 256).
+                // Bytes 2-3: sequence number big-endian (spec p.10-11).
+                user_bytes[2] = (self.sequence_num >> 8) as u8;
                 user_bytes[3] = self.sequence_num as u8;
             }
             _ => {}
@@ -179,8 +192,8 @@ impl PapPacket {
         let function = PapFunction::try_from(user_bytes[1])?;
 
         let (sequence_num, eof) = match function {
-            PapFunction::Data => (user_bytes[3] as u16, user_bytes[2] != 0),
-            PapFunction::SendData => (user_bytes[3] as u16, false),
+            PapFunction::Data => (0, user_bytes[2] != 0),
+            PapFunction::SendData => (((user_bytes[2] as u16) << 8) | user_bytes[3] as u16, false),
             _ => (0, false),
         };
 
@@ -258,7 +271,7 @@ mod tests {
         assert_eq!(buf[0], 3); // connection_id
         assert_eq!(buf[1], 4); // function code for Data
         assert_eq!(buf[2], 0); // EOF flag (false)
-        assert_eq!(buf[3], 42); // sequence_num
+        assert_eq!(buf[3], 0); // unused (Data has no sequence number)
         assert_eq!(&buf[4..len], b"PostScript data");
     }
 

--- a/tailtalk-proto/proto/tailtalk.proto
+++ b/tailtalk-proto/proto/tailtalk.proto
@@ -85,6 +85,22 @@ message SetAddressRequest {
   AppleTalkAddress address = 2;
 }
 
+// Probe a candidate AppleTalk address on an interface to discover whether
+// another node already defends it: AARP for EtherTalk, an LLAP ENQ for
+// LocalTalk. This performs no assignment; it lets a client that drives its
+// own address selection (e.g. a router) test a candidate before committing
+// it with SetAddressRequest. For LocalTalk the network must be 0.
+message ProbeAddressRequest {
+  string interface = 1;
+  AppleTalkAddress address = 2; // candidate to probe
+}
+
+message ProbeAddressReply {
+  // true if no node answered within the probe window (the address is free to
+  // claim), false if another node is already using it.
+  bool available = 1;
+}
+
 // Enable reception of an Ethernet multicast address on an interface, e.g.
 // the hardware multicast group a zone's NBP lookups are sent to. Only
 // meaningful on EtherTalk; LocalTalk has no hardware multicast, so calling
@@ -210,6 +226,7 @@ message Request {
     SetLocalRangeRequest set_local_range = 12;
     PingRequest ping = 13;
     AddMulticastRequest add_multicast = 14;
+    ProbeAddressRequest probe_address = 15;
   }
 }
 
@@ -238,6 +255,7 @@ message Reply {
     ListInterfacesReply interfaces = 4;
     OpenSocketReply socket = 5;
     ListRoutesReply routes = 6;
+    ProbeAddressReply probe_address = 7;
   }
 }
 

--- a/tailtalk/src/addressing.rs
+++ b/tailtalk/src/addressing.rs
@@ -31,10 +31,16 @@ struct SetAddress {
     chan: oneshot::Sender<()>,
 }
 
+struct ProbeAddress {
+    addr: AppleTalkAddress,
+    chan: oneshot::Sender<bool>,
+}
+
 enum AarpCommand {
     Lookup(AarpRequest),
     OurAddr(SelfAddress),
     SetAddr(SetAddress),
+    Probe(ProbeAddress),
 }
 
 pub struct Addressing {
@@ -254,43 +260,7 @@ impl Addressing {
             tokio::select! {
                 pkt = self.packet_recv.recv() => {
                     if let Some((pkt, source)) = pkt {
-                        match pkt.opcode {
-                            AarpOpcode::Request => {
-                                if pkt.target_protocol.node_number == our_addr.node_number {
-                                    self.send_response(pkt, our_addr, source).await;
-                                }
-                            },
-                            AarpOpcode::Response => {
-                                if let Some(reqs) = self.pending.remove(&pkt.sender_protocol) {
-                                    for req in reqs {
-                                        let inner_req = Arc::<AarpRequest>::into_inner(req).unwrap();
-
-                                        let node = match source {
-                                            AddressSource::EtherTalkPhase2 => {
-                                                Node::EtherTalkPhase2(pkt.sender_addr)
-                                            },
-                                            AddressSource::EtherTalkPhase1 => {
-                                                Node::EtherTalkPhase1(pkt.sender_addr)
-                                            }
-                                            AddressSource::LocalTalk => {
-                                                continue;
-                                            },
-                                        };
-
-                                        if let Err(e) = inner_req.chan.send(Ok(node)) {
-                                            tracing::error!("error responding to AarpRequest: {e:?}");
-                                        }
-                                        self.cache.insert(pkt.sender_protocol, node);
-                                    }
-                                }
-                            },
-                            AarpOpcode::Probe => {
-                                if pkt.target_protocol == our_addr {
-                                    self.send_response(pkt, our_addr, source).await;
-                                    tracing::info!("send response to probe that matched our addr");
-                                }
-                            },
-                        }
+                        self.handle_aarp_packet(pkt, source, our_addr).await;
                     }
                 }
                 req = self.request_recv.recv() => {
@@ -313,6 +283,14 @@ impl Addressing {
                                 our_addr = req.addr;
                                 let _ = self.addr_tx.send(Some(our_addr));
                                 let _ = req.chan.send(());
+                            },
+                            AarpCommand::Probe(req) => {
+                                // A controlling client (e.g. a router that
+                                // drives its own address selection) is testing
+                                // a candidate before overriding our address.
+                                // This does not change our_addr.
+                                let available = self.probe_candidate(req.addr, Some(our_addr)).await;
+                                let _ = req.chan.send(available);
                             },
                         }
                     }
@@ -357,6 +335,116 @@ impl Addressing {
             .send(packet)
             .await
             .expect("failed to dispatch response");
+    }
+
+    /// Probe `candidate` on the wire to discover whether another node is
+    /// already defending it: an AARP probe on EtherTalk, an LLAP ENQ on
+    /// LocalTalk. Returns `true` if nothing answered within the probe window
+    /// (the address is free to claim), `false` if it is in use. Does not
+    async fn handle_aarp_packet(&mut self, pkt: AarpPacket, source: AddressSource, our_addr: AppleTalkAddress) {
+        match pkt.opcode {
+            AarpOpcode::Request => {
+                if pkt.target_protocol.node_number == our_addr.node_number {
+                    self.send_response(pkt, our_addr, source).await;
+                }
+            },
+            AarpOpcode::Response => {
+                if let Some(reqs) = self.pending.remove(&pkt.sender_protocol) {
+                    for req in reqs {
+                        let inner_req = Arc::<AarpRequest>::into_inner(req).unwrap();
+
+                        let node = match source {
+                            AddressSource::EtherTalkPhase2 => {
+                                Node::EtherTalkPhase2(pkt.sender_addr)
+                            },
+                            AddressSource::EtherTalkPhase1 => {
+                                Node::EtherTalkPhase1(pkt.sender_addr)
+                            }
+                            AddressSource::LocalTalk => {
+                                continue;
+                            },
+                        };
+
+                        if let Err(e) = inner_req.chan.send(Ok(node)) {
+                            tracing::error!("error responding to AarpRequest: {e:?}");
+                        }
+                        self.cache.insert(pkt.sender_protocol, node);
+                    }
+                }
+            },
+            AarpOpcode::Probe => {
+                if pkt.target_protocol == our_addr {
+                    self.send_response(pkt, our_addr, source).await;
+                    tracing::info!("send response to probe that matched our addr");
+                }
+            },
+        }
+    }
+
+    /// Probe a candidate address on the network to see if it is in use. Does not
+    /// change our own address.
+    async fn probe_candidate(&mut self, candidate: AppleTalkAddress, our_addr: Option<AppleTalkAddress>) -> bool {
+        if self.our_mac.is_none() {
+            // LocalTalk: send an LLAP ENQ for the node; an ACK from that node
+            // means it is taken.
+            let enq = DataLinkPacket {
+                dest_node: Node::LocalTalk(candidate.node_number),
+                protocol: DataLinkProtocol::LlapEnq,
+                payload: Box::new([]),
+                src_node_id: candidate.node_number,
+            };
+            if self.outbound.send(enq).await.is_err() {
+                return false;
+            }
+
+            let deadline = tokio::time::Instant::now() + Duration::from_millis(10);
+            loop {
+                tokio::select! {
+                    _ = tokio::time::sleep_until(deadline) => return true,
+                    ack = self.lt_ack_recv.recv() => {
+                        if matches!(ack, Some(src) if src == candidate.node_number) {
+                            return false;
+                        }
+                    }
+                    _ = self.cancel.cancelled() => return false,
+                }
+            }
+        } else {
+            // EtherTalk: AARP-probe the candidate. A Response from it, or a
+            // competing Probe for it, means the address is taken.
+            let probe = self.create_packet(
+                candidate,
+                Self::broadcast_mac(self.phase),
+                candidate,
+                AarpOpcode::Probe,
+                self.phase,
+            );
+            if self.outbound.send(probe).await.is_err() {
+                return false;
+            }
+
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+            loop {
+                tokio::select! {
+                    _ = tokio::time::sleep_until(deadline) => return true,
+                    pkt = self.packet_recv.recv() => {
+                        if let Some((pkt, source)) = pkt {
+                            let taken = (pkt.opcode == AarpOpcode::Response
+                                    && pkt.sender_protocol == candidate)
+                                || (pkt.opcode == AarpOpcode::Probe
+                                    && pkt.target_protocol == candidate);
+                            if taken {
+                                return false;
+                            }
+                            if let Some(our_addr) = our_addr {
+                                self.handle_aarp_packet(pkt, source, our_addr).await;
+                            }
+                        }
+                    }
+                    _ = self.cancel.cancelled() => return false,
+                }
+            }
+        }
     }
 }
 
@@ -520,6 +608,29 @@ impl AddressingHandle {
             }
             AddressingInner::Remote { client, interface } => {
                 client.set_interface_addr(interface, addr).await
+            }
+        }
+    }
+
+    /// Probe a candidate address on the wire without claiming it.
+    ///
+    /// Returns `true` if no node is defending it (free to claim), `false` if
+    /// it is already in use. Lets a client that drives its own address
+    /// selection test a candidate before committing it with `set_addr`.
+    pub async fn probe(&self, addr: AppleTalkAddress) -> Result<bool, Error> {
+        match &self.inner {
+            AddressingInner::Local { request_send, .. } => {
+                let (tx, rx) = oneshot::channel();
+                let request = AarpCommand::Probe(ProbeAddress { addr, chan: tx });
+
+                if let Err(e) = request_send.send(request).await {
+                    return Err(Error::other(e));
+                }
+
+                rx.await.map_err(Error::other)
+            }
+            AddressingInner::Remote { client, interface } => {
+                client.probe_address(interface, addr).await
             }
         }
     }

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -758,6 +758,52 @@ impl TalkStack {
         let (_, atp_requestor, _) = atp::Atp::spawn(&self.ddp, None).await;
         pap::PapClient::get_status(atp_requestor, address).await
     }
+
+    /// Create a PAP printer emulator.
+    ///
+    /// Allocates an ATP socket and returns a [`pap::PapServer`].  The socket
+    /// number is available as `server.socket_number`; register it with NBP
+    /// manually, or use [`add_printer`](TalkStack::add_printer) which does both
+    /// in one call.
+    pub async fn pap_server(
+        &self,
+        attributes: pap::PrinterAttributes,
+        sink: impl pap::PrintSink + 'static,
+    ) -> pap::PapServer {
+        let (socket_num, _requestor, responder) = atp::Atp::spawn(&self.ddp, None).await;
+        pap::PapServer::new(responder, self.ddp.clone(), socket_num, attributes, Box::new(sink))
+    }
+
+    /// Create a PAP printer emulator and register it with NBP as `{name}:LaserWriter@*`.
+    ///
+    /// This is the high-level convenience wrapper: it allocates an ATP socket,
+    /// constructs the [`pap::PapServer`], and registers the NBP name so the Mac
+    /// Chooser can discover the printer.  Call [`pap::PapServer::run`] (or loop
+    /// on [`pap::PapServer::accept`]) to start serving connections.
+    pub async fn add_printer(
+        &self,
+        name: &str,
+        attributes: pap::PrinterAttributes,
+        sink: impl pap::PrintSink + 'static,
+    ) -> anyhow::Result<pap::PapServer> {
+        let server = self.pap_server(attributes, sink).await;
+
+        let entity_str = format!("{}:LaserWriter@*", name);
+        let entity: tailtalk_packets::nbp::EntityName = entity_str
+            .as_str()
+            .try_into()
+            .map_err(|e| anyhow::anyhow!("Invalid printer name: {}", e))?;
+
+        self.nbp
+            .register(nbp::RegisteredName {
+                name: entity,
+                sock_num: server.socket_number,
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("NBP registration failed: {}", e))?;
+
+        Ok(server)
+    }
 }
 
 /// The lower half of the stack: interfaces, addressing (AARP/LLAP), DDP and

--- a/tailtalk/src/nbp.rs
+++ b/tailtalk/src/nbp.rs
@@ -19,6 +19,11 @@ struct NbpRegisterRequest {
     chan: oneshot::Sender<Result<(), io::Error>>,
 }
 
+struct NbpUnregisterRequest {
+    request: RegisteredName,
+    chan: oneshot::Sender<Result<(), io::Error>>,
+}
+
 struct NbpLookupRequest {
     request: EntityName,
     chan: oneshot::Sender<Result<Vec<NbpTuple>, io::Error>>,
@@ -26,10 +31,11 @@ struct NbpLookupRequest {
 
 enum NbpCommand {
     Register(NbpRegisterRequest),
+    Unregister(NbpUnregisterRequest),
     Lookup(NbpLookupRequest),
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct RegisteredName {
     pub name: EntityName,
     pub sock_num: u8,
@@ -106,6 +112,9 @@ impl Nbp {
                         match command {
                             NbpCommand::Register(register) => {
                                 self.handle_register_req(register);
+                            },
+                            NbpCommand::Unregister(unregister) => {
+                                self.handle_unregister_req(unregister);
                             },
                             NbpCommand::Lookup(lookup) => {
                                 let tid = self.next_tid;
@@ -223,6 +232,24 @@ impl Nbp {
             req.request.sock_num
         );
         self.registered_names.push(req.request);
+    }
+
+    fn handle_unregister_req(&mut self, req: NbpUnregisterRequest) {
+        let before = self.registered_names.len();
+        self.registered_names.retain(|n| n != &req.request);
+        if self.registered_names.len() < before {
+            tracing::info!(
+                "unregistered NBP: {} sock num {}",
+                req.request.name,
+                req.request.sock_num
+            );
+            let _ = req.chan.send(Ok(()));
+        } else {
+            let _ = req.chan.send(Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "entity name and sock num not registered",
+            )));
+        }
     }
 
     async fn handle_packet(&mut self, ddp: DdpPacket, payload: &mut [u8]) {
@@ -350,6 +377,20 @@ impl NbpHandle {
         let (tx, rx) = oneshot::channel();
 
         let request = NbpCommand::Register(NbpRegisterRequest { request, chan: tx });
+
+        self.request_send
+            .send(request)
+            .await
+            .map_err(io::Error::other)?;
+
+        rx.await.map_err(io::Error::other)?
+    }
+
+    /// Remove a previously registered name so lookups no longer match it.
+    pub async fn unregister(&self, request: RegisteredName) -> Result<(), io::Error> {
+        let (tx, rx) = oneshot::channel();
+
+        let request = NbpCommand::Unregister(NbpUnregisterRequest { request, chan: tx });
 
         self.request_send
             .send(request)

--- a/tailtalk/src/pap.rs
+++ b/tailtalk/src/pap.rs
@@ -1,5 +1,9 @@
-use crate::atp::{AtpAddress, AtpRequestor, AtpResponder};
+use crate::atp::{Atp, AtpAddress, AtpRequestor, AtpResponder};
+use crate::ddp::DdpHandle;
 use anyhow::{Result, anyhow};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
 use tailtalk_packets::pap::{PapFunction, PapPacket};
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::time::{Duration, interval};
@@ -18,6 +22,9 @@ pub struct PapClient {
     remote_addr: AtpAddress,
     /// The printer's connection socket from OpenConnReply — used for all post-connect traffic.
     server_addr: AtpAddress,
+    /// Next SendData (read) sequence number. Continues across jobs for the
+    /// connection's lifetime — restarting it makes papd-style servers see stale retransmits.
+    read_seq: u16,
     /// Override the read buffer size per SendData cycle. When `None`, capacity is
     /// `bitmap_count × PAP_MAX_DATA_PER_PACKET` derived from the printer's per-request bitmap.
     pub chunk_size: Option<usize>,
@@ -40,6 +47,7 @@ impl PapClient {
                 node_number: 0,
                 socket_number: 0,
             },
+            read_seq: 1,
             chunk_size: None,
         }
     }
@@ -99,6 +107,7 @@ impl PapClient {
                 node_number: address.node_number,
                 socket_number: server_socket,
             };
+            self.read_seq = 1;
 
             tracing::info!("PAP connected! ID={}, Quantum={}", self.connection_id, self.flow_quantum);
             return Ok(());
@@ -120,6 +129,8 @@ impl PapClient {
         let mut eof_sent = false;
         // Skip the 30-s Tickle wait after EOF; return on the next printer SendData or a short deadline.
         let mut eof_deadline: Option<tokio::time::Instant> = None;
+        // Retransmit of the same seq must get the identical reply, not fresh source bytes.
+        let mut last_reply: Option<(u16, [u8; 4], Vec<u8>)> = None;
 
         loop {
             tokio::select! {
@@ -140,6 +151,17 @@ impl PapClient {
                     match pap_req.function {
                         PapFunction::SendData => {
                             let seq_num = pap_req.sequence_num;
+
+                            if seq_num != 0 {
+                                if let Some((seq, ub, chunk)) = &last_reply {
+                                    if *seq == seq_num {
+                                        let _ = req
+                                            .send_response_chunked(chunk.clone(), *ub, PAP_MAX_DATA_PER_PACKET)
+                                            .await;
+                                        continue;
+                                    }
+                                }
+                            }
 
                             let max_packets = if req.bitmap == 0x00 { 8 } else { req.bitmap.count_ones() as usize }.clamp(1, 8);
                             let capacity = self.chunk_size.unwrap_or(max_packets * PAP_MAX_DATA_PER_PACKET);
@@ -166,6 +188,9 @@ impl PapClient {
                             };
                             let (user_bytes, chunk_data) = pap_resp.to_atp_parts();
                             req.send_response_chunked(chunk_data.to_vec(), user_bytes, PAP_MAX_DATA_PER_PACKET).await?;
+                            if seq_num != 0 {
+                                last_reply = Some((seq_num, user_bytes, chunk_data.to_vec()));
+                            }
 
                             if eof && !eof_sent {
                                 tracing::info!("PAP: EOF sent");
@@ -233,13 +258,12 @@ impl PapClient {
     /// Pull the printer's PS stdout by issuing SendData requests until the printer sends EOF.
     pub async fn read_response(&mut self) -> Result<Vec<u8>> {
         let mut response = Vec::new();
-        let mut seq: u8 = 1;
 
         loop {
             let pkt = PapPacket {
                 connection_id: self.connection_id,
                 function: PapFunction::SendData,
-                sequence_num: seq as u16,
+                sequence_num: self.read_seq,
                 eof: false,
                 data: vec![],
             };
@@ -253,11 +277,13 @@ impl PapClient {
                 return Err(anyhow!("Expected PAP Data response, got {:?}", data_pkt.function));
             }
 
+            // Spec: sequence numbers run 1–65535 then wrap back to 1; 0 is reserved (unsequenced).
+            self.read_seq = if self.read_seq == 65535 { 1 } else { self.read_seq + 1 };
+
             response.extend_from_slice(&data_pkt.data);
             if data_pkt.eof {
                 break;
             }
-            seq = seq.wrapping_add(1);
         }
 
         Ok(response)
@@ -292,10 +318,705 @@ impl PapClient {
 
         let reply = PapPacket::parse_from_atp(resp_ub, &resp_data)?;
 
-        if reply.data.len() > 4 {
-            Ok(String::from_utf8_lossy(&reply.data[4..]).to_string())
+        // Status reply: 4 unused bytes, then a pascal string (length byte then content).
+        if reply.data.len() > 5 {
+            let len = reply.data[4] as usize;
+            let end = (5 + len).min(reply.data.len());
+            Ok(String::from_utf8_lossy(&reply.data[5..end]).to_string())
         } else {
             Ok("".to_string())
         }
     }
+}
+
+// ── PAP server (printer emulator) ────────────────────────────────────────────
+
+/// Paper size supported by the printer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PaperSize {
+    Letter,
+    A4,
+    Legal,
+    A3,
+    B5,
+    Executive,
+}
+
+impl PaperSize {
+    pub fn ppd_name(&self) -> &'static str {
+        match self {
+            Self::Letter => "Letter",
+            Self::A4 => "A4",
+            Self::Legal => "Legal",
+            Self::A3 => "A3",
+            Self::B5 => "B5",
+            Self::Executive => "Executive",
+        }
+    }
+}
+
+/// Printer capability attributes used to answer PQP queries and for IPP translation.
+///
+/// Set at construction via [`PapServer::new`] or [`TalkStack::add_printer`], and
+/// updateable at runtime via [`PapServer::update_attributes`].
+#[derive(Debug, Clone)]
+pub struct PrinterAttributes {
+    /// PAP status string returned to clients before a connection is opened.
+    /// Should be a PS status comment, e.g. `%%[ status: idle; source: EtherTalk ]%%`.
+    pub status: String,
+    /// Product name returned to the Mac driver's `*Product` PQP query.
+    /// Should match the name advertised in NBP, e.g. `"Color LaserWriter 12/600"`.
+    pub product_name: String,
+    /// PostScript language level (1 or 2). Returned for `*LanguageLevel` queries.
+    pub language_level: u8,
+    /// Whether the printer supports color output.
+    pub color: bool,
+    /// Supported output resolutions in DPI (e.g. `vec![600]`).
+    pub resolutions_dpi: Vec<u32>,
+    /// Supported paper sizes.
+    pub paper_sizes: Vec<PaperSize>,
+}
+
+impl Default for PrinterAttributes {
+    fn default() -> Self {
+        Self {
+            status: "%%[ status: idle; source: EtherTalk ]%%".to_string(),
+            product_name: "TailTalk LaserWriter".to_string(),
+            language_level: 2,
+            color: false,
+            resolutions_dpi: vec![300],
+            paper_sizes: vec![PaperSize::Letter],
+        }
+    }
+}
+
+/// A received print job ready for processing by a [`PrintSink`].
+pub struct PrintJob {
+    /// Source AppleTalk address (network/node of the client).
+    pub client_addr: AtpAddress,
+    /// Raw PostScript data received from the client.
+    pub data: Vec<u8>,
+}
+
+/// A sink that consumes incoming print jobs.
+///
+/// Implement this trait to define what happens with received jobs:
+/// saving to disk, forwarding to an IPP printer, format conversion, etc.
+///
+/// Implementations must be `Send + Sync` so the [`PapServer`] can hold them
+/// across async awaits.
+pub trait PrintSink: Send + Sync {
+    fn receive_job(&self, job: PrintJob) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + '_>>;
+}
+
+/// A [`PrintSink`] that saves each job as a numbered `.ps` file in a directory.
+///
+/// Files are named `job_{N:04}_{unix_timestamp}.ps`.
+pub struct FileSink {
+    dir: std::path::PathBuf,
+    counter: std::sync::atomic::AtomicU32,
+}
+
+impl FileSink {
+    pub fn new(dir: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            dir: dir.into(),
+            counter: std::sync::atomic::AtomicU32::new(0),
+        }
+    }
+}
+
+impl PrintSink for FileSink {
+    fn receive_job(&self, job: PrintJob) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + '_>> {
+        let dir = self.dir.clone();
+        let n = self.counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+        Box::pin(async move {
+            use std::time::{SystemTime, UNIX_EPOCH};
+            let ts = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let path = dir.join(format!("job_{n:04}_{ts}.ps"));
+            tokio::fs::create_dir_all(&dir).await?;
+            tokio::fs::write(&path, &job.data).await?;
+            tracing::info!(
+                "PAP: saved job {} ({} bytes) → {}",
+                n,
+                job.data.len(),
+                path.display()
+            );
+            Ok(())
+        })
+    }
+}
+
+/// A PAP printer emulator.
+///
+/// Accepts incoming PAP connections, handles PQP capability queries automatically
+/// using the configured [`PrinterAttributes`], and forwards real print jobs to
+/// the configured [`PrintSink`].
+///
+/// Create via [`TalkStack::add_printer`] (handles NBP registration) or directly
+/// with [`PapServer::new`] for manual control.
+pub struct PapServer {
+    responder: AtpResponder,
+    ddp: DdpHandle,
+    /// The socket number to advertise in NBP.
+    pub socket_number: u8,
+    attributes: Arc<tokio::sync::RwLock<PrinterAttributes>>,
+    sink: Box<dyn PrintSink + Send + Sync>,
+}
+
+impl PapServer {
+    pub fn new(
+        responder: AtpResponder,
+        ddp: DdpHandle,
+        socket_number: u8,
+        attributes: PrinterAttributes,
+        sink: Box<dyn PrintSink + Send + Sync>,
+    ) -> Self {
+        Self {
+            responder,
+            ddp,
+            socket_number,
+            attributes: Arc::new(tokio::sync::RwLock::new(attributes)),
+            sink,
+        }
+    }
+
+    /// Replace the current printer attributes.
+    pub async fn update_attributes(&self, attrs: PrinterAttributes) {
+        *self.attributes.write().await = attrs;
+    }
+
+    /// Return a cloned handle to the attributes lock for updating from another task.
+    pub fn attributes_handle(&self) -> Arc<tokio::sync::RwLock<PrinterAttributes>> {
+        self.attributes.clone()
+    }
+
+    fn make_status_payload(status: &str) -> Vec<u8> {
+        let bytes = status.as_bytes();
+        let len = bytes.len().min(255) as u8;
+        let mut out = vec![0u8, 0u8, 0u8, 0u8, len];
+        out.extend_from_slice(&bytes[..len as usize]);
+        out
+    }
+
+    /// Build the status payload; with `busy`, rewrites `status: idle` to `status: busy`
+    /// so the client's print monitor reflects an active session.
+    async fn status_payload(&self, busy: bool) -> Vec<u8> {
+        let attrs = self.attributes.read().await;
+        if busy {
+            Self::make_status_payload(&attrs.status.replace("status: idle", "status: busy"))
+        } else {
+            Self::make_status_payload(&attrs.status)
+        }
+    }
+
+    /// Accept one incoming PAP connection.
+    ///
+    /// PQP capability queries (e.g. `RBIUAMListQuery`) are detected and answered
+    /// automatically from the current [`PrinterAttributes`].  Real print jobs are
+    /// forwarded to the [`PrintSink`]; PQP probes are silently discarded.
+    pub async fn accept(&mut self) -> anyhow::Result<()> {
+        // ── Phase 1: wait for OpenConn, answer status queries in the meantime ──
+        let (open_req, client_data_addr, conn_id) = loop {
+            let req = self
+                .responder
+                .next()
+                .await
+                .ok_or_else(|| anyhow!("PAP listener socket closed"))?;
+
+            let pap = match PapPacket::parse_from_atp(req.user_bytes, &req.data) {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!("PAP: ignoring malformed packet on listener socket: {e}");
+                    continue;
+                }
+            };
+
+            match pap.function {
+                PapFunction::SendStatus => {
+                    let status_payload = self.status_payload(false).await;
+                    let reply = PapPacket {
+                        connection_id: 0,
+                        function: PapFunction::Status,
+                        sequence_num: 0,
+                        eof: false,
+                        data: status_payload,
+                    };
+                    let (ub, d) = reply.to_atp_parts();
+                    let _ = req.send_response(d.to_vec(), ub).await;
+                }
+                PapFunction::OpenConn => {
+                    if pap.data.len() < 2 {
+                        tracing::warn!("PAP: OpenConn payload too short, ignoring");
+                        continue;
+                    }
+                    let client_socket = pap.data[0];
+                    // Spec: server echoes the client's ConnID in OpenConnReply.
+                    let conn_id = pap.connection_id;
+                    let addr = AtpAddress {
+                        network_number: req.source.network_number,
+                        node_number: req.source.node_number,
+                        socket_number: client_socket,
+                    };
+                    break (req, addr, conn_id);
+                }
+                _ => {}
+            }
+        };
+
+        // ── Phase 2: allocate per-connection socket, send OpenConnReply ────────
+        let (conn_socket_num, conn_requestor, mut conn_responder) =
+            Atp::spawn(&self.ddp, None).await;
+
+        tracing::info!(
+            "PAP: OpenConn from {:?}, conn_id={}, conn_socket={}",
+            client_data_addr,
+            conn_id,
+            conn_socket_num
+        );
+
+        let reply_data = {
+            let attrs = self.attributes.read().await;
+            let sp = Self::make_status_payload(&attrs.status);
+            let mut d = vec![conn_socket_num, 8, 0, 0];
+            d.extend_from_slice(&sp[4..]);
+            d
+        };
+        let reply = PapPacket {
+            connection_id: conn_id,
+            function: PapFunction::OpenConnReply,
+            sequence_num: 0,
+            eof: false,
+            data: reply_data,
+        };
+        let (ub, d) = reply.to_atp_parts();
+        if let Err(e) = open_req.send_response(d.to_vec(), ub).await {
+            tracing::warn!("PAP: failed to send OpenConnReply: {e}");
+            return Ok(());
+        }
+
+        // ── Phase 3: papd-style session loop ───────────────────────────────────
+        // A connection carries a sequence of jobs (each PQP query is its own job,
+        // followed by the real print job) — keep one SendData pull outstanding at
+        // all times, and never close the connection ourselves: a server-initiated
+        // CloseConn makes the driver abort its query session and restart discovery.
+        let make_pull = |seq: u16| {
+            let requestor = conn_requestor.clone();
+            async move {
+                let send_data = PapPacket {
+                    connection_id: conn_id,
+                    function: PapFunction::SendData,
+                    sequence_num: seq,
+                    eof: false,
+                    data: vec![],
+                };
+                let (ub, d) = send_data.to_atp_parts();
+                requestor.send_request(client_data_addr, ub, d.to_vec()).await
+            }
+        };
+
+        // Spec: sequence numbers run 1–65535 then wrap to 1; 0 is reserved (unsequenced).
+        let mut seq: u16 = 1;
+        let mut pull = Box::pin(make_pull(seq));
+
+        let mut job_data: Vec<u8> = Vec::new();
+        // Printer stdout queued for the client's reads: the query answer, or empty for a print job.
+        let mut stdout: Vec<u8> = Vec::new();
+        let mut stdout_pos: usize = 0;
+        let mut response_ready = false;
+        // A client read waiting for job output, with its sequence number.
+        let mut pending_read: Option<(crate::atp::AtpReceivedRequest, u16)> = None;
+        // Next expected client read sequence number, for spotting retransmits.
+        let mut read_seq: u16 = 1;
+        // Re-sent verbatim if the client retransmits this read (reply lost on the wire).
+        let mut last_read_reply: Option<(u16, [u8; 4], Vec<u8>)> = None;
+
+        let mut last_activity = tokio::time::Instant::now();
+        let mut tickle_interval = interval(Duration::from_secs(30));
+        tickle_interval.tick().await; // skip immediate tick
+
+        loop {
+            tokio::select! {
+                res = &mut pull => {
+                    match res {
+                        Ok((resp_data, resp_ub)) => {
+                            last_activity = tokio::time::Instant::now();
+
+                            let data_pkt = match PapPacket::parse_from_atp(resp_ub, &resp_data) {
+                                Ok(p) => p,
+                                Err(e) => {
+                                    tracing::warn!("PAP: malformed Data response, dropping connection: {e}");
+                                    return Ok(());
+                                }
+                            };
+                            if data_pkt.function != PapFunction::Data {
+                                tracing::warn!("PAP: expected Data, got {:?}; dropping connection", data_pkt.function);
+                                return Ok(());
+                            }
+
+                            tracing::debug!(
+                                "PAP: received Data len={} eof={}",
+                                data_pkt.data.len(),
+                                data_pkt.eof
+                            );
+                            job_data.extend_from_slice(&data_pkt.data);
+
+                            if data_pkt.eof && job_data.is_empty() {
+                                // A zero-byte job (PapClient's post-EOF drain sends one)
+                                // would otherwise clobber a still-unread query answer.
+                                tracing::debug!("PAP: ignoring empty job");
+                            } else if data_pkt.eof {
+                                let job = std::mem::take(&mut job_data);
+                                let is_pqp = job.starts_with(b"%!PS-Adobe-3.0 Query");
+                                if is_pqp {
+                                    let attrs = self.attributes.read().await;
+                                    stdout = pqp_stdout(&attrs, &job);
+                                    tracing::info!(
+                                        "PAP: PQP query from {:?}, answering with {} bytes",
+                                        client_data_addr,
+                                        stdout.len()
+                                    );
+                                } else {
+                                    stdout = Vec::new();
+                                    tracing::info!("PAP: job complete, {} bytes received", job.len());
+                                    if let Err(e) = self
+                                        .sink
+                                        .receive_job(PrintJob {
+                                            client_addr: client_data_addr,
+                                            data: job,
+                                        })
+                                        .await
+                                    {
+                                        tracing::error!("PAP: sink error: {e}");
+                                    }
+                                }
+                                stdout_pos = 0;
+                                response_ready = true;
+                            }
+
+                            seq = if seq == 65535 { 1 } else { seq + 1 };
+                            pull = Box::pin(make_pull(seq));
+                        }
+                        Err(_) => {
+                            // A timeout usually just means the client is idle (composing
+                            // its next query); re-issue the same read, like papd's
+                            // infinite-retry PAP_READ.
+                            if last_activity.elapsed() > Duration::from_secs(120) {
+                                tracing::warn!("PAP: connection timed out after 120s of inactivity");
+                                return Ok(());
+                            }
+                            pull = Box::pin(make_pull(seq));
+                        }
+                    }
+                }
+
+                maybe_req = conn_responder.next() => {
+                    let Some(req) = maybe_req else {
+                        tracing::warn!("PAP: connection socket closed");
+                        return Ok(());
+                    };
+                    let Ok(pap) = PapPacket::parse_from_atp(req.user_bytes, &req.data) else {
+                        continue;
+                    };
+                    if pap.connection_id != conn_id {
+                        tracing::warn!("PAP: ignoring packet with mismatched conn ID {}", pap.connection_id);
+                        continue;
+                    }
+                    last_activity = tokio::time::Instant::now();
+
+                    match pap.function {
+                        PapFunction::SendData => {
+                            // A retransmit of an already-answered read means our reply
+                            // was lost; anything else out of sequence is stale (papd's rseq check).
+                            if pap.sequence_num != 0 && pap.sequence_num != read_seq {
+                                match &last_read_reply {
+                                    Some((seq, ub, chunk)) if *seq == pap.sequence_num => {
+                                        let _ = req
+                                            .send_response_chunked(chunk.clone(), *ub, PAP_MAX_DATA_PER_PACKET)
+                                            .await;
+                                    }
+                                    _ => {
+                                        tracing::debug!("PAP: ignoring stale client read seq={}", pap.sequence_num);
+                                    }
+                                }
+                            } else {
+                                let this_seq = pap.sequence_num;
+                                pending_read = Some((req, this_seq));
+                            }
+                        }
+                        PapFunction::Tickle => {
+                            tracing::debug!("PAP: received Tickle from client");
+                        }
+                        PapFunction::CloseConn => {
+                            let reply = PapPacket {
+                                connection_id: conn_id,
+                                function: PapFunction::CloseConnReply,
+                                sequence_num: 0,
+                                eof: false,
+                                data: vec![],
+                            };
+                            let (ub, d) = reply.to_atp_parts();
+                            let _ = req.send_response(d.to_vec(), ub).await;
+                            if !job_data.is_empty() {
+                                tracing::warn!(
+                                    "PAP: client closed mid-job, discarding {} partial bytes",
+                                    job_data.len()
+                                );
+                            }
+                            tracing::info!("PAP: connection closed by client");
+                            return Ok(());
+                        }
+                        _ => {}
+                    }
+                }
+
+                // The Mac polls SendStatus on the listener every ~500 ms while printing;
+                // must keep draining it during a session or its ATP queue fills and every
+                // request gets dropped (papd's parent answers status while a child prints).
+                listener_req = self.responder.next() => {
+                    let Some(req) = listener_req else {
+                        return Err(anyhow!("PAP listener socket closed"));
+                    };
+                    let Ok(pap) = PapPacket::parse_from_atp(req.user_bytes, &req.data) else {
+                        continue;
+                    };
+                    match pap.function {
+                        PapFunction::SendStatus => {
+                            let status_payload = self.status_payload(true).await;
+                            let reply = PapPacket {
+                                connection_id: 0,
+                                function: PapFunction::Status,
+                                sequence_num: 0,
+                                eof: false,
+                                data: status_payload,
+                            };
+                            let (ub, d) = reply.to_atp_parts();
+                            let _ = req.send_response(d.to_vec(), ub).await;
+                        }
+                        PapFunction::OpenConn => {
+                            // Single-session server: refuse with a busy result; the driver retries every 2s.
+                            let sp = self.status_payload(true).await;
+                            let mut reply_data = vec![0, 8, 0xFF, 0xFF];
+                            reply_data.extend_from_slice(&sp[4..]);
+                            let reply = PapPacket {
+                                connection_id: pap.connection_id,
+                                function: PapFunction::OpenConnReply,
+                                sequence_num: 0,
+                                eof: false,
+                                data: reply_data,
+                            };
+                            let (ub, d) = reply.to_atp_parts();
+                            let _ = req.send_response(d.to_vec(), ub).await;
+                        }
+                        _ => {}
+                    }
+                }
+
+                _ = tickle_interval.tick() => {
+                    if last_activity.elapsed() > Duration::from_secs(120) {
+                        tracing::warn!("PAP: connection timed out after 120s of inactivity");
+                        return Ok(());
+                    }
+                    let tickle = PapPacket {
+                        connection_id: conn_id,
+                        function: PapFunction::Tickle,
+                        sequence_num: 0,
+                        eof: false,
+                        data: vec![],
+                    };
+                    let (tub, _) = tickle.to_atp_parts();
+                    let _ = conn_requestor.send_alo(client_data_addr, tub).await;
+                }
+            }
+
+            // Answer a waiting client read once this job's output is ready; eof on the
+            // final chunk tells the driver we're done, then we reset for the next job.
+            if response_ready && pending_read.is_some() {
+                let (req, this_seq) = pending_read.take().unwrap();
+                let max_packets =
+                    if req.bitmap == 0x00 { 8 } else { req.bitmap.count_ones() as usize }.clamp(1, 8);
+                let remaining = stdout.len().saturating_sub(stdout_pos);
+                let take = remaining.min(max_packets * PAP_MAX_DATA_PER_PACKET);
+                let chunk = stdout[stdout_pos..stdout_pos + take].to_vec();
+                let eof = stdout_pos + take >= stdout.len();
+                stdout_pos += take;
+                let reply = PapPacket {
+                    connection_id: conn_id,
+                    function: PapFunction::Data,
+                    sequence_num: 0,
+                    eof,
+                    data: chunk,
+                };
+                let (ub, d) = reply.to_atp_parts();
+                let _ = req
+                    .send_response_chunked(d.to_vec(), ub, PAP_MAX_DATA_PER_PACKET)
+                    .await;
+                if this_seq != 0 {
+                    read_seq = if read_seq == 65535 { 1 } else { read_seq + 1 };
+                    last_read_reply = Some((this_seq, ub, d.to_vec()));
+                }
+                if eof {
+                    // This job's output is fully served; ready for the next job.
+                    response_ready = false;
+                    stdout = Vec::new();
+                    stdout_pos = 0;
+                }
+            }
+        }
+    }
+
+    /// Run forever, accepting connections in sequence.
+    ///
+    /// Returns only if the listener socket closes or a fatal protocol error occurs.
+    /// Per-connection errors (timeouts, malformed packets) are logged and skipped.
+    pub async fn run(&mut self) -> anyhow::Result<()> {
+        loop {
+            if let Err(e) = self.accept().await {
+                tracing::error!("PAP: {e}");
+                return Err(e);
+            }
+        }
+    }
+}
+
+// ── PQP helpers ───────────────────────────────────────────────────────────────
+
+/// Build the printer stdout payload for a PQP query job.
+///
+/// Handles three DSC comment forms, any number of blocks per job:
+/// - `%%?BeginFeatureQuery:` / `%%?EndFeatureQuery:` — PPD feature lookups (`*LanguageLevel`, etc.)
+/// - `%%?BeginQuery:` / `%%?EndQuery:` — general/vendor queries (`ADOSpooler`, `RBIUAMListQuery`, etc.)
+/// - `%%?BeginFontQuery:` / `%%?EndFontQuery:` — font availability queries
+///
+/// Each block's answer is emitted followed by `\r`; no end-of-output marker —
+/// the driver detects completion via the PAP eof flag, like papd.
+fn pqp_stdout(attrs: &PrinterAttributes, job_data: &[u8]) -> Vec<u8> {
+    let text = std::str::from_utf8(job_data).unwrap_or("");
+
+    enum Block {
+        Query(String),
+        Font(String),
+    }
+
+    let mut out = String::new();
+    let mut current: Option<Block> = None;
+
+    for line in text.split(['\r', '\n']) {
+        if let Some(rest) = line
+            .strip_prefix("%%?BeginFeatureQuery:")
+            .or_else(|| line.strip_prefix("%%?BeginQuery:"))
+        {
+            // The Mac driver sometimes appends inline PS code on the same line:
+            //   "RBIUAMListQuery(*)= flush"  →  we want just "RBIUAMListQuery"
+            // Strip everything from the first `(` or whitespace onward.
+            let rest = rest.trim();
+            let name = rest.split(['(', ' ', '\t']).next().unwrap_or(rest);
+            current = Some(Block::Query(name.to_string()));
+        } else if let Some(rest) = line.strip_prefix("%%?BeginFontQuery:") {
+            current = Some(Block::Font(rest.trim().to_string()));
+        } else if let Some(rest) = line
+            .strip_prefix("%%?EndFeatureQuery")
+            .or_else(|| line.strip_prefix("%%?EndFontQuery"))
+            .or_else(|| line.strip_prefix("%%?EndQuery"))
+        {
+            // The End comment carries the driver's fallback answer: "%%?EndQuery: *"
+            let default_val = rest.trim_start_matches(':').trim();
+            let answer = match current.take() {
+                Some(Block::Font(fonts)) => pqp_font_answer(&fonts),
+                Some(Block::Query(name)) => pqp_answer(attrs, &name, default_val),
+                None => default_val.to_string(),
+            };
+            out.push_str(&answer);
+            out.push('\r');
+        }
+    }
+
+    out.into_bytes()
+}
+
+/// Return the answer to a named PQP query, falling back to `default` for
+/// unrecognised queries.
+fn pqp_answer(attrs: &PrinterAttributes, query: &str, default: &str) -> String {
+    match query {
+        // ── RBI spooler queries (%%?BeginQuery:, Netatalk extension) ─────────
+
+        // UAM (user authentication method) list for print authentication.
+        // We do no authentication, so answer "*" (no UAMs) exactly like papd —
+        // answering anything else makes the LaserWriter driver believe a login
+        // is required and abort the query session.
+        "RBIUAMListQuery" => "*".to_string(),
+
+        // Spooler identification string, papd-style "(name) version" format.
+        "RBISpoolerID" => "(TailTalk Spooler) 1.0".to_string(),
+
+        // ── Standard PPD feature queries (%%?BeginFeatureQuery:) ─────────────
+
+        // PostScript language level: "1" or "2".
+        "*LanguageLevel" => attrs.language_level.to_string(),
+
+        // PS interpreter version: "(versnum) revnum" format.
+        // We emulate a LaserWriter running PS 2010 (a common PS Level 2 build).
+        "*PSVersion" => "(2010.020) 0".to_string(),
+
+        // Product name in PS string literal form: "(name)".
+        "*Product" => format!("({})", attrs.product_name),
+
+        // Current resolution; same source as RBResolution but different query key.
+        "*?Resolution" => attrs
+            .resolutions_dpi
+            .first()
+            .map(|dpi| format!("{dpi}dpi"))
+            .unwrap_or_else(|| default.to_string()),
+
+        // Color capability.
+        "*ColorDevice" => {
+            if attrs.color { "True".to_string() } else { "False".to_string() }
+        }
+
+        // Free PostScript VM in bytes. We report a plausible amount.
+        "*FreeVM" => "4194304".to_string(),
+
+        // TrueType rasterizer: Type42 means built-in TrueType support.
+        // Returning Type42 lets the Mac driver use TrueType fonts directly.
+        "*TTRasterizer" => "Type42".to_string(),
+
+        // PostScript fax support: we're a print spooler, not a fax machine.
+        "*FaxSupport" => "None".to_string(),
+
+        // ── ADO general queries (%%?BeginQuery:) ─────────────────────────────
+
+        // Identify ourselves as a spooler so the Mac driver adheres to DSC.
+        "ADOSpooler" => "spooler".to_string(),
+
+        // Installed RAM: we don't track this, Unknown is a safe fallback.
+        "ADORamSize" => "Unknown".to_string(),
+
+        // Binary comms: AppleTalk supports binary transmission.
+        "ADOIsBinaryOK?" => "True".to_string(),
+
+        _ => default.to_string(),
+    }
+}
+
+/// Return the answer to a font availability query.
+///
+/// The query lists font names (space-separated) in the `%%?BeginFontQuery:` line.
+/// Since we're a spooler without a PS interpreter, we report all fonts as unavailable,
+/// which causes the Mac driver to embed fonts in the print job — the safest behaviour.
+///
+/// Response format (DSC 2.1+): `/FontName:Yes` or `/FontName:No` per line, then `*`.
+fn pqp_font_answer(font_list: &str) -> String {
+    let mut lines: Vec<String> = font_list
+        .split_whitespace()
+        .filter(|f| !f.is_empty())
+        .map(|f| {
+            let name = f.trim_start_matches('/');
+            format!("/{name}:No")
+        })
+        .collect();
+    lines.push("*".to_string());
+    lines.join("\r")
 }

--- a/tailtalk/src/remote.rs
+++ b/tailtalk/src/remote.rs
@@ -245,6 +245,26 @@ impl RemoteClient {
         Ok(())
     }
 
+    pub(crate) async fn probe_address(
+        &self,
+        name: &str,
+        addr: AppleTalkAddress,
+    ) -> io::Result<bool> {
+        let kind = self
+            .request(proto::request::Kind::ProbeAddress(proto::ProbeAddressRequest {
+                interface: name.to_string(),
+                address: Some(proto::AppleTalkAddress::new(
+                    addr.network_number,
+                    addr.node_number,
+                )),
+            }))
+            .await?;
+        match kind {
+            proto::reply::Kind::ProbeAddress(reply) => Ok(reply.available),
+            _ => Err(unexpected_reply()),
+        }
+    }
+
     // ── Routing rules ────────────────────────────────────────────────────────
 
     pub(crate) async fn list_routes(&self) -> io::Result<proto::ListRoutesReply> {

--- a/tailtalk/tests/pap_test.rs
+++ b/tailtalk/tests/pap_test.rs
@@ -295,3 +295,143 @@ async fn test_pap_print_job() {
 
     hub_task.abort();
 }
+
+/// A sink that collects received jobs for assertions.
+struct CollectSink(Arc<tokio::sync::Mutex<Vec<Vec<u8>>>>);
+
+impl tailtalk::pap::PrintSink for CollectSink {
+    fn receive_job(
+        &self,
+        job: tailtalk::pap::PrintJob,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + '_>> {
+        let store = self.0.clone();
+        Box::pin(async move {
+            store.lock().await.push(job.data);
+            Ok(())
+        })
+    }
+}
+
+/// A PQP query job and a print job over one connection, each followed by a
+/// stdout read, then a client-initiated close.
+#[tokio::test]
+async fn test_pap_server_query_session() {
+    let _ = tracing_subscriber::fmt().try_init();
+
+    let hub = TestHub::new();
+    let (hub_in_tx, hub_in_rx) = mpsc::channel(100);
+    let hub_ref = Arc::new(hub);
+    let hub_runner = hub_ref.clone();
+    let hub_task = tokio::spawn(async move {
+        hub_runner.run(hub_in_rx).await;
+    });
+
+    let mac_printer = [0x00, 0x01, 0x02, 0x03, 0x04, 0xCC];
+    let mac_client = [0x00, 0x01, 0x02, 0x03, 0x04, 0xDD];
+
+    let workstation =
+        TestClient::new(mac_client, hub_in_tx.clone(), hub_ref.subscribe(), None).await;
+    // A second workstation that polls status / tries to connect mid-session.
+    let observer = TestClient::new(
+        [0x00, 0x01, 0x02, 0x03, 0x04, 0xEE],
+        hub_in_tx.clone(),
+        hub_ref.subscribe(),
+        None,
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    let printer = TestClient::new(
+        mac_printer,
+        hub_in_tx.clone(),
+        hub_ref.subscribe(),
+        Some(131),
+    )
+    .await;
+    printer
+        .nbp
+        .register(RegisteredName {
+            name: "QueryPrinter:LaserWriter@*".try_into().unwrap(),
+            sock_num: 131,
+        })
+        .await
+        .expect("Printer registration failed");
+
+    let jobs = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let mut server = tailtalk::pap::PapServer::new(
+        printer.atp_resp,
+        printer.ddp.clone(),
+        131,
+        tailtalk::pap::PrinterAttributes::default(),
+        Box::new(CollectSink(jobs.clone())),
+    );
+    tokio::spawn(async move {
+        let _ = server.run().await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let results = workstation
+        .nbp
+        .lookup("QueryPrinter:LaserWriter@*".try_into().unwrap())
+        .await
+        .expect("Lookup failed");
+    assert!(!results.is_empty());
+    let target = &results[0];
+    let printer_addr = tailtalk::atp::AtpAddress {
+        network_number: target.network_number,
+        node_number: target.node_id,
+        socket_number: target.socket_number,
+    };
+
+    let mut pap = workstation.into_pap_client();
+    pap.connect(printer_addr).await.expect("Connect failed");
+
+    // The listener must keep answering while a session is open: status polls
+    // succeed, but another client's OpenConn gets a busy result.
+    let status = PapClient::get_status(observer.atp_req.clone(), printer_addr)
+        .await
+        .expect("Status poll during session failed");
+    assert!(
+        status.contains("busy"),
+        "status during a session should report busy, got: {status}"
+    );
+    let mut second = observer.into_pap_client();
+    assert!(
+        second
+            .connect_with_timeout(printer_addr, Duration::from_millis(100))
+            .await
+            .is_err(),
+        "second connection during a session must be refused as busy"
+    );
+
+    // 1. PQP query job.
+    let query = b"%!PS-Adobe-3.0 Query\r%%?BeginQuery: RBIUAMListQuery\r(*)= flush\r%%?EndQuery: *\r%%EOF\r";
+    pap.print(query).await.expect("Query job failed");
+    let answer = pap.read_response().await.expect("Query answer failed");
+    assert_eq!(
+        answer,
+        b"*\r",
+        "RBIUAMListQuery must be answered with '*' (no authentication)"
+    );
+
+    // 2. A real print job over the same connection.
+    let ps_job = b"%!PS-Adobe-3.0\rshowpage\r%%EOF\r".to_vec();
+    pap.print(&ps_job).await.expect("Print job failed");
+    let stdout = pap.read_response().await.expect("Job stdout read failed");
+    assert!(stdout.is_empty(), "print job should produce no stdout");
+
+    // 3. Client closes the connection; the server must answer CloseConnReply.
+    tokio::time::timeout(Duration::from_secs(10), pap.close())
+        .await
+        .expect("Close timed out")
+        .expect("Close failed");
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let jobs = jobs.lock().await;
+    assert_eq!(jobs.len(), 1, "sink must receive exactly the one print job");
+    assert_eq!(jobs[0], ps_job);
+
+    println!("✓ PAP query session test passed!");
+
+    hub_task.abort();
+}


### PR DESCRIPTION
Fixes a good few small issues in our PAP setup so it can work both as a client and a server for Macs. This then allows us to accept PAP connections and process jobs from classic Macs.

The next part is essentially flipping the logic of our previous ipp bridge. We now look for modern IPP printers on the local network via mDNS and share them as PAP printers so classic Macs can print to them, along with an optional emulator that prints directly to PDF files on the host.

I also put together pap-capture as a little demo tool I was using to develop and debug this. I think it still serves as a neat example of how to use the API so kept it in.