### PR TITLE
NBP: Start listening for RTMP router advertisements

### DIFF
--- a/tailtalk-packets/src/rtmp.rs
+++ b/tailtalk-packets/src/rtmp.rs
@@ -1,5 +1,8 @@
 use thiserror::Error;
 
+/// Well-known DDP socket for both RTMP Data and RTMP Request packets.
+pub const RTMP_SOCKET: u8 = 1;
+
 #[derive(Error, Debug)]
 pub enum RtmpError {
     #[error("packet too short: expected at least {expected} bytes but found {found}")]
@@ -206,6 +209,40 @@ mod tests {
             packet.tuples[2],
             RtmpTuple::NonExtended {
                 network: 1,
+                distance: 0
+            }
+        );
+    }
+
+    /// Verifies decoding of a real RTMP Data packet. Node 128 is broadcasting on
+    /// non-extended LocalTalk net 0, advertising a single route to its own net
+    /// (net 0, distance 0).
+    #[test]
+    fn test_parse_rtmp_data_netatalk_broadcast() {
+        // RTMP payload (LLAP + DDP short header stripped).
+        //
+        // Full on-wire bytes (frame 42, 18 bytes total):
+        //   LLAP:  ff 80 01
+        //   DDP:   00 0f 01 01 01
+        //   RTMP:  00 00 08 80  00 00 82  00 00 00
+        let rtmp_payload: &[u8] = &[
+            0x00, 0x00, // Router network: 0
+            0x08, // ID length: 8 bits
+            0x80, // Node ID: 128
+            0x00, 0x00, 0x82, // Non-extended version indicator ($000082)
+            0x00, 0x00, 0x00, // Tuple 1: NonExtended, net 0, dist 0
+        ];
+
+        let packet =
+            RtmpDataPacket::parse(rtmp_payload).expect("failed to parse RTMP Data packet");
+
+        assert_eq!(packet.router_network, 0);
+        assert_eq!(packet.node_id, 128);
+        assert_eq!(packet.tuples.len(), 1);
+        assert_eq!(
+            packet.tuples[0],
+            RtmpTuple::NonExtended {
+                network: 0,
                 distance: 0
             }
         );

--- a/tailtalk/src/ddp.rs
+++ b/tailtalk/src/ddp.rs
@@ -263,12 +263,13 @@ impl DdpProcessor {
             n
         } else {
             let mut rng = rand::rng();
-            let mut candidate = rng.random_range(64u8..=255);
+            // 255 is the reserved broadcast socket, never dynamically assignable.
+            let mut candidate = rng.random_range(64u8..=254);
             for _ in 0..192u16 {
                 if !self.sockets.contains_key(&candidate) {
                     break;
                 }
-                candidate = rng.random_range(64..=255);
+                candidate = rng.random_range(64..=254);
             }
             if self.sockets.contains_key(&candidate) {
                 return Err(io::Error::from(io::ErrorKind::AddrInUse));

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -26,6 +26,7 @@ pub mod nbp;
 pub mod pap;
 pub mod remote;
 pub mod route_table;
+pub mod rtmp;
 pub mod stylewriter;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -984,8 +985,9 @@ impl TalkStackBuilder {
             None
         };
 
-        let route_table = route_table::RouteTable::new(route_table::LearningMode::Static);
+        let route_table = route_table::RouteTable::new(route_table::LearningMode::Dynamic);
         let ddp = ddp::DdpProcessor::spawn(et_addressing.clone(), lt_addressing.clone(), outbound, route_table.clone());
+        rtmp::Rtmp::spawn(&ddp, route_table.clone()).await;
 
         let transport_token = CancellationToken::new();
         tokio::spawn(processor.run(et_addressing.clone(), lt_addressing.clone(), ddp.clone(), transport_token.clone()));

--- a/tailtalk/src/nbp.rs
+++ b/tailtalk/src/nbp.rs
@@ -134,17 +134,6 @@ impl Nbp {
                                     z   => self.route_table.nbp_dispatch(NbpZone::Named(z)),
                                 };
 
-                                let dest_addr = match dispatch {
-                                    NbpDispatch::RouterBroadcast(_routers) => {
-                                        // TODO: send BrRq to each router once implemented.
-                                        // For now fall back to network-wide broadcast.
-                                        tailtalk_packets::aarp::AppleTalkAddress { network_number: 0, node_number: 255 }
-                                    }
-                                    NbpDispatch::LocalBroadcast | NbpDispatch::ZoneUnknown => {
-                                        tailtalk_packets::aarp::AppleTalkAddress { network_number: 0, node_number: 255 }
-                                    }
-                                };
-
                                 let tuple = NbpTuple {
                                     network_number: primary_addr.network_number,
                                     node_id: primary_addr.node_number,
@@ -153,19 +142,55 @@ impl Nbp {
                                     entity_name: lookup.request,
                                 };
 
-                                let packet = NbpPacket {
-                                    operation: NbpOperation::Lookup,
-                                    transaction_id: tid,
-                                    tuples: vec![tuple],
+                                let mut buf = [0u8; 1024];
+                                let send_result = match dispatch {
+                                    NbpDispatch::RouterBroadcast(routers) => {
+                                        // A router is known (via RTMP): send BrRq directly
+                                        // to it rather than broadcasting locally.
+                                        let packet = NbpPacket {
+                                            operation: NbpOperation::BroadcastRequest,
+                                            transaction_id: tid,
+                                            tuples: vec![tuple],
+                                        };
+                                        let size = packet.to_bytes(&mut buf).expect("failed to serialize");
+
+                                        let mut any_ok = false;
+                                        let mut last_err = None;
+                                        for router in routers {
+                                            let dest = crate::ddp::DdpAddress::new(router, 2);
+                                            match self.sock.send_to(&buf[..size], dest).await {
+                                                Ok(()) => any_ok = true,
+                                                Err(e) => {
+                                                    tracing::warn!(
+                                                        "NBP BrRq: failed to send to {}.{}: {e}",
+                                                        router.network_number, router.node_number,
+                                                    );
+                                                    last_err = Some(e);
+                                                }
+                                            }
+                                        }
+                                        if any_ok {
+                                            Ok(())
+                                        } else {
+                                            Err(last_err.unwrap_or_else(|| io::Error::other("no routers to send BrRq to")))
+                                        }
+                                    }
+                                    NbpDispatch::LocalBroadcast | NbpDispatch::ZoneUnknown => {
+                                        let packet = NbpPacket {
+                                            operation: NbpOperation::Lookup,
+                                            transaction_id: tid,
+                                            tuples: vec![tuple],
+                                        };
+                                        let size = packet.to_bytes(&mut buf).expect("failed to serialize");
+
+                                        let dest_addr = tailtalk_packets::aarp::AppleTalkAddress { network_number: 0, node_number: 255 };
+                                        let dest = crate::ddp::DdpAddress::new(dest_addr, 2);
+                                        self.sock.send_to(&buf[..size], dest).await
+                                    }
                                 };
 
-                                let mut buf = [0u8; 1024];
-                                let size = packet.to_bytes(&mut buf).expect("failed to serialize");
-
-                                let dest = crate::ddp::DdpAddress::new(dest_addr, 2);
-
-                                if let Err(e) = self.sock.send_to(&buf[..size], dest).await {
-                                    tracing::error!("NBP LkUp: failed to send: {e}");
+                                if let Err(e) = send_result {
+                                    tracing::error!("NBP lookup: failed to send: {e}");
                                     let _ = lookup.chan.send(Err(io::Error::other(
                                         "failed to send NBP lookup",
                                     )));
@@ -267,6 +292,15 @@ impl Nbp {
 
                 // Only send a reply if we have at least one matching tuple
                 if !response.tuples.is_empty() {
+                    // Reply to the tuple's address, not the DDP source: a
+                    // router forwarding a BrRq as a broadcast Lookup sets the
+                    // DDP source to itself, but the tuple names the original
+                    // requester.
+                    let Some(req_tuple) = packet.tuples.first() else {
+                        tracing::warn!("NBP Lookup with no request tuple; dropping");
+                        return;
+                    };
+
                     let mut buf = [0u8; 1024];
                     let size = response
                         .to_bytes(&mut buf)
@@ -274,10 +308,10 @@ impl Nbp {
 
                     let dest = crate::ddp::DdpAddress::new(
                         tailtalk_packets::aarp::AppleTalkAddress {
-                            network_number: ddp.src_network_num,
-                            node_number: ddp.src_node_id,
+                            network_number: req_tuple.network_number,
+                            node_number: req_tuple.node_id,
                         },
-                        ddp.src_sock_num,
+                        req_tuple.socket_number,
                     );
 
                     if let Err(e) = self.sock.send_to(&buf[..size], dest).await {
@@ -286,8 +320,8 @@ impl Nbp {
                         tracing::debug!(
                             "Sent NBP LookupReply with {} tuples to {}.{}",
                             response.tuples.len(),
-                            ddp.src_network_num,
-                            ddp.src_node_id
+                            req_tuple.network_number,
+                            req_tuple.node_id
                         );
                     }
                 } else {

--- a/tailtalk/src/rtmp.rs
+++ b/tailtalk/src/rtmp.rs
@@ -1,0 +1,133 @@
+//! RTMP listener actor.
+//!
+//! Routers broadcast an RTMP Data packet on every directly-connected cable
+//! roughly every 10 seconds. Seeing one means a router is present, so its
+//! tuples are fed into the [`RouteTable`], which is what makes NBP dispatch
+//! switch from local broadcast to a directed request at the router.
+//!
+//! Receive-only: TailTalk never originates RTMP packets of its own.
+
+use tailtalk_packets::aarp::AppleTalkAddress;
+use tailtalk_packets::ddp::{DdpPacket, DdpProtocolType};
+use tailtalk_packets::rtmp::{RTMP_SOCKET, RtmpDataPacket, RtmpTuple};
+
+use crate::ddp::{DdpHandle, DdpSocket};
+use crate::route_table::RouteTable;
+
+pub struct Rtmp {
+    sock: DdpSocket,
+    route_table: RouteTable,
+}
+
+impl Rtmp {
+    /// Spawn the RTMP listener actor.
+    pub async fn spawn(ddp: &DdpHandle, route_table: RouteTable) {
+        let sock = ddp
+            .new_sock(DdpProtocolType::RtmpResponse, Some(RTMP_SOCKET))
+            .await
+            .expect("failed to create RTMP sock");
+
+        let rtmp = Rtmp { sock, route_table };
+        tokio::spawn(async move { rtmp.run().await });
+    }
+
+    async fn run(mut self) {
+        while let Ok(pkt) = self.sock.recv().await {
+            self.handle_packet(&pkt.headers, &pkt.payload);
+        }
+    }
+
+    fn handle_packet(&self, ddp: &DdpPacket, payload: &[u8]) {
+        let data = match RtmpDataPacket::parse(payload) {
+            Ok(data) => data,
+            Err(e) => {
+                tracing::debug!("RTMP: failed to parse Data packet: {e}");
+                return;
+            }
+        };
+
+        // Unlike a forwarded NBP Lookup, an RTMP Data packet is always sent
+        // directly by the router itself, so the DDP source is its address.
+        let router = AppleTalkAddress {
+            network_number: ddp.src_network_num,
+            node_number: ddp.src_node_id,
+        };
+
+        let tuples = tuples_for_route_table(&data);
+        if tuples.is_empty() {
+            return;
+        }
+
+        tracing::info!(
+            "RTMP: router {}.{} advertises {} route(s); switching NBP to router broadcast",
+            router.network_number,
+            router.node_number,
+            tuples.len(),
+        );
+
+        self.route_table.handle_rtmp(router, &tuples);
+    }
+}
+
+/// Flatten an RTMP Data packet's tuples into `(range_lo, range_hi, hop_count)`
+/// entries for [`RouteTable::handle_rtmp`]. The hop count recorded is the
+/// distance from us, i.e. one more than the distance the router advertised
+/// from itself.
+fn tuples_for_route_table(data: &RtmpDataPacket) -> Vec<(u16, u16, u8)> {
+    data.tuples
+        .iter()
+        .map(|t| match *t {
+            RtmpTuple::NonExtended { network, distance } => {
+                (network, network, distance.saturating_add(1))
+            }
+            RtmpTuple::Extended { range_start, distance, range_end } => {
+                (range_start, range_end, distance.saturating_add(1))
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::route_table::{LearningMode, NbpDispatch, NbpZone};
+
+    fn addr(net: u16, node: u8) -> AppleTalkAddress {
+        AppleTalkAddress { network_number: net, node_number: node }
+    }
+
+    /// Real RTMP Data packet captured from netatalk running tailtalkd
+    /// (pcaps/netatalk.pcap, frame 42). Node 128 broadcasting on non-extended
+    /// LocalTalk net 0, advertising a single route to its own net (net 0,
+    /// distance 0). Same payload verified parseable in tailtalk-packets.
+    const NETATALK_RTMP_PAYLOAD: &[u8] = &[
+        0x00, 0x00, // Router network: 0
+        0x08, // ID length: 8 bits
+        0x80, // Node ID: 128
+        0x00, 0x00, 0x82, // Non-extended version indicator ($000082)
+        0x00, 0x00, 0x00, // Tuple 1: NonExtended, net 0, dist 0
+    ];
+
+    #[test]
+    fn tuples_for_route_table_converts_and_increments_hop_count() {
+        let data = RtmpDataPacket::parse(NETATALK_RTMP_PAYLOAD).unwrap();
+        assert_eq!(tuples_for_route_table(&data), vec![(0, 0, 1)]);
+    }
+
+    /// End-to-end: a real captured RTMP broadcast, once fed into the route
+    /// table, is enough to flip NBP dispatch from local to router broadcast.
+    #[test]
+    fn seeing_rtmp_broadcast_switches_nbp_to_router_broadcast() {
+        let table = RouteTable::new(LearningMode::Dynamic);
+        assert_eq!(table.nbp_dispatch(NbpZone::All), NbpDispatch::LocalBroadcast);
+
+        let data = RtmpDataPacket::parse(NETATALK_RTMP_PAYLOAD).unwrap();
+        let router = addr(0, 128);
+        table.handle_rtmp(router, &tuples_for_route_table(&data));
+
+        assert_eq!(
+            table.nbp_dispatch(NbpZone::All),
+            NbpDispatch::RouterBroadcast(vec![router])
+        );
+    }
+}


### PR DESCRIPTION
Starts listening for RTMP updates from a router present on the network. If one is seen, we will switch away from using NBP lookups to NBP broadcast requests directed towards the router.

As part of this we now correctly use the source address advertised in the NBP tuple, not the DDP source address which could be the router.