### PR TITLE
GUI: Search for ghostscript in macOS path, add keep awake option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1491,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -3008,6 +3074,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3313,6 +3385,21 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keepawake"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5521b450ec179362595d5cbda7c3abd5da3af3dff58456434ad3ca33c95226b7"
+dependencies = [
+ "cfg-if",
+ "derive_builder",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "thiserror 2.0.18",
+ "windows 0.62.2",
+ "zbus",
 ]
 
 [[package]]
@@ -4186,7 +4273,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
  "dispatch2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -4289,6 +4378,20 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "dispatch2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -6482,6 +6585,7 @@ dependencies = [
  "hfs-reader",
  "if-addrs",
  "ipp",
+ "keepawake",
  "mdns-sd",
  "rfd",
  "serde",

--- a/tailtalk-gui/Cargo.toml
+++ b/tailtalk-gui/Cargo.toml
@@ -21,6 +21,7 @@ dirs = "6"
 hfs-reader = { workspace = true } #unified
 if-addrs = "0.15"
 ipp = "6.0.1"
+keepawake = "0.6"
 mdns-sd = "0.20.0"
 rfd = "0.17"
 shellexpand = "3"

--- a/tailtalk-gui/ipp_bridge.rs
+++ b/tailtalk-gui/ipp_bridge.rs
@@ -1221,60 +1221,67 @@ async fn urf_to_rasterizable(data: Vec<u8>, job_token: u32) -> anyhow::Result<Ve
     }
 }
 
-/// Return the name of the Ghostscript executable on this platform.
-/// On Windows, Ghostscript may be installed as `gswin64c` or `gswin32c`
-/// rather than `gs`; try each in order and return the first one found.
-pub(crate) fn gs_command() -> &'static str {
+/// Absolute fallback locations to check for Ghostscript beyond `$PATH`.
+/// A GUI app launched from Finder/LaunchServices (rather than a terminal)
+/// gets a bare-minimum PATH that doesn't include Homebrew's or MacPorts'
+/// install prefixes, so a plain `Command::new("gs")` fails to spawn even
+/// though `gs` works fine from a shell.
+#[cfg(target_os = "macos")]
+const GS_FALLBACK_PATHS: &[&str] = &[
+    "/opt/homebrew/bin/gs",       // Homebrew, Apple Silicon
+    "/usr/local/bin/gs",          // Homebrew, Intel
+    "/usr/local/opt/ghostscript/bin/gs",
+    "/opt/local/bin/gs",          // MacPorts
+];
+
+fn gs_works(candidate: &str) -> bool {
+    std::process::Command::new(candidate)
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Locate a usable Ghostscript executable, checking `$PATH` first and then
+/// (on macOS) common install locations that a Finder-launched app's PATH
+/// won't include. Returns the name or full path to invoke it with.
+fn find_gs() -> Option<String> {
     #[cfg(target_os = "windows")]
-    {
-        for candidate in &["gswin64c", "gswin32c", "gs"] {
-            if std::process::Command::new(candidate)
-                .arg("--version")
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .map(|s| s.success())
-                .unwrap_or(false)
-            {
-                return candidate;
-            }
-        }
-        "gswin64c" // fall through to a named binary so the error message is useful
-    }
+    let path_candidates: &[&str] = &["gswin64c", "gswin32c", "gs"];
     #[cfg(not(target_os = "windows"))]
-    "gs"
+    let path_candidates: &[&str] = &["gs"];
+
+    for candidate in path_candidates {
+        if gs_works(candidate) {
+            return Some((*candidate).to_string());
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    for candidate in GS_FALLBACK_PATHS {
+        if gs_works(candidate) {
+            return Some((*candidate).to_string());
+        }
+    }
+
+    None
+}
+
+/// Return the name or full path of the Ghostscript executable to invoke.
+pub(crate) fn gs_command() -> String {
+    find_gs().unwrap_or_else(|| {
+        #[cfg(target_os = "windows")]
+        { "gswin64c".to_string() } // fall through to a named binary so the error message is useful
+        #[cfg(not(target_os = "windows"))]
+        { "gs".to_string() }
+    })
 }
 
 /// Returns true if a usable Ghostscript executable is found on this platform.
 pub fn gs_probe() -> bool {
-    #[cfg(target_os = "windows")]
-    {
-        // gs_command() already probes all candidates; if it falls through to the
-        // default name without finding anything, a --version call will fail.
-        for candidate in &["gswin64c", "gswin32c", "gs"] {
-            if std::process::Command::new(candidate)
-                .arg("--version")
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .map(|s| s.success())
-                .unwrap_or(false)
-            {
-                return true;
-            }
-        }
-        false
-    }
-    #[cfg(not(target_os = "windows"))]
-    {
-        std::process::Command::new("gs")
-            .arg("--version")
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
-    }
+    find_gs().is_some()
 }
 
 /// Rasterize a PDF/PS/URF document with Ghostscript to a raw raster device

--- a/tailtalk-gui/main.rs
+++ b/tailtalk-gui/main.rs
@@ -38,6 +38,7 @@ struct AppConfig {
     laserwriter_name: Option<String>,
     laserwriter_output_path: Option<String>,
     laserwriter_convert_pdf: bool,
+    keep_awake_enabled: bool,
 }
 
 fn config_path() -> Option<PathBuf> {
@@ -242,6 +243,11 @@ fn main() -> anyhow::Result<()> {
     // Shared handle used to shut the stack down when the window closes.
     let active_handle: Arc<tokio::sync::Mutex<Option<ShutdownHandle>>> =
         Arc::new(tokio::sync::Mutex::new(None));
+    // Power assertion preventing idle system sleep while the stack is running
+    // (the daemon's network sockets don't survive a full system sleep). Held
+    // only while running; dropping it releases the assertion.
+    let keep_awake: Arc<std::sync::Mutex<Option<keepawake::KeepAwake>>> =
+        Arc::new(std::sync::Mutex::new(None));
 
     let (_log_guard, log_dir) = init_logging();
 
@@ -335,10 +341,16 @@ fn main() -> anyhow::Result<()> {
             ui.set_laserwriter_output_path(v.as_str().into());
         }
         ui.set_laserwriter_convert_pdf(config.laserwriter_convert_pdf);
+        ui.set_keep_awake_enabled(config.keep_awake_enabled);
     }
 
     let ui_handle = ui.as_weak();
-    rt_handle.spawn(server_loop(cmd_rx, ui_handle, active_handle.clone()));
+    rt_handle.spawn(server_loop(
+        cmd_rx,
+        ui_handle,
+        active_handle.clone(),
+        keep_awake.clone(),
+    ));
 
     let ui_weak = ui.as_weak();
     #[cfg(feature = "ethertalk")]
@@ -498,6 +510,7 @@ fn main() -> anyhow::Result<()> {
                     if s.is_empty() { None } else { Some(s) }
                 },
                 laserwriter_convert_pdf: ui.get_laserwriter_convert_pdf(),
+                keep_awake_enabled: ui.get_keep_awake_enabled(),
             });
 
             let pcap_path: Option<PathBuf> = if ui.get_pcap_enabled() {
@@ -866,6 +879,7 @@ fn main() -> anyhow::Result<()> {
             h.graceful_shutdown().await;
         }
     });
+    keep_awake.lock().unwrap().take();
 
     Ok(())
 }
