### PR TITLE
DDP: Swap to long form on LocalTalk networks with routers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,19 @@ jobs:
     - name: Run tests
       run: cargo test
 
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y pkg-config libfontconfig1-dev libudev-dev libpcap-dev
+    - name: Install clippy
+      run: rustup component add clippy
+    - name: Run clippy
+      run: cargo clippy --workspace --all-targets -- -D warnings
+
   release:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/tailtalk/src/addressing.rs
+++ b/tailtalk/src/addressing.rs
@@ -165,6 +165,7 @@ impl Addressing {
             protocol: DataLinkProtocol::Aarp,
             payload: payload.into(),
             src_node_id: 0, // AARP is never sent to LocalTalk destinations
+            ddp_long: false,
         }
     }
 
@@ -184,6 +185,7 @@ impl Addressing {
                     protocol: DataLinkProtocol::LlapEnq,
                     payload: Box::new([]),
                     src_node_id: node_num,
+                    ddp_long: false,
                 };
                 self.outbound.send(enq).await.expect("failed to dispatch LLAP ENQ");
 
@@ -305,6 +307,7 @@ impl Addressing {
                             protocol: DataLinkProtocol::LlapAck,
                             payload: Box::new([]),
                             src_node_id: our_addr.node_number,
+                            ddp_long: false,
                         };
                         let _ = self.outbound.send(ack).await;
                     }
@@ -392,6 +395,7 @@ impl Addressing {
                 protocol: DataLinkProtocol::LlapEnq,
                 payload: Box::new([]),
                 src_node_id: candidate.node_number,
+                ddp_long: false,
             };
             if self.outbound.send(enq).await.is_err() {
                 return false;

--- a/tailtalk/src/ddp.rs
+++ b/tailtalk/src/ddp.rs
@@ -527,8 +527,13 @@ impl DdpProcessor {
         dest_node: Node,
         our_addr: AppleTalkAddress,
     ) {
-        // Short DDP (DDP-S, 5-byte header) is LocalTalk only.
-        let use_short = matches!(dest_node, Node::LocalTalk(_));
+        // Short DDP (DDP-S, 5-byte header) is LocalTalk only, and only while
+        // the segment is unrouted: it carries no network number, which is
+        // fine in isolation but ambiguous once a router (seen via RTMP) puts
+        // us in a multi-network topology. Once a router is known, switch to
+        // long-form DDP even on LocalTalk, same as NBP switches to router
+        // broadcast requests.
+        let use_short = matches!(dest_node, Node::LocalTalk(_)) && !self.route_table.has_router();
 
         let header_len = if use_short { 5 } else { DdpHeaders::LEN };
         let headers = DdpHeaders {
@@ -582,6 +587,7 @@ impl DdpProcessor {
                 protocol: DataLinkProtocol::Ddp,
                 payload,
                 src_node_id: our_addr.node_number,
+                ddp_long: !use_short,
             })
             .await
         {

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -45,6 +45,11 @@ pub struct DataLinkPacket {
     /// Our own LocalTalk node ID, used to populate the LLAP `src_node` field.
     /// Zero for Ethernet destinations (LLAP is not used on EtherTalk).
     pub src_node_id: u8,
+    /// For `DataLinkProtocol::Ddp` on a LocalTalk destination, whether
+    /// `payload` holds a long-form (13-byte) DDP header rather than the
+    /// short-form (5-byte) one — selects the LLAP DDP-long vs. DDP-short
+    /// frame type. Ignored for every other protocol/destination.
+    pub ddp_long: bool,
 }
 
 pub struct PacketProcessor {
@@ -522,7 +527,7 @@ impl PacketProcessor {
                             let llap_pkt = LlapPacket {
                                 dst_node: node_id,
                                 src_node: pkt.src_node_id,
-                                type_: LlapType::DdpShort,
+                                type_: if pkt.ddp_long { LlapType::DdpLong } else { LlapType::DdpShort },
                             };
                             let header_len = llap_pkt
                                 .to_bytes(&mut output_buf)

--- a/tailtalk/src/pap.rs
+++ b/tailtalk/src/pap.rs
@@ -152,15 +152,14 @@ impl PapClient {
                         PapFunction::SendData => {
                             let seq_num = pap_req.sequence_num;
 
-                            if seq_num != 0 {
-                                if let Some((seq, ub, chunk)) = &last_reply {
-                                    if *seq == seq_num {
-                                        let _ = req
-                                            .send_response_chunked(chunk.clone(), *ub, PAP_MAX_DATA_PER_PACKET)
-                                            .await;
-                                        continue;
-                                    }
-                                }
+                            if seq_num != 0
+                                && let Some((seq, ub, chunk)) = &last_reply
+                                && *seq == seq_num
+                            {
+                                let _ = req
+                                    .send_response_chunked(chunk.clone(), *ub, PAP_MAX_DATA_PER_PACKET)
+                                    .await;
+                                continue;
                             }
 
                             let max_packets = if req.bitmap == 0x00 { 8 } else { req.bitmap.count_ones() as usize }.clamp(1, 8);

--- a/tailtalk/src/route_table.rs
+++ b/tailtalk/src/route_table.rs
@@ -193,6 +193,10 @@ impl Inner {
         self.rtmp.lookup(net).map(|e| NextHop::Via(e.next_hop))
     }
 
+    fn has_router(&self) -> bool {
+        !self.rtmp.entries.is_empty()
+    }
+
     fn routers_for_zone(&self, zone: &str) -> Vec<AppleTalkAddress> {
         let mut seen = HashSet::new();
         self.zip
@@ -393,6 +397,17 @@ impl RouteTable {
         self.0.read().unwrap().route_for(net)
     }
 
+    /// Returns `true` once at least one router has advertised itself via RTMP
+    /// (or been configured programmatically).
+    ///
+    /// Used to decide when to stop using short-form (5-byte) DDP headers on
+    /// LocalTalk: those omit the network number entirely, which is fine on
+    /// an isolated LocalTalk segment but ambiguous as soon as a router makes
+    /// off-segment addressing possible.
+    pub fn has_router(&self) -> bool {
+        self.0.read().unwrap().has_router()
+    }
+
     /// Return the router addresses that can forward NBP requests for `zone`.
     ///
     /// Derived from ZIP (zone → ranges) then RTMP (range → next-hop).
@@ -461,6 +476,16 @@ mod tests {
         assert_eq!(t.route_for(155), Some(NextHop::Via(addr(1, 2))));
         // Parts of the old range outside [150, 160] are gone
         assert_eq!(t.route_for(100), None);
+    }
+
+    #[test]
+    fn has_router_tracks_rtmp_entries() {
+        let t = RouteTable::new(LearningMode::Static);
+        assert!(!t.has_router());
+        t.insert_route(200, 210, addr(100, 1));
+        assert!(t.has_router());
+        t.remove_route(200, 210);
+        assert!(!t.has_router());
     }
 
     #[test]


### PR DESCRIPTION
Makes our LocalTalk networking automatically swap to long form DDP packets when a router is detected on the network. This makes sure that we use the correct packet type to be able to respond to devices beyond our own network.

Additionally adds a cargo clippy stage to CI and fixes the outstanding issues with it.