@@ -876,6 +890,7 @@ async fn server_loop(
     mut cmd_rx: tokio::sync::mpsc::Receiver<ServerCommand>,
     ui_weak: slint::Weak<AppWindow>,
     active: Arc<tokio::sync::Mutex<Option<ShutdownHandle>>>,
+    keep_awake: Arc<std::sync::Mutex<Option<keepawake::KeepAwake>>>,
 ) {
     let mut shutdown_handle: Option<ShutdownHandle> = None;
 
@@ -897,6 +912,7 @@ async fn server_loop(
                 if let Some(h) = shutdown_handle.take() {
                     active.lock().await.take();
                     h.graceful_shutdown().await;
+                    keep_awake.lock().unwrap().take();
                 }
 
                 let ui_w = ui_weak.clone();
@@ -922,10 +938,23 @@ async fn server_loop(
                 if let Ok((handle, extra)) = ready_rx.await {
                     *active.lock().await = Some(extra);
                     shutdown_handle = Some(handle);
+                    let keep_awake = keep_awake.clone();
                     slint::invoke_from_event_loop(move || {
                         if let Some(ui) = ui_w.upgrade() {
                             ui.set_starting(false);
                             ui.set_running(true);
+                            if ui.get_keep_awake_enabled() {
+                                match keepawake::Builder::default()
+                                    .idle(true)
+                                    .reason("TailTalk AFP server is running")
+                                    .app_name("TailTalk")
+                                    .app_reverse_domain("com.tailtalk.app")
+                                    .create()
+                                {
+                                    Ok(k) => *keep_awake.lock().unwrap() = Some(k),
+                                    Err(e) => tracing::warn!("Could not enable keep-awake: {e}"),
+                                }
+                            }
                         }
                     })
                     .ok();
@@ -939,6 +968,7 @@ async fn server_loop(
                     active.lock().await.take();
                     h.graceful_shutdown().await;
                 }
+                keep_awake.lock().unwrap().take();
                 let ui_w = ui_weak.clone();
                 slint::invoke_from_event_loop(move || {
                     if let Some(ui) = ui_w.upgrade() {

--- a/tailtalk-gui/ui/app.slint
+++ b/tailtalk-gui/ui/app.slint
@@ -30,6 +30,7 @@ export component AppWindow inherits Window {
     in-out property <string> laserwriter-name: "Color LaserWriter 12/600";
     in-out property <string> laserwriter-output-path;
     in-out property <bool> laserwriter-convert-pdf: false;
+    in-out property <bool> keep-awake-enabled: false;
     in-out property <string> info-message: "";
 
     in-out property <bool> import-progress-visible: false;
@@ -61,6 +62,11 @@ export component AppWindow inherits Window {
     MenuBar {
         Menu {
             title: "File";
+            MenuItem {
+                title: "Keep Awake";
+                checkable: true;
+                checked <=> root.keep-awake-enabled;
+            }
             MenuItem {
                 title: "Import Archive/Disk Image…";
                 activated => { root.import-files(); }


### PR DESCRIPTION
Ghostscript installed via Brew on macOS ends up in /opt/homebrew/bin which is not in the standard system path. This causes us to incorrectly think it is not installed on macOS when run via the app bundle even though it is. Now we explicitly check this path.

Additionally adds a "Keep Awake" option under the File menu that will prevent the system from going completely to sleep, allowing the file and printer share to keep going. This should work on macOS, Linux and Windows.