### PR TITLE
Core: Overhaul routing, ZIP/RTMP engines, and Netatalk integration

### DIFF
--- a/examples/nbp-lookup/main.rs
+++ b/examples/nbp-lookup/main.rs
@@ -13,6 +13,10 @@ struct Args {
     #[arg(short, long)]
     tashtalk: Option<String>,
 
+    /// Capture LocalTalk traffic to this pcap file (DLT 114 / LINKTYPE_LOCALTALK)
+    #[arg(short, long)]
+    pcap: Option<String>,
+
     /// Entity to look up in Object:Type@Zone format. Use = as wildcard.
     #[arg(default_value = "=:=@*")]
     entity: String,
@@ -41,7 +45,23 @@ async fn main() -> anyhow::Result<()> {
     if let Some(ref tty) = args.tashtalk {
         builder = builder.localtalk(tty);
     }
+    if let Some(ref path) = args.pcap {
+        builder = builder.pcap_capture(path);
+    }
     let stack = builder.build().await.expect("failed to build AppleTalk stack");
+
+    // A router advertises via RTMP only about every 10 seconds, and until we
+    // hear one NBP can only broadcast on the local cable — so a one-shot lookup
+    // at startup misses everything behind the router. Wait a little over one
+    // RTMP interval for a router before looking up; proceed if the cable turns
+    // out to be isolated.
+    if !stack.route_table.has_router() {
+        println!("Waiting for a router advertisement...");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(11);
+        while !stack.route_table.has_router() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+    }
 
     println!("Looking up '{}'...", entity);
     match stack.nbp.lookup(entity).await {
@@ -59,6 +79,12 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         Err(e) => eprintln!("Lookup failed: {}", e),
+    }
+
+    // The pcap writer runs on its own thread and drains a channel; give it a
+    // moment to flush the request and any trailing responses before we exit.
+    if args.pcap.is_some() {
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     }
 
     Ok(())

--- a/tailtalk-daemon/src/lib.rs
+++ b/tailtalk-daemon/src/lib.rs
@@ -38,6 +38,10 @@ pub struct DaemonConfig {
     pub localtalk_node: Option<u8>,
     /// LocalTalk pcap capture path.
     pub pcap: Option<PathBuf>,
+    /// Disable the daemon's own RTMP listener and ZIP client (DDP sockets 1
+    /// and 6). Needed when a client such as netatalk's `atalkd` runs its own
+    /// router engines over this daemon and must bind those sockets itself.
+    pub no_router_discovery: bool,
 }
 
 // ── Daemon state ──────────────────────────────────────────────────────────────
@@ -94,6 +98,10 @@ impl Daemon {
 
         if let Some(ref path) = config.pcap {
             builder = builder.pcap_capture(path);
+        }
+
+        if config.no_router_discovery {
+            builder = builder.disable_router_discovery();
         }
 
         let underlay = builder.build_underlay().await?;
@@ -309,7 +317,7 @@ impl Session {
             }
             Kind::SetLocalRange(r) => match r.range.and_then(range_from_proto) {
                 Some((lo, hi)) => {
-                    self.state.route_table.set_local_range(lo, hi);
+                    self.state.route_table.set_local_range_for(tailtalk::route_table::Interface::EtherTalk, lo, hi);
                     proto::Reply::ok(id)
                 }
                 None => invalid(id, "set_local_range requires a valid range"),
@@ -539,6 +547,12 @@ impl Session {
         let (Ok(network), Ok(node)) = (u16::try_from(nh.network), u8::try_from(nh.node)) else {
             return invalid(id, "next_hop out of range");
         };
+        let interface = match route.interface {
+            1 => Some(tailtalk::route_table::Interface::EtherTalk),
+            2 => Some(tailtalk::route_table::Interface::EtherTalk),
+            3 => Some(tailtalk::route_table::Interface::LocalTalk),
+            _ => None,
+        };
         self.state.route_table.insert_route(
             lo,
             hi,
@@ -546,6 +560,7 @@ impl Session {
                 network_number: network,
                 node_number: node,
             },
+            interface.unwrap_or(tailtalk::route_table::Interface::EtherTalk),
         );
         proto::Reply::ok(id)
     }
@@ -575,12 +590,17 @@ fn routes_to_proto(table: &RouteTable) -> proto::ListRoutesReply {
         routes: snapshot
             .routes
             .into_iter()
-            .map(|(lo, hi, next_hop)| proto::Route {
+            .map(|(lo, hi, next_hop, interface)| proto::Route {
                 range: Some(range_to_proto((lo, hi))),
                 next_hop: Some(proto::AppleTalkAddress::new(
                     next_hop.network_number,
                     next_hop.node_number,
                 )),
+                interface: match interface {
+                    Some(tailtalk::route_table::Interface::EtherTalk) => 2,
+                    Some(tailtalk::route_table::Interface::LocalTalk) => 3,
+                    None => 0,
+                },
             })
             .collect(),
         zones: snapshot
@@ -634,6 +654,11 @@ async fn socket_pump_inbound(
             dest_socket: h.dest_sock_num as u32,
             ddp_type: u8::from(h.protocol_typ) as u32,
             payload: pkt.payload.into_vec(),
+            arrival_link: match pkt.source {
+                tailtalk_packets::aarp::AddressSource::EtherTalkPhase1 => 1,
+                tailtalk_packets::aarp::AddressSource::EtherTalkPhase2 => 2,
+                tailtalk_packets::aarp::AddressSource::LocalTalk => 3,
+            },
         };
         if out_tx.send(proto::ServerMessage::datagram(datagram)).await.is_err() {
             break;

--- a/tailtalk-daemon/src/main.rs
+++ b/tailtalk-daemon/src/main.rs
@@ -48,6 +48,12 @@ struct Cli {
     #[arg(long)]
     pcap: Option<PathBuf>,
 
+    /// Disable the built-in RTMP listener and ZIP client (DDP sockets 1 and
+    /// 6). Use when a client (e.g. netatalk's atalkd) runs its own router
+    /// engines over this daemon.
+    #[arg(long)]
+    no_router_discovery: bool,
+
     /// Cable range of the local segment, as LO-HI (e.g. 100-105).
     #[arg(long, value_parser = parse_range)]
     local_range: Option<RangeArg>,
@@ -147,6 +153,7 @@ async fn main() -> anyhow::Result<()> {
         localtalk: cli.localtalk,
         localtalk_node: cli.localtalk_node,
         pcap: cli.pcap,
+        no_router_discovery: cli.no_router_discovery,
     })
     .await?;
 
@@ -154,7 +161,7 @@ async fn main() -> anyhow::Result<()> {
     // modify these later through the API.
     let table = daemon.route_table();
     if let Some(RangeArg(lo, hi)) = cli.local_range {
-        table.set_local_range(lo, hi);
+        table.set_local_range_for(tailtalk::route_table::Interface::EtherTalk, lo, hi);
     }
     for RouteArg(lo, hi, net, node) in &cli.routes {
         table.insert_route(
@@ -164,6 +171,7 @@ async fn main() -> anyhow::Result<()> {
                 network_number: *net,
                 node_number: *node,
             },
+            tailtalk::route_table::Interface::EtherTalk,
         );
     }
     for ZoneArg(name, ranges) in &cli.zones {

--- a/tailtalk-daemon/tests/integration.rs
+++ b/tailtalk-daemon/tests/integration.rs
@@ -241,6 +241,7 @@ async fn routing_rules_over_unix_socket() {
                 route: Some(proto::Route {
                     range: Some(proto::CableRange { lo: 200, hi: 210 }),
                     next_hop: Some(proto::AppleTalkAddress::new(100, 1)),
+                    interface: 2,
                 }),
             }),
         )
@@ -275,8 +276,8 @@ async fn routing_rules_over_unix_socket() {
 
     // ...and actually applied to the daemon's forwarding table.
     assert_eq!(
-        daemon.route_table().route_for(205),
-        Some(NextHop::Via(addr(100, 1)))
+        daemon.route_table().resolve(205),
+        Some(NextHop::Via { router: addr(100, 1), interface: tailtalk::route_table::Interface::EtherTalk })
     );
 
     // Remove and verify.
@@ -290,7 +291,7 @@ async fn routing_rules_over_unix_socket() {
         )
         .await,
     );
-    assert_eq!(daemon.route_table().route_for(205), None);
+    assert_eq!(daemon.route_table().resolve(205), None);
 }
 
 #[tokio::test]
@@ -311,6 +312,7 @@ async fn route_changes_are_pushed_to_all_clients() {
                 route: Some(proto::Route {
                     range: Some(proto::CableRange { lo: 200, hi: 210 }),
                     next_hop: Some(proto::AppleTalkAddress::new(100, 1)),
+                    interface: 2,
                 }),
             }),
         )
@@ -336,7 +338,7 @@ async fn route_changes_are_pushed_to_all_clients() {
     );
 
     // Changes made directly on the daemon (e.g. its CLI) are pushed too.
-    daemon.route_table().set_local_range(10, 15);
+    daemon.route_table().set_local_range_for(tailtalk::route_table::Interface::EtherTalk, 10, 15);
     let push = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let msg: proto::ServerMessage =
@@ -360,10 +362,10 @@ async fn talkstack_mirror_follows_daemon_changes() {
 
     // A rule added on the daemon after the client connected shows up in the
     // client's route table via the push channel — no RPC from the client.
-    daemon.route_table().insert_route(200, 210, addr(100, 1));
+    daemon.route_table().insert_route(200, 210, addr(100, 1), tailtalk::route_table::Interface::EtherTalk);
     let mut synced = false;
     for _ in 0..100 {
-        if stack.route_table.route_for(205) == Some(NextHop::Via(addr(100, 1))) {
+        if stack.route_table.resolve(205) == Some(NextHop::Via { router: addr(100, 1), interface: tailtalk::route_table::Interface::EtherTalk }) {
             synced = true;
             break;
         }
@@ -375,7 +377,7 @@ async fn talkstack_mirror_follows_daemon_changes() {
     daemon.route_table().remove_route(200, 210);
     let mut synced = false;
     for _ in 0..100 {
-        if stack.route_table.route_for(205).is_none() {
+        if stack.route_table.resolve(205).is_none() {
             synced = true;
             break;
         }
@@ -389,21 +391,21 @@ async fn talkstack_remote_mode_over_unix() {
     let (daemon, _dir, path) = start_daemon().await;
 
     // Rules configured on the daemon before the client connects…
-    daemon.route_table().insert_route(200, 210, addr(100, 1));
+    daemon.route_table().insert_route(200, 210, addr(100, 1), tailtalk::route_table::Interface::EtherTalk);
 
     let stack = TalkStack::builder().daemon_unix(&path).build().await.unwrap();
 
     // …are mirrored into the client's route table at build time.
     assert_eq!(
-        stack.route_table.route_for(205),
-        Some(NextHop::Via(addr(100, 1)))
+        stack.route_table.resolve(205),
+        Some(NextHop::Via { router: addr(100, 1), interface: tailtalk::route_table::Interface::EtherTalk })
     );
 
     // Client-side modifications propagate back to the daemon.
-    stack.route_table.insert_route(300, 310, addr(100, 2));
+    stack.route_table.insert_route(300, 310, addr(100, 2), tailtalk::route_table::Interface::EtherTalk);
     let mut synced = false;
     for _ in 0..100 {
-        if daemon.route_table().route_for(305) == Some(NextHop::Via(addr(100, 2))) {
+        if daemon.route_table().resolve(305) == Some(NextHop::Via { router: addr(100, 2), interface: tailtalk::route_table::Interface::EtherTalk }) {
             synced = true;
             break;
         }
@@ -467,7 +469,7 @@ async fn talkstack_remote_mode_over_udp() {
     let sock = stack.ddp.new_sock(DdpProtocolType::Adsp, None).await.unwrap();
     assert!((64..=254).contains(&sock.socket_num()));
 
-    stack.route_table.set_local_range(50, 55);
+    stack.route_table.set_local_range_for(tailtalk::route_table::Interface::EtherTalk, 50, 55);
     let mut synced = false;
     for _ in 0..100 {
         if daemon.route_table().is_local(52) {

--- a/tailtalk-gui/main.rs
+++ b/tailtalk-gui/main.rs
@@ -93,7 +93,7 @@ enum ServerCommand {
         pcap_path: Option<PathBuf>,
         ipp_bridge_enabled: bool,
         lw_bridge_enabled: bool,
-        laserwriter: Option<LaserWriterConfig>,
+        laserwriter: Box<Option<LaserWriterConfig>>,
     },
     Stop,
 }
@@ -534,7 +534,7 @@ fn main() -> anyhow::Result<()> {
                 pcap_path,
                 ipp_bridge_enabled: ui.get_ipp_bridge_enabled(),
                 lw_bridge_enabled: ui.get_lw_bridge_enabled(),
-                laserwriter,
+                laserwriter: Box::new(laserwriter),
             });
             if send_result.is_err() {
                 tracing::warn!("Server command queue full; ignoring Start");
@@ -928,7 +928,7 @@ async fn server_loop(
                     pcap_path,
                     ipp_bridge_enabled,
                     lw_bridge_enabled,
-                    laserwriter,
+                    *laserwriter,
                     ready_tx,
                     ui_w.clone(),
                 ));

--- a/tailtalk-packets/src/lib.rs
+++ b/tailtalk-packets/src/lib.rs
@@ -12,3 +12,4 @@ pub mod llap;
 pub mod nbp;
 pub mod pap;
 pub mod rtmp;
+pub mod zip;

--- a/tailtalk-packets/src/zip.rs
+++ b/tailtalk-packets/src/zip.rs
@@ -1,0 +1,423 @@
+//! Zone Information Protocol (ZIP) GetNetInfo request/reply.
+//!
+//! ZIP is how an AppleTalk node discovers which zone it belongs to. A node that
+//! has just acquired its DDP node address broadcasts a **GetNetInfo request**
+//! (ZIP op 5) to the local routers, including the zone name it currently
+//! believes it belongs to (kept in PRAM), or an empty name if it has none. A
+//! router answers with a **GetNetInfo reply** (ZIP op 6) carrying the cable's
+//! network number range, the zone's multicast address, and — if the requested
+//! zone was invalid — the cable's default zone name.
+//!
+//! ZIP rides on DDP protocol type 6 ([`crate::ddp::DdpProtocolType::Zip`]),
+//! delivered to socket 6 ([`ZIP_SOCKET`]) on both ends. This module parses and
+//! builds the ZIP payload only, starting at the ZIP operation byte; the DDP type
+//! byte lives in the DDP header, not here.
+//!
+//! Op codes, flag bits, and the wire layout mirror Netatalk's
+//! `include/atalk/zip.h` and `bin/getzones/getzones.c`.
+
+use thiserror::Error;
+
+/// ZIP is carried on DDP socket 6 (the ZIP socket) on both ends.
+pub const ZIP_SOCKET: u8 = 6;
+
+/// Maximum length of an AppleTalk zone name (`MAX_ZONE_LENGTH` in Netatalk).
+pub const MAX_ZONE_LENGTH: usize = 32;
+
+// ZIP operation codes (first byte of the ZIP payload); see ZIPOP_* in zip.h.
+const ZIPOP_GNI: u8 = 5;
+const ZIPOP_GNIREPLY: u8 = 6;
+const ZIPOP_NOTIFY: u8 = 7;
+
+/// GetNetInfo reply flag: the zone name the node supplied is no longer valid;
+/// the node should adopt [`GetNetInfoReply::default_zone`] instead.
+pub const ZIPGNI_INVALID: u8 = 0x80;
+/// GetNetInfo reply flag: the zone has no multicast address; use broadcast for
+/// zone-scoped delivery.
+pub const ZIPGNI_USE_BROADCAST: u8 = 0x40;
+/// GetNetInfo reply flag: this cable carries only a single zone.
+pub const ZIPGNI_ONE_ZONE: u8 = 0x20;
+
+#[derive(Error, Debug)]
+pub enum ZipError {
+    #[error("packet too short: expected at least {expected} bytes but found {found}")]
+    TooShort { expected: usize, found: usize },
+    #[error("unexpected ZIP operation {found}; expected {expected}")]
+    UnexpectedOp { expected: u8, found: u8 },
+    #[error("zone name is {length} bytes; the ZIP maximum is {MAX_ZONE_LENGTH}")]
+    ZoneTooLong { length: usize },
+    #[error("buffer too small: need {needed} bytes but only {available} available")]
+    BufferTooSmall { needed: usize, available: usize },
+}
+
+/// A ZIP GetNetInfo request (ZIP operation 5), sent node → routers.
+///
+/// The layout is: op (1) + five reserved zero bytes + a length-prefixed zone
+/// name. An empty `zone` means "I have no zone; give me the default".
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GetNetInfoRequest {
+    /// Zone name the node is asking the router to confirm; empty if it has none.
+    pub zone: String,
+}
+
+impl GetNetInfoRequest {
+    /// Minimum size: op (1) + 5 reserved zero bytes + zone length byte (1).
+    const MIN_LEN: usize = 7;
+
+    pub fn parse(buf: &[u8]) -> Result<Self, ZipError> {
+        if buf.len() < Self::MIN_LEN {
+            return Err(ZipError::TooShort {
+                expected: Self::MIN_LEN,
+                found: buf.len(),
+            });
+        }
+        if buf[0] != ZIPOP_GNI {
+            return Err(ZipError::UnexpectedOp {
+                expected: ZIPOP_GNI,
+                found: buf[0],
+            });
+        }
+        // buf[1..6] are five reserved bytes, always zero on the wire.
+        let (zone, _) = read_pstring(buf, 6)?;
+        Ok(Self { zone })
+    }
+
+    pub fn to_bytes(&self, buf: &mut [u8]) -> Result<usize, ZipError> {
+        let (zone_cow, _, _) = encoding_rs::MACINTOSH.encode(&self.zone);
+        if zone_cow.len() > MAX_ZONE_LENGTH {
+            return Err(ZipError::ZoneTooLong {
+                length: zone_cow.len(),
+            });
+        }
+        let needed = Self::MIN_LEN + zone_cow.len();
+        if buf.len() < needed {
+            return Err(ZipError::BufferTooSmall {
+                needed,
+                available: buf.len(),
+            });
+        }
+        buf[0] = ZIPOP_GNI;
+        buf[1..6].fill(0);
+        write_pbytes(buf, 6, &zone_cow);
+        Ok(needed)
+    }
+}
+
+/// A ZIP GetNetInfo reply (ZIP operation 6), sent router → node.
+///
+/// Layout: op (1) + flags (1) + network range start (2, big-endian) + network
+/// range end (2, big-endian) + length-prefixed echoed zone name +
+/// length-prefixed multicast address + optional length-prefixed default zone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GetNetInfoReply {
+    /// Flag bits; interpret via [`Self::zone_invalid`], [`Self::use_broadcast`],
+    /// and [`Self::one_zone`], or the `ZIPGNI_*` constants.
+    pub flags: u8,
+    /// First network number of the cable range (equals `range_end` on a
+    /// non-extended LocalTalk network).
+    pub range_start: u16,
+    /// Last network number of the cable range.
+    pub range_end: u16,
+    /// The zone name echoed back from the request.
+    pub zone: String,
+    /// Multicast (hardware) address for the zone; empty when the reply sets
+    /// [`ZIPGNI_USE_BROADCAST`] or the link has no multicast.
+    pub multicast: Vec<u8>,
+    /// Default zone name for the cable. Present (and adopted by the node) when
+    /// the requested zone was invalid.
+    pub default_zone: Option<String>,
+}
+
+impl GetNetInfoReply {
+    /// Minimum size: op (1) + flags (1) + range start (2) + range end (2) +
+    /// zone length byte (1).
+    const MIN_LEN: usize = 7;
+
+    /// The zone name the node supplied is invalid; it should adopt
+    /// [`Self::default_zone`].
+    pub fn zone_invalid(&self) -> bool {
+        self.flags & ZIPGNI_INVALID != 0
+    }
+
+    /// The zone has no multicast address; zone-scoped traffic must use broadcast.
+    pub fn use_broadcast(&self) -> bool {
+        self.flags & ZIPGNI_USE_BROADCAST != 0
+    }
+
+    /// This cable carries only a single zone.
+    pub fn one_zone(&self) -> bool {
+        self.flags & ZIPGNI_ONE_ZONE != 0
+    }
+
+    pub fn parse(buf: &[u8]) -> Result<Self, ZipError> {
+        if buf.len() < Self::MIN_LEN {
+            return Err(ZipError::TooShort {
+                expected: Self::MIN_LEN,
+                found: buf.len(),
+            });
+        }
+        if buf[0] != ZIPOP_GNIREPLY {
+            return Err(ZipError::UnexpectedOp {
+                expected: ZIPOP_GNIREPLY,
+                found: buf[0],
+            });
+        }
+        let flags = buf[1];
+        let range_start = u16::from_be_bytes([buf[2], buf[3]]);
+        let range_end = u16::from_be_bytes([buf[4], buf[5]]);
+
+        let mut offset = 6;
+        let (zone, consumed) = read_pstring(buf, offset)?;
+        offset += consumed;
+        let (multicast, consumed) = read_pbytes(buf, offset)?;
+        let multicast = multicast.to_vec();
+        offset += consumed;
+
+        // The default zone is only present when the router chose to send it
+        // (typically when the requested zone was invalid). A zero length byte,
+        // or no trailing bytes at all, both mean "no default zone".
+        let default_zone = if offset < buf.len() {
+            let (zone, _) = read_pstring(buf, offset)?;
+            (!zone.is_empty()).then_some(zone)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            flags,
+            range_start,
+            range_end,
+            zone,
+            multicast,
+            default_zone,
+        })
+    }
+
+    pub fn to_bytes(&self, buf: &mut [u8]) -> Result<usize, ZipError> {
+        let (zone, _, _) = encoding_rs::MACINTOSH.encode(&self.zone);
+        if zone.len() > MAX_ZONE_LENGTH {
+            return Err(ZipError::ZoneTooLong { length: zone.len() });
+        }
+        let default_zone = self
+            .default_zone
+            .as_ref()
+            .map(|z| encoding_rs::MACINTOSH.encode(z).0);
+        if let Some(default_zone) = &default_zone
+            && default_zone.len() > MAX_ZONE_LENGTH {
+                return Err(ZipError::ZoneTooLong {
+                    length: default_zone.len(),
+                });
+            }
+
+        let needed = 6
+            + (1 + zone.len())
+            + (1 + self.multicast.len())
+            + default_zone.as_ref().map_or(0, |z| 1 + z.len());
+        if buf.len() < needed {
+            return Err(ZipError::BufferTooSmall {
+                needed,
+                available: buf.len(),
+            });
+        }
+
+        buf[0] = ZIPOP_GNIREPLY;
+        buf[1] = self.flags;
+        buf[2..4].copy_from_slice(&self.range_start.to_be_bytes());
+        buf[4..6].copy_from_slice(&self.range_end.to_be_bytes());
+        let mut offset = 6;
+        offset += write_pbytes(buf, offset, &zone);
+        offset += write_pbytes(buf, offset, &self.multicast);
+        if let Some(default_zone) = &default_zone {
+            offset += write_pbytes(buf, offset, default_zone);
+        }
+        Ok(offset)
+    }
+}
+
+/// A ZIP Notify (ZIP operation 7), sent router → node when the zone information
+/// for the node's cable changes (e.g. a network renumber). The node should
+/// re-run GetNetInfo to refresh its zone.
+///
+/// The Notify body is intentionally not interpreted: the authoritative new zone
+/// comes from the follow-up GetNetInfo reply, so this is treated purely as a
+/// trigger (as Netatalk's `atalkd` does).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Notify {
+    /// Flag byte, carried but not interpreted.
+    pub flags: u8,
+}
+
+impl Notify {
+    pub fn parse(buf: &[u8]) -> Result<Self, ZipError> {
+        // op (1) + flags (1)
+        if buf.len() < 2 {
+            return Err(ZipError::TooShort {
+                expected: 2,
+                found: buf.len(),
+            });
+        }
+        if buf[0] != ZIPOP_NOTIFY {
+            return Err(ZipError::UnexpectedOp {
+                expected: ZIPOP_NOTIFY,
+                found: buf[0],
+            });
+        }
+        Ok(Self { flags: buf[1] })
+    }
+}
+
+/// Reads a length-prefixed byte string at `offset`: a single length byte
+/// followed by that many bytes. Returns the bytes and the total consumed
+/// (length byte included).
+fn read_pbytes(buf: &[u8], offset: usize) -> Result<(&[u8], usize), ZipError> {
+    let len = *buf.get(offset).ok_or(ZipError::TooShort {
+        expected: offset + 1,
+        found: buf.len(),
+    })? as usize;
+    let start = offset + 1;
+    let end = start + len;
+    let slice = buf.get(start..end).ok_or(ZipError::TooShort {
+        expected: end,
+        found: buf.len(),
+    })?;
+    Ok((slice, 1 + len))
+}
+
+/// Like [`read_pbytes`] but decodes the payload as a MacRoman zone name.
+fn read_pstring(buf: &[u8], offset: usize) -> Result<(String, usize), ZipError> {
+    let (bytes, consumed) = read_pbytes(buf, offset)?;
+    let (name, _, _) = encoding_rs::MACINTOSH.decode(bytes);
+    Ok((name.into_owned(), consumed))
+}
+
+/// Writes `data` as a length-prefixed byte string at `offset`. The caller must
+/// have ensured the buffer is large enough; returns bytes written.
+fn write_pbytes(buf: &mut [u8], offset: usize, data: &[u8]) -> usize {
+    buf[offset] = data.len() as u8;
+    buf[offset + 1..offset + 1 + data.len()].copy_from_slice(data);
+    1 + data.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A GetNetInfo request with an empty zone name, exactly as embedded in the
+    /// `ddp.rs` capture (op 5, five reserved zeros, zero-length zone).
+    #[test]
+    fn test_getnetinfo_request_empty_zone() {
+        const WIRE: &[u8] = &[0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+
+        let req = GetNetInfoRequest::parse(WIRE).expect("failed to parse GNI request");
+        assert_eq!(req.zone, "");
+
+        let mut buf = [0u8; WIRE.len()];
+        let n = req.to_bytes(&mut buf).expect("failed to encode");
+        assert_eq!(&buf[..n], WIRE);
+    }
+
+    #[test]
+    fn test_getnetinfo_request_named_zone() {
+        let req = GetNetInfoRequest {
+            zone: "Bandley3".into(),
+        };
+        let mut buf = [0u8; 64];
+        let n = req.to_bytes(&mut buf).expect("failed to encode");
+
+        // op + 5 zeros + len(8) + "Bandley3"
+        assert_eq!(buf[0], ZIPOP_GNI);
+        assert_eq!(&buf[1..6], &[0, 0, 0, 0, 0]);
+        assert_eq!(buf[6], 8);
+        assert_eq!(&buf[7..n], b"Bandley3");
+
+        let round = GetNetInfoRequest::parse(&buf[..n]).expect("failed to parse");
+        assert_eq!(round, req);
+    }
+
+    /// A non-extended LocalTalk reply: single zone "MyZone", net range 1–1, no
+    /// multicast, no default zone.
+    #[test]
+    fn test_getnetinfo_reply_localtalk() {
+        const WIRE: &[u8] = &[
+            0x06, // op = GetNetInfo reply
+            0x20, // flags = ZIPGNI_ONE_ZONE
+            0x00, 0x01, // range start = 1
+            0x00, 0x01, // range end = 1
+            0x06, b'M', b'y', b'Z', b'o', b'n', b'e', // zone "MyZone"
+            0x00, // multicast length = 0
+        ];
+
+        let reply = GetNetInfoReply::parse(WIRE).expect("failed to parse GNI reply");
+        assert_eq!(reply.flags, ZIPGNI_ONE_ZONE);
+        assert!(reply.one_zone());
+        assert!(!reply.zone_invalid());
+        assert_eq!(reply.range_start, 1);
+        assert_eq!(reply.range_end, 1);
+        assert_eq!(reply.zone, "MyZone");
+        assert!(reply.multicast.is_empty());
+        assert_eq!(reply.default_zone, None);
+
+        let mut buf = [0u8; 64];
+        let n = reply.to_bytes(&mut buf).expect("failed to encode");
+        assert_eq!(&buf[..n], WIRE);
+    }
+
+    /// An extended reply that invalidates the requested zone and hands back a
+    /// multicast address plus a default zone. Exercises every optional field.
+    #[test]
+    fn test_getnetinfo_reply_invalid_with_default() {
+        let reply = GetNetInfoReply {
+            flags: ZIPGNI_INVALID,
+            range_start: 3,
+            range_end: 5,
+            zone: "BogusZone".into(),
+            multicast: vec![0x09, 0x00, 0x07, 0xff, 0xff, 0xff],
+            default_zone: Some("Engineering".into()),
+        };
+
+        let mut buf = [0u8; 128];
+        let n = reply.to_bytes(&mut buf).expect("failed to encode");
+        let round = GetNetInfoReply::parse(&buf[..n]).expect("failed to parse");
+
+        assert_eq!(round, reply);
+        assert!(round.zone_invalid());
+        assert_eq!(round.multicast.len(), 6);
+        assert_eq!(round.default_zone.as_deref(), Some("Engineering"));
+    }
+
+    #[test]
+    fn test_notify_parse() {
+        let notify = Notify::parse(&[0x07, 0x00]).expect("failed to parse Notify");
+        assert_eq!(notify.flags, 0);
+        // Wrong op is rejected.
+        assert!(matches!(
+            Notify::parse(&[0x06, 0x00]),
+            Err(ZipError::UnexpectedOp { .. })
+        ));
+        // A GNI reply is not a Notify.
+        assert!(GetNetInfoReply::parse(&[0x07, 0x00]).is_err());
+    }
+
+    #[test]
+    fn test_wrong_op_is_rejected() {
+        // A GNI reply fed to the request parser (and vice versa) must fail.
+        let reply_bytes = &[0x06, 0x20, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00];
+        assert!(matches!(
+            GetNetInfoRequest::parse(reply_bytes),
+            Err(ZipError::UnexpectedOp {
+                expected: ZIPOP_GNI,
+                found: ZIPOP_GNIREPLY
+            })
+        ));
+    }
+
+    #[test]
+    fn test_truncated_zone_is_rejected() {
+        // Claims an 8-byte zone but only supplies 3.
+        let bytes = &[0x05, 0, 0, 0, 0, 0, 0x08, b'a', b'b', b'c'];
+        assert!(matches!(
+            GetNetInfoRequest::parse(bytes),
+            Err(ZipError::TooShort { .. })
+        ));
+    }
+}

--- a/tailtalk-proto/proto/tailtalk.proto
+++ b/tailtalk-proto/proto/tailtalk.proto
@@ -144,6 +144,13 @@ message SendDatagram {
   uint32 ddp_type = 5;
 }
 
+enum AddressSource {
+  ADDRESS_SOURCE_UNKNOWN = 0;
+  ADDRESS_SOURCE_ETHERTALK_PHASE_1 = 1;
+  ADDRESS_SOURCE_ETHERTALK_PHASE_2 = 2;
+  ADDRESS_SOURCE_LOCALTALK = 3;
+}
+
 // Daemon → client datagram, delivered for any open socket.
 message ReceivedDatagram {
   uint32 socket_id = 1; // the local socket this arrived on
@@ -154,6 +161,7 @@ message ReceivedDatagram {
   uint32 dest_socket = 5;
   uint32 ddp_type = 6;
   bytes payload = 7;
+  AddressSource arrival_link = 8;
 }
 
 // ── Routing rules ─────────────────────────────────────────────────────────────
@@ -162,6 +170,7 @@ message Route {
   CableRange range = 1;
   // Router on the local segment that forwards traffic for `range`.
   AppleTalkAddress next_hop = 2;
+  AddressSource interface = 3;
 }
 
 message Zone {

--- a/tailtalk/src/addressing.rs
+++ b/tailtalk/src/addressing.rs
@@ -49,7 +49,7 @@ pub struct Addressing {
     lt_ack_recv: mpsc::Receiver<u8>,
     lt_enq_recv: mpsc::Receiver<u8>,
     pending: HashMap<AppleTalkAddress, Vec<Arc<AarpRequest>>>,
-    cache: Arc<DashMap<AppleTalkAddress, Node>>,
+    cache: Arc<DashMap<AppleTalkAddress, CacheEntry>>,
     outbound: OutboundHandle,
     our_mac: Option<EthernetMac>,
     phase: AddressSource,
@@ -216,14 +216,31 @@ impl Addressing {
             addr
         } else {
             // EtherTalk: probe via AARP. Retry with a new random address on conflict.
+            //
+            // On Phase 2 (extended) networks the provisional address is drawn
+            // from the startup range $FF00–$FFFE, as Inside AppleTalk
+            // specifies: the cable's real network range is unknown until a
+            // router answers ZIP GetNetInfo, after which the ZIP actor
+            // re-acquires an address inside that range. On an isolated cable
+            // the startup address simply remains in use. Phase 1
+            // (nonextended) nodes address with network 0 until a router's
+            // RTMP broadcast supplies the real network number.
             'probe: loop {
-                let node_num = rand::rng().random_range(1..=254);
-                let addr = AppleTalkAddress {
-                    network_number: 1,
-                    node_number: node_num,
+                let addr = match self.phase {
+                    AddressSource::EtherTalkPhase2 => AppleTalkAddress {
+                        network_number: rand::rng().random_range(0xFF00..=0xFFFE),
+                        node_number: rand::rng().random_range(1..=253),
+                    },
+                    _ => AppleTalkAddress {
+                        network_number: 0,
+                        node_number: rand::rng().random_range(1..=254),
+                    },
                 };
 
-                tracing::info!("addressing: Selecting 1.{node_num} as our address");
+                tracing::info!(
+                    "addressing: Selecting {}.{} as our provisional address",
+                    addr.network_number, addr.node_number
+                );
 
                 let probe = self.create_packet(
                     addr,
@@ -241,13 +258,19 @@ impl Addressing {
                 loop {
                     tokio::select! {
                         _ = tokio::time::sleep_until(probe_deadline) => {
-                            tracing::info!("No response, address 1.{node_num} confirmed");
+                            tracing::info!(
+                                "No response, address {}.{} confirmed",
+                                addr.network_number, addr.node_number
+                            );
                             break 'probe addr;
                         }
                         pkt = self.packet_recv.recv() => {
                             if let Some((pkt, _source)) = pkt
                                 && pkt.opcode == AarpOpcode::Probe && pkt.target_protocol == addr {
-                                    tracing::warn!("Address conflict for 1.{node_num}, re-selecting");
+                                    tracing::warn!(
+                                        "Address conflict for {}.{}, re-selecting",
+                                        addr.network_number, addr.node_number
+                                    );
                                     continue 'probe;
                                 }
                         }
@@ -368,10 +391,12 @@ impl Addressing {
                             },
                         };
 
+                        // The requester may have timed out and dropped its
+                        // receiver; still cache the answer below.
                         if let Err(e) = inner_req.chan.send(Ok(node)) {
-                            tracing::error!("error responding to AarpRequest: {e:?}");
+                            tracing::debug!("AARP response arrived after requester gave up: {e:?}");
                         }
-                        self.cache.insert(pkt.sender_protocol, node);
+                        self.cache.insert(pkt.sender_protocol, CacheEntry::Valid(node));
                     }
                 }
             },
@@ -452,6 +477,12 @@ impl Addressing {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum CacheEntry {
+    Valid(Node),
+    Negative(tokio::time::Instant),
+}
+
 /// Handle to interface addressing.
 #[derive(Clone)]
 pub struct AddressingHandle {
@@ -467,7 +498,7 @@ enum AddressingInner {
         lt_ack_send: mpsc::Sender<u8>,
         lt_enq_send: mpsc::Sender<u8>,
         addr_watch: watch::Receiver<Option<AppleTalkAddress>>,
-        cache: Arc<DashMap<AppleTalkAddress, Node>>,
+        cache: Arc<DashMap<AppleTalkAddress, CacheEntry>>,
         _cancel: Arc<DropGuard>,
     },
     Remote {
@@ -511,7 +542,7 @@ impl AddressingHandle {
 
     pub fn learn(&self, addr: AppleTalkAddress, node: Node) {
         if let AddressingInner::Local { cache, .. } = &self.inner {
-            cache.insert(addr, node);
+            cache.insert(addr, CacheEntry::Valid(node));
         }
     }
 
@@ -538,9 +569,26 @@ impl AddressingHandle {
         }
 
         match &self.inner {
-            AddressingInner::Local { cache, .. } => cache.get(addr).map(|v| *v),
+            AddressingInner::Local { cache, .. } => {
+                if let Some(entry) = cache.get(addr) {
+                    match *entry {
+                        CacheEntry::Valid(node) => Some(node),
+                        CacheEntry::Negative(_) => None,
+                    }
+                } else {
+                    None
+                }
+            }
             // Link-layer resolution happens inside the daemon.
             AddressingInner::Remote { .. } => None,
+        }
+    }
+
+    fn get_cache_entry(&self, addr: &AppleTalkAddress) -> Option<CacheEntry> {
+        if let AddressingInner::Local { cache, .. } = &self.inner {
+            cache.get(addr).map(|v| *v)
+        } else {
+            None
         }
     }
 
@@ -548,6 +596,14 @@ impl AddressingHandle {
         if let Some(mac) = self.try_lookup(&addr) {
             return Ok(mac);
         }
+
+        if let Some(CacheEntry::Negative(expires_at)) = self.get_cache_entry(&addr)
+            && tokio::time::Instant::now() < expires_at {
+                return Err(Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "AARP negative cache hit",
+                ));
+            }
 
         let request_send = match &self.inner {
             AddressingInner::Local { request_send, .. } => request_send,
@@ -567,9 +623,25 @@ impl AddressingHandle {
             return Err(Error::other(e));
         }
 
-        match rx.await {
-            Ok(res) => res,
-            Err(e) => Err(Error::other(e)),
+        // A node that isn't on this cable never answers, and the pending
+        // request would otherwise wait forever — which would wedge callers
+        // like the DDP processor. Bound the wait; the stale pending entry is
+        // simply overwritten by any later lookup for the same address.
+        match tokio::time::timeout(Duration::from_secs(2), rx).await {
+            Ok(Ok(res)) => res,
+            Ok(Err(e)) => Err(Error::other(e)),
+            Err(_) => {
+                if let AddressingInner::Local { cache, .. } = &self.inner {
+                    cache.insert(addr, CacheEntry::Negative(tokio::time::Instant::now() + Duration::from_secs(60)));
+                }
+                Err(Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!(
+                        "AARP lookup for {}.{} timed out",
+                        addr.network_number, addr.node_number
+                    ),
+                ))
+            }
         }
     }
 
@@ -652,12 +724,77 @@ impl AddressingHandle {
             // AARP is not used on LocalTalk; address assignment uses LLAP ENQ/ACK instead.
             AddressSource::LocalTalk => return Ok(()),
         };
-        cache.insert(headers.sender_protocol, node);
+        cache.insert(headers.sender_protocol, CacheEntry::Valid(node));
 
         packet_send
             .try_send((headers, source))
             .map_err(Error::other)?;
 
         Ok(())
+    }
+
+    /// Move an EtherTalk interface's address inside `[lo..=hi]` if it isn't
+    /// already, probing candidates via AARP so we don't collide with a node that
+    /// already owns the address.
+    pub async fn acquire_in_range(&self, lo: u16, hi: u16) {
+        const MAX_CANDIDATES: usize = 8;
+        let cur = match self.addr().await {
+            Ok(cur) => cur,
+            Err(e) => {
+                tracing::warn!("addressing: could not read current address: {e}");
+                return;
+            }
+        };
+        if lo <= cur.network_number && cur.network_number <= hi {
+            return;
+        }
+
+        for _ in 0..MAX_CANDIDATES {
+            let candidate = AppleTalkAddress {
+                network_number: rand::rng().random_range(lo..=hi),
+                node_number: rand::rng().random_range(1..=253),
+            };
+            match self.probe(candidate).await {
+                Ok(true) => {
+                    match self.set_addr(candidate).await {
+                        Ok(()) => tracing::info!(
+                            "addressing: adopted EtherTalk address {}.{} inside cable range {lo}-{hi}",
+                            candidate.network_number,
+                            candidate.node_number,
+                        ),
+                        Err(e) => tracing::warn!("addressing: failed to adopt probed address: {e}"),
+                    }
+                    return;
+                }
+                Ok(false) => continue, // in use, next candidate
+                Err(e) => {
+                    tracing::warn!("addressing: address probe failed: {e}");
+                    return;
+                }
+            }
+        }
+        tracing::warn!(
+            "addressing: no free address found in cable range {lo}-{hi} after {MAX_CANDIDATES} probes; keeping {}.{}",
+            cur.network_number,
+            cur.node_number
+        );
+    }
+
+    /// Update the network number of the current address while keeping the node number.
+    /// Used when learning the real network number from a router.
+    pub async fn adopt_network_number(&self, net: u16) {
+        match self.addr().await {
+            Ok(cur) if cur.network_number != net => {
+                let new = AppleTalkAddress {
+                    network_number: net,
+                    node_number: cur.node_number,
+                };
+                if let Err(e) = self.set_addr(new).await {
+                    tracing::warn!("addressing: failed to adopt network number {net}: {e}");
+                }
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!("addressing: could not read current address: {e}"),
+        }
     }
 }

--- a/tailtalk/src/ddp.rs
+++ b/tailtalk/src/ddp.rs
@@ -16,12 +16,14 @@ use crate::{
     DataLinkPacket, DataLinkProtocol, OutboundHandle,
     addressing::{Addressing, AddressingHandle, Node},
     remote::RemoteClient,
-    route_table::{NextHop, RouteTable},
+    route_table::{Interface, NextHop, RouteTable},
 };
 
 pub struct Packet {
     pub headers: DdpHeaders,
     pub payload: Box<[u8]>,
+    /// Which link the packet arrived on. Now carried by the daemon proto as well.
+    pub source: AppleTalkAddressSource,
 }
 
 #[derive(Debug)]
@@ -205,6 +207,30 @@ pub struct DdpProcessor {
 }
 
 impl DdpProcessor {
+    async fn et_addr(&self) -> Result<AppleTalkAddress, Error> {
+        if let Some(et) = &self.et_addressing {
+            if let Some(watch) = et.addr_watch()
+                && let Some(addr) = *watch.borrow() {
+                    return Ok(addr);
+                }
+            et.addr().await
+        } else {
+            Err(Error::new(io::ErrorKind::NotFound, "no EtherTalk interface"))
+        }
+    }
+
+    async fn lt_addr(&self) -> Result<AppleTalkAddress, Error> {
+        if let Some(lt) = &self.lt_addressing {
+            if let Some(watch) = lt.addr_watch()
+                && let Some(addr) = *watch.borrow() {
+                    return Ok(addr);
+                }
+            lt.addr().await
+        } else {
+            Err(Error::new(io::ErrorKind::NotFound, "no LocalTalk interface"))
+        }
+    }
+
     pub fn spawn(
         et_addressing: Option<AddressingHandle>,
         lt_addressing: Option<AddressingHandle>,
@@ -323,13 +349,13 @@ impl DdpProcessor {
         };
         let is_for_us = packet.headers.dest_node_id == 255 || {
             let mut matched = false;
-            if let Some(et) = &self.et_addressing
-                && let Ok(our) = et.addr().await {
+            if self.et_addressing.is_some()
+                && let Ok(our) = self.et_addr().await {
                     matched |= our.matches(&dest, packet.source);
             }
             if !matched
-                && let Some(lt) = &self.lt_addressing
-                && let Ok(our) = lt.addr().await {
+                && self.lt_addressing.is_some()
+                && let Ok(our) = self.lt_addr().await {
                     matched |= our.matches(&dest, packet.source);
             }
             matched
@@ -345,6 +371,7 @@ impl DdpProcessor {
             match socket.try_send(Packet {
                 headers: packet.headers,
                 payload: packet.payload,
+                source: packet.source,
             }) {
                 Ok(_) => {}
                 Err(TrySendError::Closed(_)) => {
@@ -361,7 +388,13 @@ impl DdpProcessor {
 
     /// Hand an outbound packet addressed to ourselves straight to the target
     /// local socket, synthesizing the headers a wire reception would carry.
-    fn deliver_local(&mut self, packet: &OutboundPacket, our_addr: AppleTalkAddress) {
+    /// `source` is the link of the interface whose address matched.
+    fn deliver_local(
+        &mut self,
+        packet: &OutboundPacket,
+        our_addr: AppleTalkAddress,
+        source: AppleTalkAddressSource,
+    ) {
         let headers = DdpHeaders {
             hop_count: 0,
             len: packet.payload.len() + DdpHeaders::LEN,
@@ -379,6 +412,7 @@ impl DdpProcessor {
             match socket.try_send(Packet {
                 headers,
                 payload: packet.payload.clone(),
+                source,
             }) {
                 Ok(_) => {}
                 Err(TrySendError::Closed(_)) => {
@@ -398,14 +432,14 @@ impl DdpProcessor {
         // all nodes on each cable receive it, regardless of their network number.
         if packet.dest.addr.network_number == 0 && packet.dest.addr.node_number == 255 {
             let mut sent = false;
-            if let Some(et) = &self.et_addressing {
-                let et_addr = et.addr().await.unwrap();
+            if self.et_addressing.is_some() {
+                let et_addr = self.et_addr().await.unwrap();
                 let dest_node = Node::EtherTalkPhase2(Addressing::APPLETALK_BROADCAST_MULTICAST);
                 self.send_ddp_to_node(&packet, dest_node, et_addr).await;
                 sent = true;
             }
-            if let Some(lt) = &self.lt_addressing {
-                let lt_addr = lt.addr().await.unwrap();
+            if self.lt_addressing.is_some() {
+                let lt_addr = self.lt_addr().await.unwrap();
                 self.send_ddp_to_node(&packet, Node::LocalTalk(255), lt_addr).await;
                 sent = true;
             }
@@ -425,97 +459,140 @@ impl DdpProcessor {
         // rely on this, e.g. to reach an NBP responder on their own node.
         // Address {0,0} ("any net, any node") conventionally means the node
         // itself — the kernel AppleTalk stacks loop it back the same way.
+        // Network 0 acts as an "our net" wildcard only on links that natively
+        // address with network 0 (LocalTalk, Phase 1 EtherTalk); on Phase 2
+        // {0, N} names a node on such a cable, not us.
         let dest = packet.dest.addr;
         let to_self = dest.network_number == 0 && dest.node_number == 0;
         if let Some(et) = &self.et_addressing
-            && let Ok(our) = et.addr().await
+            && let Ok(our) = self.et_addr().await
             && (to_self
                 || (dest.node_number == our.node_number
-                    && (dest.network_number == our.network_number || dest.network_number == 0)))
+                    && (dest.network_number == our.network_number
+                        || (dest.network_number == 0
+                            && et.phase != AppleTalkAddressSource::EtherTalkPhase2))))
         {
-            self.deliver_local(&packet, our);
+            self.deliver_local(&packet, our, et.phase);
             return;
         }
-        if let Some(lt) = &self.lt_addressing
-            && let Ok(our) = lt.addr().await
+        if self.lt_addressing.is_some()
+            && let Ok(our) = self.lt_addr().await
             && (to_self
                 || (dest.node_number == our.node_number
                     && (dest.network_number == our.network_number || dest.network_number == 0)))
         {
-            self.deliver_local(&packet, our);
+            self.deliver_local(&packet, our, AppleTalkAddressSource::LocalTalk);
             return;
         }
 
         // Routing happens here, not in the caller: first resolve the
         // link-level next hop (the destination itself when it is on one of
         // our cables or unknown, otherwise the responsible router from the
-        // route table), then pick whichever interface reaches that hop.
-        let hop = if dest.network_number == 0 {
+        // route table), then pick the interface that reaches that hop. The
+        // route table remembers which cable dynamic routes and local ranges
+        // belong to; programmatic entries carry no tag, so the fallback
+        // guesses from the address shape and what is configured.
+        let (hop, route_iface) = if dest.network_number == 0 {
             // Network 0 is by definition on the local cable.
-            dest
+            (dest, None)
         } else {
-            match self.route_table.route_for(dest.network_number) {
-                Some(NextHop::Via(router)) => router,
+            match self.route_table.resolve(dest.network_number) {
+                Some(NextHop::Via { router, interface }) => (router, Some(interface)),
                 // On our cable range, or no route known: try it directly.
-                Some(NextHop::Local) | None => dest,
+                Some(NextHop::Local(interface)) => (dest, Some(interface)),
+                None => (dest, None),
             }
         };
 
-        let dest_node = if hop.network_number == 0 {
-            // Network 0 is ambiguous between LocalTalk and nonextended
-            // (Phase 1) EtherTalk. With only one of the two configured,
-            // there's nothing to disambiguate — it must be that one. With
-            // both configured, check whether this node has actually been
-            // learned as an EtherTalk Phase 1 peer (e.g. from a packet it
-            // sent us); only fall back to LocalTalk if it hasn't.
-            match (&self.lt_addressing, &self.et_addressing) {
-                (Some(_), None) => Node::LocalTalk(hop.node_number),
-                (None, Some(et)) => match et.try_lookup(&hop) {
-                    Some(node) => node,
-                    None => {
+        let dest_node = match route_iface {
+            Some(Interface::LocalTalk) if self.lt_addressing.is_some() => {
+                Node::LocalTalk(hop.node_number)
+            }
+            Some(Interface::EtherTalk) if self.et_addressing.is_some() => {
+                match self.et_addressing.as_ref().unwrap().lookup(hop).await {
+                    Ok(node) => node,
+                    Err(e) => {
                         tracing::error!(
-                            "DDP: dropping packet to {}.{} — next hop {}.{} is on network 0 but no EtherTalk Phase 1 binding is cached for it",
+                            "DDP: dropping packet to {}.{} — AARP lookup for next hop {}.{} failed: {e}",
                             dest.network_number, dest.node_number,
                             hop.network_number, hop.node_number,
                         );
                         return;
                     }
-                },
-                (Some(_), Some(et)) => et.try_lookup(&hop).unwrap_or(Node::LocalTalk(hop.node_number)),
-                (None, None) => {
-                    tracing::error!(
-                        "DDP: dropping packet to {}.{} — next hop {}.{} is on network 0, but no interfaces are configured",
-                        dest.network_number, dest.node_number,
-                        hop.network_number, hop.node_number,
-                    );
-                    return;
                 }
             }
-        } else {
-            let Some(et) = &self.et_addressing else {
-                tracing::error!(
-                    "DDP: dropping packet to {}.{} — next hop {}.{} needs EtherTalk, which is not configured",
-                    dest.network_number, dest.node_number,
-                    hop.network_number, hop.node_number,
-                );
-                return;
-            };
-            match et.lookup(hop).await {
-                Ok(node) => node,
-                Err(e) => {
-                    tracing::error!(
-                        "DDP: dropping packet to {}.{} — AARP lookup for next hop {}.{} failed: {e}",
-                        dest.network_number, dest.node_number,
-                        hop.network_number, hop.node_number,
-                    );
-                    return;
+            // No (usable) interface recorded for this hop — fall back on the
+            // address shape and the configured interfaces.
+            _ if hop.network_number == 0 => {
+                // Network 0 is ambiguous between LocalTalk and nonextended
+                // (Phase 1) EtherTalk. With only one of the two configured,
+                // there's nothing to disambiguate — it must be that one. With
+                // both configured, check whether this node has actually been
+                // learned as an EtherTalk Phase 1 peer (e.g. from a packet it
+                // sent us); only fall back to LocalTalk if it hasn't.
+                match (&self.lt_addressing, &self.et_addressing) {
+                    (Some(_), None) => Node::LocalTalk(hop.node_number),
+                    (None, Some(et)) => match et.try_lookup(&hop) {
+                        Some(node) => node,
+                        None => {
+                            tracing::error!(
+                                "DDP: dropping packet to {}.{} — next hop {}.{} is on network 0 but no EtherTalk Phase 1 binding is cached for it",
+                                dest.network_number, dest.node_number,
+                                hop.network_number, hop.node_number,
+                            );
+                            return;
+                        }
+                    },
+                    (Some(_), Some(et)) => et.try_lookup(&hop).unwrap_or(Node::LocalTalk(hop.node_number)),
+                    (None, None) => {
+                        tracing::error!(
+                            "DDP: dropping packet to {}.{} — next hop {}.{} is on network 0, but no interfaces are configured",
+                            dest.network_number, dest.node_number,
+                            hop.network_number, hop.node_number,
+                        );
+                        return;
+                    }
+                }
+            }
+            _ => {
+                // Nonzero network, unknown cable: on a single-interface stack
+                // the hop can only be on that interface. With both, try AARP
+                // on EtherTalk first and treat silence as "must be the
+                // LocalTalk cable".
+                match (&self.lt_addressing, &self.et_addressing) {
+                    (Some(_), None) => Node::LocalTalk(hop.node_number),
+                    (None, Some(et)) | (Some(_), Some(et)) => match et.lookup(hop).await {
+                        Ok(node) => node,
+                        Err(e) if self.lt_addressing.is_some() => {
+                            tracing::debug!(
+                                "DDP: AARP found nothing for next hop {}.{} ({e}); assuming it is on the LocalTalk cable",
+                                hop.network_number, hop.node_number,
+                            );
+                            Node::LocalTalk(hop.node_number)
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "DDP: dropping packet to {}.{} — AARP lookup for next hop {}.{} failed: {e}",
+                                dest.network_number, dest.node_number,
+                                hop.network_number, hop.node_number,
+                            );
+                            return;
+                        }
+                    },
+                    (None, None) => {
+                        tracing::error!(
+                            "DDP: dropping packet to {}.{} — no interfaces are configured",
+                            dest.network_number, dest.node_number,
+                        );
+                        return;
+                    }
                 }
             }
         };
 
         let our_addr = match &dest_node {
-            Node::LocalTalk(_) => self.lt_addressing.as_ref().unwrap().addr().await.unwrap(),
-            _ => self.et_addressing.as_ref().unwrap().addr().await.unwrap(),
+            Node::LocalTalk(_) => self.lt_addr().await.unwrap(),
+            _ => self.et_addr().await.unwrap(),
         };
 
         self.send_ddp_to_node(&packet, dest_node, our_addr).await;

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -28,6 +28,7 @@ pub mod remote;
 pub mod route_table;
 pub mod rtmp;
 pub mod stylewriter;
+pub mod zip;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum DataLinkProtocol {
@@ -451,7 +452,6 @@ impl PacketProcessor {
                                                     addressing_handle.received_llap_ack(llap.src_node);
                                                 }
                                                 LlapType::DdpLong => {
-                                                    tracing::info!("TashTalk: LocalTalk DDP Long");
                                                     if let Ok(headers) = DdpPacket::parse(&data[3..]) {
                                                         let end = (3 + headers.len).min(data.len());
                                                         let payload =
@@ -688,6 +688,10 @@ pub struct TalkStack {
     pub ddp: ddp::DdpHandle,
     pub nbp: nbp::NbpHandle,
     pub echo: echo::EchoHandle,
+    /// Handle to the resident ZIP client, for forcing a zone re-discovery.
+    /// `None` with a remote daemon (which runs its own) or when router
+    /// discovery is disabled.
+    pub zip: Option<zip::ZipHandle>,
     /// Shared routing table. Call `insert_route` / `insert_zone` on this to
     /// program static routes before or after the stack is running.
     pub route_table: route_table::RouteTable,
@@ -823,6 +827,8 @@ pub struct Underlay {
     pub lt_addressing: Option<addressing::AddressingHandle>,
     pub ddp: ddp::DdpHandle,
     pub route_table: route_table::RouteTable,
+    /// Handle to the ZIP actor; `None` when router discovery is disabled.
+    pub zip: Option<zip::ZipHandle>,
     /// Cancel to stop the transport (PacketProcessor).
     pub transport_token: CancellationToken,
 }
@@ -844,6 +850,8 @@ pub struct TalkStackBuilder {
     lt_fixed_node: Option<u8>,
     pcap_path: Option<PathBuf>,
     daemon: Option<remote::DaemonEndpoint>,
+    router_discovery: bool,
+    zone_cache: Option<PathBuf>,
 }
 
 impl TalkStack {
@@ -858,6 +866,8 @@ impl TalkStack {
             lt_fixed_node: None,
             pcap_path: None,
             daemon: None,
+            router_discovery: true,
+            zone_cache: None,
         }
     }
 }
@@ -892,9 +902,28 @@ impl TalkStackBuilder {
 
     /// Use a fixed AppleTalk node on LocalTalk instead of probing via LLAP ENQ.
     ///
-    /// The network number is always 0 on LocalTalk and cannot be configured.
+    /// The network number starts as 0 on LocalTalk; a router's RTMP/ZIP
+    /// advertisements may later supply the cable's real network number.
     pub fn localtalk_fixed_address(mut self, node: u8) -> Self {
         self.lt_fixed_node = Some(node);
+        self
+    }
+
+    /// Disable the resident RTMP listener and ZIP client.
+    ///
+    /// These own DDP sockets 1 and 6 and adapt addressing/routing to router
+    /// advertisements. Disable them when an external router engine (e.g.
+    /// netatalk's `atalkd` driving a TailTalk daemon) needs those sockets and
+    /// manages routes itself.
+    pub fn disable_router_discovery(mut self) -> Self {
+        self.router_discovery = false;
+        self
+    }
+
+    /// Persist the learned zone name to this file (PRAM-style), so the next
+    /// startup can ask the router to re-confirm it.
+    pub fn zone_cache(mut self, path: impl Into<PathBuf>) -> Self {
+        self.zone_cache = Some(path.into());
         self
     }
 
@@ -992,7 +1021,6 @@ impl TalkStackBuilder {
 
         let route_table = route_table::RouteTable::new(route_table::LearningMode::Dynamic);
         let ddp = ddp::DdpProcessor::spawn(et_addressing.clone(), lt_addressing.clone(), outbound, route_table.clone());
-        rtmp::Rtmp::spawn(&ddp, route_table.clone()).await;
 
         let transport_token = CancellationToken::new();
         tokio::spawn(processor.run(et_addressing.clone(), lt_addressing.clone(), ddp.clone(), transport_token.clone()));
@@ -1005,7 +1033,25 @@ impl TalkStackBuilder {
             lt.addr().await?;
         }
 
-        Ok(Underlay { et_addressing, lt_addressing, ddp, route_table, transport_token })
+        // Router discovery starts only after addressing has settled: ZIP's
+        // initial GetNetInfo broadcast needs a source address, and the RTMP
+        // listener may adopt gleaned network numbers on top of it.
+        let zip = if self.router_discovery {
+            let zip = zip::Zip::spawn(
+                &ddp,
+                et_addressing.clone(),
+                lt_addressing.clone(),
+                route_table.clone(),
+                self.zone_cache.clone(),
+            )
+            .await;
+            rtmp::Rtmp::spawn(&ddp, route_table.clone(), lt_addressing.clone(), Some(zip.clone())).await;
+            Some(zip)
+        } else {
+            None
+        };
+
+        Ok(Underlay { et_addressing, lt_addressing, ddp, route_table, zip, transport_token })
     }
 
     /// Launch the full AppleTalk stack and return handles to each layer.
@@ -1019,7 +1065,7 @@ impl TalkStackBuilder {
             return self.build_remote(endpoint).await;
         }
 
-        let Underlay { et_addressing, lt_addressing, ddp, route_table, transport_token } =
+        let Underlay { et_addressing, lt_addressing, ddp, route_table, zip, transport_token } =
             self.build_underlay().await?;
 
         let echo = echo::Echo::spawn(&ddp).await;
@@ -1028,7 +1074,7 @@ impl TalkStackBuilder {
         let service_token = CancellationToken::new();
         let services_done = CancellationToken::new();
 
-        Ok(TalkStack { et_addressing, lt_addressing, ddp, nbp, echo, route_table, service_token, transport_token, services_done })
+        Ok(TalkStack { et_addressing, lt_addressing, ddp, nbp, echo, zip, route_table, service_token, transport_token, services_done })
     }
 
     /// Build the stack on top of a remote daemon's underlay.
@@ -1108,7 +1154,7 @@ impl TalkStackBuilder {
             });
         }
 
-        Ok(TalkStack { et_addressing, lt_addressing, ddp, nbp, echo, route_table, service_token, transport_token, services_done })
+        Ok(TalkStack { et_addressing, lt_addressing, ddp, nbp, echo, zip: None, route_table, service_token, transport_token, services_done })
     }
 }
 

--- a/tailtalk/src/nbp.rs
+++ b/tailtalk/src/nbp.rs
@@ -1,13 +1,13 @@
 use crate::{
     addressing::AddressingHandle,
     ddp::{DdpHandle, DdpSocket},
-    route_table::{NbpDispatch, NbpZone, RouteTable},
+    route_table::{Interface, NbpDispatch, NbpZone, RouteTable},
 };
 use std::collections::HashMap;
 use std::io;
 use std::time::Duration;
 use tailtalk_packets::{
-    aarp::AppleTalkAddress,
+    aarp::{AddressSource, AppleTalkAddress},
     ddp::{DdpPacket, DdpProtocolType},
     nbp::{EntityName, NbpOperation, NbpPacket, NbpTuple},
 };
@@ -100,7 +100,7 @@ impl Nbp {
                 sock_recv = self.sock.recv() => {
                     match sock_recv {
                         Ok(mut pkt) => {
-                            self.handle_packet(pkt.headers, &mut pkt.payload).await;
+                            self.handle_packet(pkt.headers, &mut pkt.payload, pkt.source).await;
                         },
                         Err(_e) => {
 
@@ -120,23 +120,33 @@ impl Nbp {
                                 let tid = self.next_tid;
                                 self.next_tid = self.next_tid.wrapping_add(1);
 
-                                // Use the primary address (ET if available, else LT) in the lookup tuple.
-                                let primary_addr = if let Some(et) = &self.et_addressing {
-                                    et.addr().await.expect("failed to get ET addr")
-                                } else {
-                                    self.lt_addressing.as_ref().expect("no addressing").addr().await.expect("failed to get LT addr")
+                                // Derive dispatch strategy from the zone in the entity name.
+                                // "*" is the local zone, not just the local cable: with a
+                                // router present it needs a BrRq to the router (which forwards
+                                // the lookup onto other cables, like the far side of a bridge),
+                                // falling back to a local broadcast only when there is none.
+                                // That is exactly the "=" (all zones) dispatch; the two differ
+                                // only in the zone carried in the request, which stays intact.
+                                let dispatch = match lookup.request.zone.as_str() {
+                                    "*" | "=" => self.route_table.nbp_dispatch(NbpZone::All),
+                                    z => self.route_table.nbp_dispatch(NbpZone::Named(z)),
                                 };
 
-                                // Derive dispatch strategy from the zone in the entity name.
-                                let dispatch = match lookup.request.zone.as_str() {
-                                    "*" => self.route_table.nbp_dispatch(NbpZone::Local),
-                                    "=" => self.route_table.nbp_dispatch(NbpZone::All),
-                                    z   => self.route_table.nbp_dispatch(NbpZone::Named(z)),
+                                // The reply address we advertise in the tuple: when
+                                // asking a router, use our address on that router's
+                                // cable so replies forwarded from other networks can
+                                // route back; otherwise the primary address.
+                                let reply_iface = match &dispatch {
+                                    NbpDispatch::RouterBroadcast(routers) => routers
+                                        .first()
+                                        .and_then(|r| self.route_table.interface_for_net(r.network_number)),
+                                    _ => None,
                                 };
+                                let our_addr = self.addr_on(reply_iface).await;
 
                                 let tuple = NbpTuple {
-                                    network_number: primary_addr.network_number,
-                                    node_id: primary_addr.node_number,
+                                    network_number: our_addr.network_number,
+                                    node_id: our_addr.node_number,
                                     socket_number: 2,
                                     enumerator: 0,
                                     entity_name: lookup.request,
@@ -146,7 +156,10 @@ impl Nbp {
                                 let send_result = match dispatch {
                                     NbpDispatch::RouterBroadcast(routers) => {
                                         // A router is known (via RTMP): send BrRq directly
-                                        // to it rather than broadcasting locally.
+                                        // to it rather than broadcasting locally. Any single
+                                        // router ("A-ROUTER") handles the whole request, so
+                                        // stop at the first successful send — asking several
+                                        // would only duplicate every reply.
                                         let packet = NbpPacket {
                                             operation: NbpOperation::BroadcastRequest,
                                             transaction_id: tid,
@@ -154,26 +167,24 @@ impl Nbp {
                                         };
                                         let size = packet.to_bytes(&mut buf).expect("failed to serialize");
 
-                                        let mut any_ok = false;
-                                        let mut last_err = None;
+                                        let mut result = Err(io::Error::other("no routers to send BrRq to"));
                                         for router in routers {
                                             let dest = crate::ddp::DdpAddress::new(router, 2);
                                             match self.sock.send_to(&buf[..size], dest).await {
-                                                Ok(()) => any_ok = true,
+                                                Ok(()) => {
+                                                    result = Ok(());
+                                                    break;
+                                                }
                                                 Err(e) => {
                                                     tracing::warn!(
                                                         "NBP BrRq: failed to send to {}.{}: {e}",
                                                         router.network_number, router.node_number,
                                                     );
-                                                    last_err = Some(e);
+                                                    result = Err(e);
                                                 }
                                             }
                                         }
-                                        if any_ok {
-                                            Ok(())
-                                        } else {
-                                            Err(last_err.unwrap_or_else(|| io::Error::other("no routers to send BrRq to")))
-                                        }
+                                        result
                                     }
                                     NbpDispatch::LocalBroadcast | NbpDispatch::ZoneUnknown => {
                                         let packet = NbpPacket {
@@ -277,7 +288,31 @@ impl Nbp {
         }
     }
 
-    async fn handle_packet(&mut self, ddp: DdpPacket, payload: &mut [u8]) {
+    /// Our address on the given interface, falling back to the primary
+    /// address (ET if available, else LT) when unspecified or unconfigured.
+    async fn addr_on(&self, iface: Option<Interface>) -> AppleTalkAddress {
+        let handle = match iface {
+            Some(Interface::LocalTalk) if self.lt_addressing.is_some() => {
+                self.lt_addressing.as_ref()
+            }
+            Some(Interface::EtherTalk) if self.et_addressing.is_some() => {
+                self.et_addressing.as_ref()
+            }
+            _ => self.et_addressing.as_ref().or(self.lt_addressing.as_ref()),
+        };
+        handle
+            .expect("no addressing configured")
+            .addr()
+            .await
+            .expect("failed to get interface address")
+    }
+
+    async fn handle_packet(
+        &mut self,
+        ddp: DdpPacket,
+        payload: &mut [u8],
+        source: AddressSource,
+    ) {
         let packet = match NbpPacket::from_bytes(payload) {
             Ok(pkt) => pkt,
             Err(e) => {
@@ -288,7 +323,9 @@ impl Nbp {
 
         match packet.operation {
             NbpOperation::Lookup => {
-                let response = self.generate_response(&packet, ddp.src_network_num, ddp.src_node_id).await;
+                let response = self
+                    .generate_response(&packet, ddp.src_network_num, ddp.src_node_id, source)
+                    .await;
 
                 // Only send a reply if we have at least one matching tuple
                 if !response.tuples.is_empty() {
@@ -346,32 +383,14 @@ impl Nbp {
         }
     }
 
-    async fn generate_response(&self, nbp: &NbpPacket, source_network: u16, source_node: u8) -> NbpPacket {
-        // Respond with the address on the same interface the lookup arrived from.
-        let our_addr = if source_network == 0 {
-            // Network 0 is ambiguous between LocalTalk and nonextended
-            // EtherTalk (Phase 1). With only one interface configured, it
-            // must be that one. With both, check whether the requester has
-            // been learned as an EtherTalk Phase 1 peer before assuming
-            // LocalTalk.
-            match (&self.lt_addressing, &self.et_addressing) {
-                (Some(lt), None) => lt.addr().await.expect("failed to get LT addr"),
-                (None, Some(et)) => et.addr().await.expect("failed to get ET addr"),
-                (Some(lt), Some(et)) => {
-                    let peer = AppleTalkAddress { network_number: 0, node_number: source_node };
-                    if et.try_lookup(&peer).is_some() {
-                        et.addr().await.expect("failed to get ET addr")
-                    } else {
-                        lt.addr().await.expect("failed to get LT addr")
-                    }
-                }
-                (None, None) => panic!("no addressing configured"),
-            }
-        } else if let Some(et) = &self.et_addressing {
-            et.addr().await.expect("failed to get ET addr")
-        } else {
-            self.lt_addressing.as_ref().expect("no addressing").addr().await.expect("failed to get LT addr")
-        };
+    async fn generate_response(
+        &self,
+        nbp: &NbpPacket,
+        _source_network: u16,
+        _source_node: u8,
+        source: AddressSource,
+    ) -> NbpPacket {
+        let our_addr = self.addr_on(Some(Interface::from(source))).await;
 
         let mut tuples = Vec::new();
 

--- a/tailtalk/src/remote.rs
+++ b/tailtalk/src/remote.rs
@@ -289,7 +289,7 @@ impl RemoteClient {
                     range: Some(proto::CableRange { lo: *lo as u32, hi: *hi as u32 }),
                 })
             }
-            RouteChange::InsertRoute { lo, hi, next_hop } => {
+            RouteChange::InsertRoute { lo, hi, next_hop, interface } => {
                 proto::request::Kind::AddRoute(proto::AddRouteRequest {
                     route: Some(proto::Route {
                         range: Some(proto::CableRange { lo: *lo as u32, hi: *hi as u32 }),
@@ -297,6 +297,11 @@ impl RemoteClient {
                             next_hop.network_number,
                             next_hop.node_number,
                         )),
+                        interface: match interface {
+                            Some(crate::route_table::Interface::EtherTalk) => 2, // EtherTalkPhase2 by default for daemon
+                            Some(crate::route_table::Interface::LocalTalk) => 3,
+                            None => 0,
+                        },
                     }),
                 })
             }
@@ -352,6 +357,12 @@ fn dispatch(shared: &Shared, msg: proto::ServerMessage) {
             let packet = Packet {
                 headers,
                 payload: dg.payload.into_boxed_slice(),
+                source: match dg.arrival_link {
+                    1 => tailtalk_packets::aarp::AddressSource::EtherTalkPhase1,
+                    2 => tailtalk_packets::aarp::AddressSource::EtherTalkPhase2,
+                    3 => tailtalk_packets::aarp::AddressSource::LocalTalk,
+                    _ => tailtalk_packets::aarp::AddressSource::EtherTalkPhase2, // default fallback
+                },
             };
             let sockets = shared.sockets.lock().unwrap();
             if let Some(tx) = sockets.get(&socket_id)
@@ -385,6 +396,11 @@ pub(crate) fn snapshot_from_proto(
             .filter_map(|route| {
                 let range = route.range.as_ref()?;
                 let next_hop = route.next_hop.as_ref()?;
+                let interface = match route.interface {
+                    1 | 2 => Some(crate::route_table::Interface::EtherTalk),
+                    3 => Some(crate::route_table::Interface::LocalTalk),
+                    _ => None,
+                };
                 Some((
                     range.lo as u16,
                     range.hi as u16,
@@ -392,6 +408,7 @@ pub(crate) fn snapshot_from_proto(
                         network_number: next_hop.network as u16,
                         node_number: next_hop.node as u8,
                     },
+                    interface,
                 ))
             })
             .collect(),

--- a/tailtalk/src/route_table.rs
+++ b/tailtalk/src/route_table.rs
@@ -1,6 +1,15 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
-use tailtalk_packets::aarp::AppleTalkAddress;
+use std::time::{Duration, Instant};
+use tailtalk_packets::aarp::{AddressSource, AppleTalkAddress};
+
+/// How long an RTMP-learned route stays valid without being re-advertised.
+///
+/// Routers broadcast their table every ~10 seconds; Inside AppleTalk has
+/// nodes discard entries after roughly a minute without refresh. Expiry is
+/// what lets [`RouteTable::has_router`] fall back to `false` (resuming
+/// short-form DDP and local NBP broadcast) when the router disappears.
+const RTMP_ROUTE_TTL: Duration = Duration::from_secs(60);
 
 #[derive(Debug)]
 pub enum LearningMode {
@@ -10,13 +19,38 @@ pub enum LearningMode {
     Static,
 }
 
+/// Which physical interface (cable) an address, route, or local range belongs
+/// to. Phase 1 and Phase 2 EtherTalk share a cable, so they map to one variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Interface {
+    EtherTalk,
+    LocalTalk,
+}
+
+impl From<AddressSource> for Interface {
+    fn from(src: AddressSource) -> Self {
+        match src {
+            AddressSource::LocalTalk => Interface::LocalTalk,
+            AddressSource::EtherTalkPhase1 | AddressSource::EtherTalkPhase2 => {
+                Interface::EtherTalk
+            }
+        }
+    }
+}
+
 /// Where to send a DDP packet for a given destination network.
+///
+/// Every route (whether dynamically learned or programmatically inserted)
+/// must be explicitly bound to the `Interface` it can be reached on.
 #[derive(Debug, PartialEq, Eq)]
 pub enum NextHop {
-    /// Destination is on our cable; resolve with AARP and send directly.
-    Local,
+    /// Destination is on our cable; resolve on the link and send directly.
+    Local(Interface),
     /// Forward to this router.
-    Via(AppleTalkAddress),
+    Via {
+        router: AppleTalkAddress,
+        interface: Interface,
+    },
 }
 
 /// Zone portion of an NBP name.
@@ -49,9 +83,40 @@ pub enum NbpDispatch {
 struct RtmpEntry {
     range_lo: u16,
     range_hi: u16,
-    #[allow(dead_code)] // retained for future route-age / best-path selection
+    #[allow(dead_code)] // retained for future best-path selection
     hop_count: u8,
     next_hop: AppleTalkAddress,
+    /// Cable the route was learned on. Must be known.
+    interface: Interface,
+    /// When the entry stops being served; `None` for programmatic entries,
+    /// which never expire.
+    expires_at: Option<Instant>,
+}
+
+impl RtmpEntry {
+    fn expired(&self, now: Instant) -> bool {
+        self.expires_at.is_some_and(|at| now >= at)
+    }
+}
+
+/// A router heard advertising on a cable, used as the endpoint "A-Router":
+/// the next hop for any destination with no more-specific route.
+///
+/// Per Inside AppleTalk a non-router node needs no routing table — it forwards
+/// every off-cable packet to a router it has heard and lets the router do the
+/// work. That is the only way to reach nodes behind a LocalTalk–EtherTalk
+/// bridge like AsanteTalk, which announces itself in the RTMP header but sends
+/// no route tuples. Lowest priority: local ranges and specific routes win.
+struct DefaultRouter {
+    addr: AppleTalkAddress,
+    interface: Interface,
+    expires_at: Option<Instant>,
+}
+
+impl DefaultRouter {
+    fn expired(&self, now: Instant) -> bool {
+        self.expires_at.is_some_and(|at| now >= at)
+    }
 }
 
 /// Sorted, non-overlapping list of cable range → next-hop mappings.
@@ -64,35 +129,60 @@ impl RtmpTable {
         Self { entries: Vec::new() }
     }
 
-    /// O(log n) lookup: find the entry whose range contains `net`.
-    fn lookup(&self, net: u16) -> Option<&RtmpEntry> {
+    /// O(log n) lookup: find the live entry whose range contains `net`.
+    fn lookup(&self, net: u16, now: Instant) -> Option<&RtmpEntry> {
         let idx = self.entries.partition_point(|e| e.range_lo <= net);
         let idx = idx.checked_sub(1)?;
         let e = &self.entries[idx];
-        (net <= e.range_hi).then_some(e)
+        (net <= e.range_hi && !e.expired(now)).then_some(e)
     }
 
-    /// Insert or replace a route covering [lo..=hi].
+    /// Insert or replace a route covering [lo..=hi]. Returns `true` when the
+    /// route is new or its next hop changed (as opposed to a pure refresh).
     ///
     /// Any existing entry that overlaps is removed wholesale — not trimmed.
     /// RTMP cable ranges are non-overlapping by protocol, so partial overlaps
     /// shouldn't arise in practice.
-    fn insert(&mut self, lo: u16, hi: u16, next_hop: AppleTalkAddress, hop_count: u8) {
+    fn insert(
+        &mut self,
+        lo: u16,
+        hi: u16,
+        next_hop: AppleTalkAddress,
+        hop_count: u8,
+        interface: Interface,
+        expires_at: Option<Instant>,
+    ) -> bool {
+        let refresh = self
+            .entries
+            .iter()
+            .any(|e| e.range_lo == lo && e.range_hi == hi && e.next_hop == next_hop);
         self.entries.retain(|e| e.range_hi < lo || e.range_lo > hi);
         let pos = self.entries.partition_point(|e| e.range_lo < lo);
-        self.entries.insert(pos, RtmpEntry { range_lo: lo, range_hi: hi, hop_count, next_hop });
+        self.entries.insert(
+            pos,
+            RtmpEntry { range_lo: lo, range_hi: hi, hop_count, next_hop, interface, expires_at },
+        );
+        !refresh
     }
 
     fn remove(&mut self, lo: u16, hi: u16) {
         self.entries.retain(|e| !(e.range_lo == lo && e.range_hi == hi));
     }
 
-    fn all_next_hops_deduped(&self) -> Vec<AppleTalkAddress> {
+    fn all_next_hops_deduped(&self, now: Instant) -> Vec<AppleTalkAddress> {
         let mut seen = HashSet::new();
         self.entries
             .iter()
+            .filter(|e| !e.expired(now))
             .filter_map(|e| seen.insert(e.next_hop).then_some(e.next_hop))
             .collect()
+    }
+
+    /// Drop expired entries; returns how many were removed.
+    fn purge_expired(&mut self, now: Instant) -> usize {
+        let before = self.entries.len();
+        self.entries.retain(|e| !e.expired(now));
+        before - self.entries.len()
     }
 }
 
@@ -149,7 +239,7 @@ impl ZipTable {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RouteChange {
     SetLocalRange(CableRange),
-    InsertRoute { lo: u16, hi: u16, next_hop: AppleTalkAddress },
+    InsertRoute { lo: u16, hi: u16, next_hop: AppleTalkAddress, interface: Option<Interface> },
     RemoveRoute { lo: u16, hi: u16 },
     InsertZone { zone: String, ranges: Vec<CableRange> },
     RemoveZone { zone: String },
@@ -159,18 +249,27 @@ pub enum RouteChange {
 #[derive(Debug, Clone, Default)]
 pub struct RouteSnapshot {
     pub local_range: Option<CableRange>,
-    /// `(range_lo, range_hi, next_hop)` for every RTMP entry.
-    pub routes: Vec<(u16, u16, AppleTalkAddress)>,
+    /// `(range_lo, range_hi, next_hop, interface)` for every RTMP entry.
+    pub routes: Vec<(u16, u16, AppleTalkAddress, Option<Interface>)>,
     /// `(zone name, cable ranges)` for every known zone.
     pub zones: Vec<(String, Vec<CableRange>)>,
 }
 
 // ── Inner state ───────────────────────────────────────────────────────────────
 
+/// A local cable range, tagged with the interface it belongs to.
+struct LocalRange {
+    interface: Interface,
+    range: CableRange,
+}
+
 struct Inner {
     mode: LearningMode,
-    local_range: Option<CableRange>,
+    local_ranges: Vec<LocalRange>,
     rtmp: RtmpTable,
+    /// A router heard advertising but carrying no usable route to a given
+    /// destination — the catch-all next hop. See [`DefaultRouter`].
+    default_router: Option<DefaultRouter>,
     zip: ZipTable,
     publisher: Option<tokio::sync::mpsc::UnboundedSender<RouteChange>>,
 }
@@ -182,37 +281,92 @@ impl Inner {
         }
     }
 
-    fn is_local(&self, net: u16) -> bool {
-        self.local_range.is_some_and(|(lo, hi)| lo <= net && net <= hi)
-    }
-
-    fn route_for(&self, net: u16) -> Option<NextHop> {
-        if self.is_local(net) {
-            return Some(NextHop::Local);
+    /// Insert or update the local range slot for `interface` (one slot per
+    /// tag, including the untagged slot). Returns `true` if the value changed.
+    fn upsert_local_range(&mut self, interface: Interface, range: CableRange) -> bool {
+        match self.local_ranges.iter_mut().find(|r| r.interface == interface) {
+            Some(existing) if existing.range == range => false,
+            Some(existing) => {
+                existing.range = range;
+                true
+            }
+            None => {
+                self.local_ranges.push(LocalRange { interface, range });
+                true
+            }
         }
-        self.rtmp.lookup(net).map(|e| NextHop::Via(e.next_hop))
     }
 
-    fn has_router(&self) -> bool {
-        !self.rtmp.entries.is_empty()
+    fn local_range_for(&self, net: u16) -> Option<&LocalRange> {
+        self.local_ranges
+            .iter()
+            .find(|r| r.range.0 <= net && net <= r.range.1)
     }
 
-    fn routers_for_zone(&self, zone: &str) -> Vec<AppleTalkAddress> {
+    fn is_local(&self, net: u16) -> bool {
+        self.local_range_for(net).is_some()
+    }
+
+    fn route_for(&self, net: u16, now: Instant) -> Option<NextHop> {
+        if let Some(local) = self.local_range_for(net) {
+            return Some(NextHop::Local(local.interface));
+        }
+        if let Some(e) = self.rtmp.lookup(net, now) {
+            return Some(NextHop::Via { router: e.next_hop, interface: e.interface });
+        }
+        // Last resort: forward anything we have no specific route for to the
+        // A-Router. This is what carries off-cable traffic when a bridge
+        // advertises itself but sends no route tuples (e.g. AsanteTalk).
+        self.live_default_router(now)
+            .map(|r| NextHop::Via { router: r.addr, interface: r.interface })
+    }
+
+    fn live_default_router(&self, now: Instant) -> Option<&DefaultRouter> {
+        self.default_router.as_ref().filter(|r| !r.expired(now))
+    }
+
+    /// Which cable network `net` sits on, if any tagged local range or
+    /// tagged route covers it.
+    fn interface_for_net(&self, net: u16, now: Instant) -> Option<Interface> {
+        self.route_for(net, now).map(|hop| match hop {
+            NextHop::Local(iface) => iface,
+            NextHop::Via { interface, .. } => interface,
+        })
+    }
+
+    fn has_router(&self, now: Instant) -> bool {
+        self.rtmp.entries.iter().any(|e| !e.expired(now))
+            || self.live_default_router(now).is_some()
+    }
+
+    /// Every distinct router we could hand an NBP request to: the specific
+    /// RTMP next hops, plus the A-Router if one is live.
+    fn all_routers(&self, now: Instant) -> Vec<AppleTalkAddress> {
+        let mut routers = self.rtmp.all_next_hops_deduped(now);
+        if let Some(r) = self.live_default_router(now)
+            && !routers.contains(&r.addr)
+        {
+            routers.push(r.addr);
+        }
+        routers
+    }
+
+    fn routers_for_zone(&self, zone: &str, now: Instant) -> Vec<AppleTalkAddress> {
         let mut seen = HashSet::new();
         self.zip
             .ranges_for_zone(zone)
             .iter()
-            .filter_map(|&(lo, _)| self.rtmp.lookup(lo))
+            .filter_map(|&(lo, _)| self.rtmp.lookup(lo, now))
             .filter_map(|e| seen.insert(e.next_hop).then_some(e.next_hop))
             .collect()
     }
 
-    fn nbp_dispatch(&self, zone: NbpZone<'_>) -> NbpDispatch {
+    fn nbp_dispatch(&self, zone: NbpZone<'_>, now: Instant) -> NbpDispatch {
         match zone {
             NbpZone::Local => NbpDispatch::LocalBroadcast,
 
             NbpZone::All => {
-                let routers = self.rtmp.all_next_hops_deduped();
+                let routers = self.all_routers(now);
                 if routers.is_empty() {
                     NbpDispatch::LocalBroadcast
                 } else {
@@ -221,12 +375,12 @@ impl Inner {
             }
 
             NbpZone::Named(name) => {
-                let routers = self.routers_for_zone(name);
+                let routers = self.routers_for_zone(name, now);
                 if !routers.is_empty() {
                     return NbpDispatch::RouterBroadcast(routers);
                 }
                 // Zone not in ZIP — try any known router as a last resort.
-                let any = self.rtmp.all_next_hops_deduped();
+                let any = self.all_routers(now);
                 if any.is_empty() {
                     NbpDispatch::ZoneUnknown
                 } else {
@@ -253,8 +407,9 @@ impl RouteTable {
     pub fn new(mode: LearningMode) -> Self {
         Self(Arc::new(RwLock::new(Inner {
             mode,
-            local_range: None,
+            local_ranges: Vec::new(),
             rtmp: RtmpTable::new(),
+            default_router: None,
             zip: ZipTable::new(),
             publisher: None,
         })))
@@ -262,14 +417,18 @@ impl RouteTable {
 
     // ── Configuration ─────────────────────────────────────────────────────────
 
-    /// Set the cable range for our own segment.
+
+
+    /// Set the cable range of a specific interface's segment.
     ///
-    /// Required for [`is_local`](Self::is_local) and
-    /// [`route_for`](Self::route_for) to distinguish on-segment destinations.
-    pub fn set_local_range(&self, lo: u16, hi: u16) {
+    /// Called by ZIP (GetNetInfo reply) and RTMP (router's own-cable tuple)
+    /// as the range is discovered. Idempotent: republishing the same range is
+    /// a no-op, so periodic router broadcasts don't spam the change stream.
+    pub fn set_local_range_for(&self, interface: Interface, lo: u16, hi: u16) {
         let mut inner = self.0.write().unwrap();
-        inner.local_range = Some((lo, hi));
-        inner.publish(RouteChange::SetLocalRange((lo, hi)));
+        if inner.upsert_local_range(interface, (lo, hi)) {
+            inner.publish(RouteChange::SetLocalRange((lo, hi)));
+        }
     }
 
     /// Attach a channel that receives every subsequent programmatic change.
@@ -283,10 +442,13 @@ impl RouteTable {
     // ── Programmatic inserts ──────────────────────────────────────────────────
 
     /// Insert or replace a route: DDP packets for `[lo..=hi]` go to `next_hop`.
-    pub fn insert_route(&self, lo: u16, hi: u16, next_hop: AppleTalkAddress) {
+    ///
+    /// Programmatic routes carry no interface tag and never expire.
+    pub fn insert_route(&self, lo: u16, hi: u16, next_hop: AppleTalkAddress, interface: Interface) {
         let mut inner = self.0.write().unwrap();
-        inner.rtmp.insert(lo, hi, next_hop, 1);
-        inner.publish(RouteChange::InsertRoute { lo, hi, next_hop });
+        if inner.rtmp.insert(lo, hi, next_hop, 0, interface, None) {
+            inner.publish(RouteChange::InsertRoute { lo, hi, next_hop, interface: Some(interface) });
+        }
     }
 
     /// Remove the route covering exactly `[lo..=hi]`.
@@ -321,10 +483,15 @@ impl RouteTable {
     /// Replace the entire table contents with `snapshot`, without publishing.
     pub fn replace_contents(&self, snapshot: RouteSnapshot) {
         let mut inner = self.0.write().unwrap();
-        inner.local_range = snapshot.local_range;
+        inner.local_ranges.clear();
+        if let Some(range) = snapshot.local_range {
+            // Static local range configuration defaults to EtherTalk
+            inner.local_ranges.push(LocalRange { interface: Interface::EtherTalk, range });
+        }
         inner.rtmp = RtmpTable::new();
-        for (lo, hi, next_hop) in snapshot.routes {
-            inner.rtmp.insert(lo, hi, next_hop, 1);
+        inner.default_router = None;
+        for (lo, hi, next_hop, interface) in snapshot.routes {
+            inner.rtmp.insert(lo, hi, next_hop, 0, interface.unwrap_or(Interface::EtherTalk), None);
         }
         inner.zip = ZipTable::new();
         for (zone, ranges) in snapshot.zones {
@@ -335,15 +502,20 @@ impl RouteTable {
     }
 
     /// Copy the entire table contents, for querying over an API.
+    ///
+    /// The snapshot format carries no interface tags or expiry: the untagged
+    /// local range is preferred, and only live routes are included.
     pub fn snapshot(&self) -> RouteSnapshot {
+        let now = Instant::now();
         let inner = self.0.read().unwrap();
         RouteSnapshot {
-            local_range: inner.local_range,
+            local_range: inner.local_ranges.first().map(|r| r.range),
             routes: inner
                 .rtmp
                 .entries
                 .iter()
-                .map(|e| (e.range_lo, e.range_hi, e.next_hop))
+                .filter(|e| !e.expired(now))
+                .map(|e| (e.range_lo, e.range_hi, e.next_hop, Some(e.interface)))
                 .collect(),
             zones: inner
                 .zip
@@ -356,17 +528,62 @@ impl RouteTable {
 
     // ── Dynamic learning ──────────────────────────────────────────────────────
 
-    /// Process an RTMP data packet received from `src`.
+    /// Process an RTMP data packet received from `src` on `interface`.
     ///
-    /// Each tuple is `(range_lo, range_hi, hop_count)`. No-op in
-    /// [`LearningMode::Static`].
-    pub fn handle_rtmp(&self, src: AppleTalkAddress, tuples: &[(u16, u16, u8)]) {
+    /// Each tuple is `(range_lo, range_hi, hop_count)`. Learned routes expire
+    /// after [`RTMP_ROUTE_TTL`] unless refreshed by another broadcast. No-op
+    /// in [`LearningMode::Static`].
+    pub fn handle_rtmp(
+        &self,
+        src: AppleTalkAddress,
+        interface: Interface,
+        tuples: &[(u16, u16, u8)],
+    ) {
         if matches!(self.0.read().unwrap().mode, LearningMode::Static) {
             return;
         }
+        let expires_at = Some(Instant::now() + RTMP_ROUTE_TTL);
         let mut inner = self.0.write().unwrap();
         for &(lo, hi, hops) in tuples {
-            inner.rtmp.insert(lo, hi, src, hops);
+            // Publish only genuine changes, not the 10-second refreshes, so a
+            // daemon doesn't rebroadcast its table to clients on every beacon.
+            if inner.rtmp.insert(lo, hi, src, hops, interface, expires_at) {
+                inner.publish(RouteChange::InsertRoute { lo, hi, next_hop: src, interface: Some(interface) });
+            }
+        }
+    }
+
+    /// Record that `router` is advertising on `interface`, making it the
+    /// endpoint's A-Router: the next hop for any destination with no
+    /// more-specific route. Refreshed on every RTMP broadcast and expiring on
+    /// the same TTL as learned routes. No-op in [`LearningMode::Static`].
+    ///
+    /// This is what lets an endpoint reach off-cable nodes behind a bridge
+    /// that announces itself but sends no route tuples (e.g. AsanteTalk).
+    pub fn note_router(&self, router: AppleTalkAddress, interface: Interface) {
+        let mut inner = self.0.write().unwrap();
+        if matches!(inner.mode, LearningMode::Static) {
+            return;
+        }
+        inner.default_router = Some(DefaultRouter {
+            addr: router,
+            interface,
+            expires_at: Some(Instant::now() + RTMP_ROUTE_TTL),
+        });
+    }
+
+    /// Drop expired RTMP-learned routes and, if it has lapsed, the A-Router.
+    /// Meant to be called periodically (the RTMP listener does this); reads
+    /// already ignore expired entries, this just reclaims them.
+    pub fn purge_expired(&self) {
+        let now = Instant::now();
+        let mut inner = self.0.write().unwrap();
+        let purged = inner.rtmp.purge_expired(now);
+        if inner.default_router.as_ref().is_some_and(|r| r.expired(now)) {
+            inner.default_router = None;
+        }
+        if purged > 0 {
+            tracing::info!("route table: {purged} RTMP route(s) expired without refresh");
         }
     }
 
@@ -384,28 +601,39 @@ impl RouteTable {
 
     // ── Query surface ─────────────────────────────────────────────────────────
 
-    /// Returns `true` if `net` falls within our own cable range.
+    /// Check whether a given network number falls into any of our local ranges.
     pub fn is_local(&self, net: u16) -> bool {
         self.0.read().unwrap().is_local(net)
     }
 
-    /// Determine where to send a DDP packet destined for network `net`.
-    ///
-    /// Returns `None` when the destination is off-segment and no route is
-    /// known; the caller should drop or error the packet.
-    pub fn route_for(&self, net: u16) -> Option<NextHop> {
-        self.0.read().unwrap().route_for(net)
+    /// Look up the next hop for a destination network.
+    pub fn resolve(&self, net: u16) -> Option<NextHop> {
+        self.0.read().unwrap().route_for(net, Instant::now())
     }
 
-    /// Returns `true` once at least one router has advertised itself via RTMP
-    /// (or been configured programmatically).
+    /// Find the router for a remote network, if known.
+    pub fn route_for(&self, net: u16) -> Option<AppleTalkAddress> {
+        match self.resolve(net) {
+            Some(NextHop::Via { router, .. }) => Some(router),
+            _ => None,
+        }
+    }
+
+    /// Which cable network `net` sits on, judged by tagged local ranges and
+    /// tagged (dynamically learned) routes. `None` when unknown.
+    pub fn interface_for_net(&self, net: u16) -> Option<Interface> {
+        self.0.read().unwrap().interface_for_net(net, Instant::now())
+    }
+
+    /// Returns `true` while at least one live router is known, via RTMP
+    /// advertisement (until it expires) or programmatic configuration.
     ///
     /// Used to decide when to stop using short-form (5-byte) DDP headers on
     /// LocalTalk: those omit the network number entirely, which is fine on
     /// an isolated LocalTalk segment but ambiguous as soon as a router makes
     /// off-segment addressing possible.
     pub fn has_router(&self) -> bool {
-        self.0.read().unwrap().has_router()
+        self.0.read().unwrap().has_router(Instant::now())
     }
 
     /// Return the router addresses that can forward NBP requests for `zone`.
@@ -413,12 +641,12 @@ impl RouteTable {
     /// Derived from ZIP (zone → ranges) then RTMP (range → next-hop).
     /// Returns an empty `Vec` if the zone is unknown.
     pub fn routers_for_zone(&self, zone: &str) -> Vec<AppleTalkAddress> {
-        self.0.read().unwrap().routers_for_zone(zone)
+        self.0.read().unwrap().routers_for_zone(zone, Instant::now())
     }
 
     /// Determine how to dispatch an NBP LkUp for the given zone.
     pub fn nbp_dispatch(&self, zone: NbpZone<'_>) -> NbpDispatch {
-        self.0.read().unwrap().nbp_dispatch(zone)
+        self.0.read().unwrap().nbp_dispatch(zone, Instant::now())
     }
 }
 
@@ -437,7 +665,7 @@ mod tests {
     #[test]
     fn local_range_membership() {
         let t = RouteTable::new(LearningMode::Static);
-        t.set_local_range(100, 105);
+        t.set_local_range_for(Interface::EtherTalk, 100, 105);
 
         assert!(t.is_local(100));
         assert!(t.is_local(103));
@@ -446,43 +674,194 @@ mod tests {
         assert!(!t.is_local(106));
     }
 
+
+
     #[test]
     fn route_for_local() {
         let t = RouteTable::new(LearningMode::Static);
-        t.set_local_range(100, 105);
-        assert_eq!(t.route_for(102), Some(NextHop::Local));
+        t.set_local_range_for(Interface::EtherTalk, 100, 105);
+        assert_eq!(t.resolve(102), Some(NextHop::Local(Interface::EtherTalk)));
     }
 
     #[test]
     fn route_for_via_router() {
         let t = RouteTable::new(LearningMode::Static);
-        t.set_local_range(100, 105);
-        t.insert_route(200, 210, addr(100, 1));
-        assert_eq!(t.route_for(205), Some(NextHop::Via(addr(100, 1))));
+        t.set_local_range_for(Interface::EtherTalk, 100, 105);
+        t.insert_route(200, 210, addr(100, 1), Interface::EtherTalk);
+        assert_eq!(t.route_for(205), Some(addr(100, 1)));
     }
 
     #[test]
     fn route_for_unknown_returns_none() {
         let t = RouteTable::new(LearningMode::Static);
-        t.set_local_range(100, 105);
-        assert_eq!(t.route_for(999), None);
+        t.set_local_range_for(Interface::EtherTalk, 100, 105);
+        assert_eq!(t.resolve(999), None);
     }
 
     #[test]
     fn insert_route_replaces_overlap() {
         let t = RouteTable::new(LearningMode::Static);
-        t.insert_route(100, 200, addr(1, 1));
-        t.insert_route(150, 160, addr(1, 2)); // overlaps; old entry removed wholesale
-        assert_eq!(t.route_for(155), Some(NextHop::Via(addr(1, 2))));
+        t.insert_route(100, 200, addr(1, 1), Interface::EtherTalk);
+        t.insert_route(150, 160, addr(1, 2), Interface::EtherTalk); // overlaps; old entry removed wholesale
+        assert_eq!(t.route_for(155), Some(addr(1, 2)));
         // Parts of the old range outside [150, 160] are gone
         assert_eq!(t.route_for(100), None);
+    }
+
+    #[test]
+    fn dynamic_routes_carry_interface_and_local_range_wins() {
+        let t = RouteTable::new(LearningMode::Dynamic);
+        t.set_local_range_for(Interface::LocalTalk, 2, 2);
+        t.handle_rtmp(addr(2, 254), Interface::LocalTalk, &[(2, 2, 1), (3, 5, 1)]);
+
+        // Our own cable range takes precedence over the router's own-net tuple.
+        assert_eq!(t.resolve(2), Some(NextHop::Local(Interface::LocalTalk)));
+        // Off-cable network routes via the router, tagged with its cable.
+        assert_eq!(
+            t.route_for(4),
+            Some(addr(2, 254))
+        );
+        assert_eq!(t.interface_for_net(2), Some(Interface::LocalTalk));
+        assert_eq!(t.interface_for_net(254), None);
+    }
+
+    #[test]
+    fn a_router_forwards_unknown_nets() {
+        // An AsanteTalk-style bridge that announces itself but sends no tuples:
+        // note_router alone must make it the next hop for off-cable traffic.
+        let t = RouteTable::new(LearningMode::Dynamic);
+        t.set_local_range_for(Interface::LocalTalk, 65456, 65456);
+        t.note_router(addr(65456, 190), Interface::LocalTalk);
+
+        assert!(t.has_router());
+        // Our own cable is still delivered directly, not via the router.
+        assert_eq!(t.resolve(65456), Some(NextHop::Local(Interface::LocalTalk)));
+        // Any off-cable net now routes via the A-Router on LocalTalk.
+        assert_eq!(
+            t.resolve(65309),
+            Some(NextHop::Via { router: addr(65456, 190), interface: Interface::LocalTalk })
+        );
+        assert_eq!(
+            t.nbp_dispatch(NbpZone::All),
+            NbpDispatch::RouterBroadcast(vec![addr(65456, 190)])
+        );
+    }
+
+    #[test]
+    fn specific_route_wins_over_a_router() {
+        let t = RouteTable::new(LearningMode::Dynamic);
+        t.note_router(addr(2, 254), Interface::LocalTalk);
+        t.handle_rtmp(addr(2, 254), Interface::LocalTalk, &[(3, 5, 1)]);
+        // A net with a specific route uses it; everything else falls to the A-Router.
+        assert_eq!(
+            t.resolve(4),
+            Some(NextHop::Via { router: addr(2, 254), interface: Interface::LocalTalk })
+        );
+        assert_eq!(
+            t.resolve(999),
+            Some(NextHop::Via { router: addr(2, 254), interface: Interface::LocalTalk })
+        );
+        // The router appears once in NBP dispatch, not twice.
+        assert_eq!(
+            t.nbp_dispatch(NbpZone::All),
+            NbpDispatch::RouterBroadcast(vec![addr(2, 254)])
+        );
+    }
+
+    #[test]
+    fn a_router_is_static_mode_noop() {
+        let t = RouteTable::new(LearningMode::Static);
+        t.note_router(addr(65456, 190), Interface::LocalTalk);
+        assert!(!t.has_router());
+        assert_eq!(t.resolve(65309), None);
+    }
+
+    #[test]
+    fn a_router_expires_and_purges() {
+        let t = RouteTable::new(LearningMode::Dynamic);
+        t.note_router(addr(65456, 190), Interface::LocalTalk);
+        assert!(t.has_router());
+
+        // Force the A-Router past its TTL.
+        {
+            let mut inner = t.0.write().unwrap();
+            if let Some(r) = inner.default_router.as_mut() {
+                r.expires_at = Some(Instant::now() - Duration::from_secs(1));
+            }
+        }
+
+        // Reads ignore it even before purge.
+        assert!(!t.has_router());
+        assert_eq!(t.resolve(65309), None);
+        assert_eq!(t.nbp_dispatch(NbpZone::All), NbpDispatch::LocalBroadcast);
+
+        t.purge_expired();
+        assert!(t.0.read().unwrap().default_router.is_none());
+    }
+
+    #[test]
+    fn rtmp_routes_expire_and_purge() {
+        let t = RouteTable::new(LearningMode::Dynamic);
+        t.handle_rtmp(addr(2, 254), Interface::LocalTalk, &[(3, 5, 1)]);
+        assert!(t.has_router());
+        assert!(t.resolve(4).is_some());
+
+        // Force the entry past its TTL.
+        {
+            let mut inner = t.0.write().unwrap();
+            for e in &mut inner.rtmp.entries {
+                e.expires_at = Some(Instant::now() - Duration::from_secs(1));
+            }
+        }
+
+        // Reads ignore the expired entry even before it is purged.
+        assert!(!t.has_router());
+        assert_eq!(t.resolve(4), None);
+        assert_eq!(t.nbp_dispatch(NbpZone::All), NbpDispatch::LocalBroadcast);
+
+        t.purge_expired();
+        assert!(t.0.read().unwrap().rtmp.entries.is_empty());
+
+        // A fresh broadcast brings the route back.
+        t.handle_rtmp(addr(2, 254), Interface::LocalTalk, &[(3, 5, 1)]);
+        assert!(t.has_router());
+    }
+
+    #[test]
+    fn set_local_range_publishes_only_changes() {
+        let t = RouteTable::new(LearningMode::Dynamic);
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        t.set_publisher(tx);
+
+        t.set_local_range_for(Interface::EtherTalk, 3, 5);
+        t.set_local_range_for(Interface::EtherTalk, 3, 5); // refresh, no publish
+        t.set_local_range_for(Interface::EtherTalk, 3, 6); // change, publish
+
+        assert_eq!(rx.try_recv(), Ok(RouteChange::SetLocalRange((3, 5))));
+        assert_eq!(rx.try_recv(), Ok(RouteChange::SetLocalRange((3, 6))));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn handle_rtmp_publishes_only_new_routes() {
+        let t = RouteTable::new(LearningMode::Dynamic);
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        t.set_publisher(tx);
+
+        t.handle_rtmp(addr(2, 254), Interface::LocalTalk, &[(3, 5, 1)]);
+        t.handle_rtmp(addr(2, 254), Interface::LocalTalk, &[(3, 5, 1)]); // refresh
+        assert_eq!(
+            rx.try_recv(),
+            Ok(RouteChange::InsertRoute { lo: 3, hi: 5, next_hop: addr(2, 254), interface: Some(Interface::LocalTalk) })
+        );
+        assert!(rx.try_recv().is_err());
     }
 
     #[test]
     fn has_router_tracks_rtmp_entries() {
         let t = RouteTable::new(LearningMode::Static);
         assert!(!t.has_router());
-        t.insert_route(200, 210, addr(100, 1));
+        t.insert_route(200, 210, addr(100, 1), Interface::EtherTalk);
         assert!(t.has_router());
         t.remove_route(200, 210);
         assert!(!t.has_router());
@@ -491,9 +870,9 @@ mod tests {
     #[test]
     fn remove_route() {
         let t = RouteTable::new(LearningMode::Static);
-        t.insert_route(200, 210, addr(100, 1));
+        t.insert_route(200, 210, addr(100, 1), Interface::EtherTalk);
         t.remove_route(200, 210);
-        assert_eq!(t.route_for(205), None);
+        assert_eq!(t.resolve(205), None);
     }
 
     // ── NBP dispatch ──────────────────────────────────────────────────────────
@@ -501,7 +880,7 @@ mod tests {
     #[test]
     fn nbp_local_always_broadcasts() {
         let t = RouteTable::new(LearningMode::Static);
-        t.insert_route(200, 210, addr(100, 1)); // router present, still local
+        t.insert_route(200, 210, addr(100, 1), Interface::EtherTalk); // router present, still local
         assert_eq!(t.nbp_dispatch(NbpZone::Local), NbpDispatch::LocalBroadcast);
     }
 
@@ -514,7 +893,7 @@ mod tests {
     #[test]
     fn nbp_all_with_router() {
         let t = RouteTable::new(LearningMode::Static);
-        t.insert_route(200, 210, addr(100, 1));
+        t.insert_route(200, 210, addr(100, 1), Interface::EtherTalk);
         assert_eq!(
             t.nbp_dispatch(NbpZone::All),
             NbpDispatch::RouterBroadcast(vec![addr(100, 1)])
@@ -524,7 +903,7 @@ mod tests {
     #[test]
     fn nbp_named_zone_known() {
         let t = RouteTable::new(LearningMode::Static);
-        t.insert_route(200, 210, addr(100, 1));
+        t.insert_route(200, 210, addr(100, 1), Interface::EtherTalk);
         t.insert_zone("Engineering", &[(200, 210)]);
         assert_eq!(
             t.nbp_dispatch(NbpZone::Named("Engineering")),
@@ -539,7 +918,7 @@ mod tests {
         assert_eq!(t.nbp_dispatch(NbpZone::Named("Printers")), NbpDispatch::ZoneUnknown);
 
         // Router known but zone not in ZIP — falls back to that router
-        t.insert_route(200, 210, addr(100, 1));
+        t.insert_route(200, 210, addr(100, 1), Interface::EtherTalk);
         assert_eq!(
             t.nbp_dispatch(NbpZone::Named("Printers")),
             NbpDispatch::RouterBroadcast(vec![addr(100, 1)])
@@ -551,19 +930,25 @@ mod tests {
     #[test]
     fn handle_rtmp_respects_mode() {
         let dynamic = RouteTable::new(LearningMode::Dynamic);
-        dynamic.handle_rtmp(addr(100, 1), &[(200, 210, 1), (300, 305, 2)]);
-        assert_eq!(dynamic.route_for(205), Some(NextHop::Via(addr(100, 1))));
-        assert_eq!(dynamic.route_for(301), Some(NextHop::Via(addr(100, 1))));
+        dynamic.handle_rtmp(addr(100, 1), Interface::EtherTalk, &[(200, 210, 1), (300, 305, 2)]);
+        assert_eq!(
+            dynamic.route_for(205),
+            Some(addr(100, 1))
+        );
+        assert_eq!(
+            dynamic.resolve(301),
+            Some(NextHop::Via { router: addr(100, 1), interface: Interface::EtherTalk })
+        );
 
         let static_ = RouteTable::new(LearningMode::Static);
-        static_.handle_rtmp(addr(100, 1), &[(200, 210, 1)]);
-        assert_eq!(static_.route_for(205), None);
+        static_.handle_rtmp(addr(100, 1), Interface::EtherTalk, &[(200, 210, 1)]);
+        assert_eq!(static_.resolve(205), None);
     }
 
     #[test]
     fn handle_zip_reply_respects_mode() {
         let dynamic = RouteTable::new(LearningMode::Dynamic);
-        dynamic.insert_route(200, 210, addr(100, 1));
+        dynamic.insert_route(200, 210, addr(100, 1), Interface::EtherTalk);
         dynamic.handle_zip_reply((200, 210), &["Engineering", "Printers"]);
         assert_eq!(
             dynamic.nbp_dispatch(NbpZone::Named("Engineering")),
@@ -571,7 +956,7 @@ mod tests {
         );
 
         let static_ = RouteTable::new(LearningMode::Static);
-        static_.insert_route(200, 210, addr(100, 1));
+        static_.insert_route(200, 210, addr(100, 1), Interface::EtherTalk);
         static_.handle_zip_reply((200, 210), &["Engineering"]);
         // ZIP entry not recorded; zone unknown but falls back to the known router
         assert_eq!(
@@ -583,7 +968,7 @@ mod tests {
     #[test]
     fn remove_zone() {
         let t = RouteTable::new(LearningMode::Static);
-        t.insert_route(200, 210, addr(100, 1));
+        t.insert_route(200, 210, addr(100, 1), Interface::EtherTalk);
         t.insert_zone("Engineering", &[(200, 210)]);
         t.remove_zone("Engineering");
         // Falls back to any-router since zone is gone but route remains
@@ -597,8 +982,8 @@ mod tests {
     fn clone_shares_state() {
         let t1 = RouteTable::new(LearningMode::Static);
         let t2 = t1.clone();
-        t1.insert_route(200, 210, addr(100, 1));
-        assert_eq!(t2.route_for(205), Some(NextHop::Via(addr(100, 1))));
+        t1.insert_route(200, 210, addr(100, 1), Interface::EtherTalk);
+        assert_eq!(t2.resolve(205), Some(NextHop::Via { router: addr(100, 1), interface: Interface::EtherTalk }));
     }
 
     #[test]
@@ -606,8 +991,8 @@ mod tests {
         let t = RouteTable::new(LearningMode::Static);
 
         // Consecutive duplicates: two ranges, same router
-        t.insert_route(200, 210, addr(100, 1));
-        t.insert_route(211, 220, addr(100, 1));
+        t.insert_route(200, 210, addr(100, 1), Interface::EtherTalk);
+        t.insert_route(211, 220, addr(100, 1), Interface::EtherTalk);
         t.insert_zone("Engineering", &[(200, 210), (211, 220)]);
         assert_eq!(
             t.nbp_dispatch(NbpZone::Named("Engineering")),
@@ -615,8 +1000,8 @@ mod tests {
         );
 
         // Non-consecutive: zone spans A, B, A — router A must appear only once
-        t.insert_route(221, 230, addr(100, 2)); // router B
-        t.insert_route(231, 240, addr(100, 1)); // router A again
+        t.insert_route(221, 230, addr(100, 2), Interface::EtherTalk); // router B
+        t.insert_route(231, 240, addr(100, 1), Interface::EtherTalk); // router A again
         t.insert_zone("Engineering", &[(221, 230), (231, 240)]);
         assert_eq!(
             t.nbp_dispatch(NbpZone::Named("Engineering")),

--- a/tailtalk/src/rtmp.rs
+++ b/tailtalk/src/rtmp.rs
@@ -2,43 +2,98 @@
 //!
 //! Routers broadcast an RTMP Data packet on every directly-connected cable
 //! roughly every 10 seconds. Seeing one means a router is present, so its
-//! tuples are fed into the [`RouteTable`], which is what makes NBP dispatch
-//! switch from local broadcast to a directed request at the router.
+//! tuples are fed into the [`RouteTable`] — tagged with the interface they
+//! arrived on — which is what makes NBP dispatch switch from local broadcast
+//! to a directed request at the router, and DDP switch to long-form headers
+//! on LocalTalk.
+//!
+//! The broadcast also describes the local cable itself:
+//!
+//! * On a nonextended network (LocalTalk, Phase 1 EtherTalk) the RTMP header
+//!   carries the cable's network number, which nodes glean to replace their
+//!   provisional network 0 — classic "RTMP stub" behaviour.
+//! * On an extended network the mandatory first tuple is the sender's own
+//!   cable range.
+//!
+//! Both are recorded as the interface's local range. The first router seen on
+//! a cable also triggers a ZIP GetNetInfo refresh, so a router that boots
+//! after us still gets asked for the zone and (on EtherTalk) a proper
+//! in-range address.
+//!
+//! Learned routes expire if not refreshed (see [`RouteTable`]); a periodic
+//! tick here reclaims them. Tuples advertised at distance 31 ("notify
+//! neighbor") are poisoned routes and are removed rather than inserted.
 //!
 //! Receive-only: TailTalk never originates RTMP packets of its own.
 
+use std::collections::HashSet;
+use std::time::Duration;
+
 use tailtalk_packets::aarp::AppleTalkAddress;
-use tailtalk_packets::ddp::{DdpPacket, DdpProtocolType};
+use tailtalk_packets::ddp::DdpProtocolType;
 use tailtalk_packets::rtmp::{RTMP_SOCKET, RtmpDataPacket, RtmpTuple};
 
-use crate::ddp::{DdpHandle, DdpSocket};
-use crate::route_table::RouteTable;
+use crate::addressing::AddressingHandle;
+use crate::ddp::{DdpHandle, DdpSocket, Packet};
+use crate::route_table::{CableRange, Interface, RouteTable};
+use crate::zip::ZipHandle;
+
+/// Distance at which a tuple means "this route is gone" (notify neighbor).
+const RTMP_DISTANCE_UNREACHABLE: u8 = 31;
 
 pub struct Rtmp {
     sock: DdpSocket,
     route_table: RouteTable,
+    /// Used to adopt the gleaned network number on nonextended LocalTalk.
+    lt_addressing: Option<AddressingHandle>,
+    /// Poked to re-run GetNetInfo when a router first appears on a cable.
+    zip: Option<ZipHandle>,
+    /// Interfaces a router has already been seen on (ZIP refresh debounce).
+    seen_router_on: HashSet<Interface>,
 }
 
 impl Rtmp {
     /// Spawn the RTMP listener actor.
-    pub async fn spawn(ddp: &DdpHandle, route_table: RouteTable) {
+    pub async fn spawn(
+        ddp: &DdpHandle,
+        route_table: RouteTable,
+        lt_addressing: Option<AddressingHandle>,
+        zip: Option<ZipHandle>,
+    ) {
         let sock = ddp
             .new_sock(DdpProtocolType::RtmpResponse, Some(RTMP_SOCKET))
             .await
             .expect("failed to create RTMP sock");
 
-        let rtmp = Rtmp { sock, route_table };
+        let rtmp = Rtmp {
+            sock,
+            route_table,
+            lt_addressing,
+            zip,
+            seen_router_on: HashSet::new(),
+        };
         tokio::spawn(async move { rtmp.run().await });
     }
 
     async fn run(mut self) {
-        while let Ok(pkt) = self.sock.recv().await {
-            self.handle_packet(&pkt.headers, &pkt.payload);
+        let mut purge = tokio::time::interval(Duration::from_secs(10));
+        purge.tick().await; // consume the immediate first tick
+
+        loop {
+            tokio::select! {
+                recv = self.sock.recv() => {
+                    match recv {
+                        Ok(pkt) => self.handle_packet(&pkt).await,
+                        Err(_) => break,
+                    }
+                }
+                _ = purge.tick() => self.route_table.purge_expired(),
+            }
         }
     }
 
-    fn handle_packet(&self, ddp: &DdpPacket, payload: &[u8]) {
-        let data = match RtmpDataPacket::parse(payload) {
+    async fn handle_packet(&mut self, pkt: &Packet) {
+        let data = match RtmpDataPacket::parse(&pkt.payload) {
             Ok(data) => data,
             Err(e) => {
                 tracing::debug!("RTMP: failed to parse Data packet: {e}");
@@ -46,45 +101,128 @@ impl Rtmp {
             }
         };
 
+        // The actor only runs where the underlay is in-process, so the
+        // arrival link is always known.
+        let source = pkt.source;
+        let iface = Interface::from(source);
+
         // Unlike a forwarded NBP Lookup, an RTMP Data packet is always sent
-        // directly by the router itself, so the DDP source is its address.
+        // directly by the router itself, so the DDP source is its address. On
+        // LocalTalk it arrives as short-form DDP with no network number (DDP
+        // source network 0), so fall back to the cable number the RTMP header
+        // advertises — otherwise we'd address the router as net 0 rather than
+        // its real address, which not every router honours.
         let router = AppleTalkAddress {
-            network_number: ddp.src_network_num,
-            node_number: ddp.src_node_id,
+            network_number: if pkt.headers.src_network_num != 0 {
+                pkt.headers.src_network_num
+            } else {
+                data.router_network
+            },
+            node_number: pkt.headers.src_node_id,
         };
 
-        let tuples = tuples_for_route_table(&data);
-        if tuples.is_empty() {
-            return;
+        self.learn_local_cable(iface, &data).await;
+
+        // Hearing any RTMP broadcast means a router is on this cable. Record it
+        // as the A-Router so off-cable traffic has a next hop even when the
+        // broadcast carries no route tuples — the case for LocalTalk–EtherTalk
+        // bridges like AsanteTalk, which announce themselves in the header only.
+        self.route_table.note_router(router, iface);
+
+        // First time we've seen a router on this cable: it implies zones and
+        // (on EtherTalk) a real cable range to move into, so ask ZIP to
+        // rediscover. Fires regardless of whether the broadcast carried route
+        // tuples — a tupleless bridge is still a router worth querying.
+        if self.seen_router_on.insert(iface) {
+            tracing::info!(
+                "RTMP: router {}.{} appeared on {iface:?}; switching NBP to router broadcast",
+                router.network_number,
+                router.node_number,
+            );
+            if let Some(zip) = &self.zip {
+                let zip = zip.clone();
+                tokio::spawn(async move {
+                    let _ = zip.refresh().await;
+                });
+            }
         }
 
-        tracing::info!(
-            "RTMP: router {}.{} advertises {} route(s); switching NBP to router broadcast",
-            router.network_number,
-            router.node_number,
-            tuples.len(),
-        );
+        let (tuples, poisoned) = tuples_for_route_table(&data);
+        for &(lo, hi) in &poisoned {
+            tracing::info!("RTMP: router {}.{} withdrew route {lo}-{hi}",
+                router.network_number, router.node_number);
+            self.route_table.remove_route(lo, hi);
+        }
+        if !tuples.is_empty() {
+            self.route_table.handle_rtmp(router, iface, &tuples);
+        }
+    }
 
-        self.route_table.handle_rtmp(router, &tuples);
+    /// Record what the broadcast says about the local cable itself, and on
+    /// nonextended LocalTalk adopt the gleaned network number.
+    async fn learn_local_cable(&self, iface: Interface, data: &RtmpDataPacket) {
+        let Some((lo, hi)) = local_cable_range(iface, data) else {
+            return;
+        };
+        self.route_table.set_local_range_for(iface, lo, hi);
+
+        if iface == Interface::LocalTalk
+            && let Some(lt) = &self.lt_addressing
+            && let Ok(cur) = lt.addr().await
+            && cur.network_number != lo
+        {
+            tracing::info!(
+                "RTMP: gleaned LocalTalk network number {lo} from router broadcast (was {})",
+                cur.network_number
+            );
+            let new = AppleTalkAddress { network_number: lo, node_number: cur.node_number };
+            if let Err(e) = lt.set_addr(new).await {
+                tracing::warn!("RTMP: failed to adopt network number {lo}: {e}");
+            }
+        }
+    }
+}
+
+/// What an RTMP Data packet reveals about the sender's own cable: the header
+/// network number on nonextended networks, the mandatory first range tuple on
+/// extended ones. `None` when the broadcast predates configuration (net 0).
+fn local_cable_range(iface: Interface, data: &RtmpDataPacket) -> Option<CableRange> {
+    match (iface, data.tuples.first()) {
+        // Extended cable: the first tuple is the sender's own range.
+        (Interface::EtherTalk, Some(&RtmpTuple::Extended { range_start, distance: 0, range_end })) => {
+            (range_start != 0).then_some((range_start, range_end))
+        }
+        // Nonextended cable (LocalTalk, or Phase 1 EtherTalk): the header
+        // names the network the router is sending through.
+        _ => (data.router_network != 0).then_some((data.router_network, data.router_network)),
     }
 }
 
 /// Flatten an RTMP Data packet's tuples into `(range_lo, range_hi, hop_count)`
-/// entries for [`RouteTable::handle_rtmp`]. The hop count recorded is the
-/// distance from us, i.e. one more than the distance the router advertised
-/// from itself.
-fn tuples_for_route_table(data: &RtmpDataPacket) -> Vec<(u16, u16, u8)> {
-    data.tuples
-        .iter()
-        .map(|t| match *t {
-            RtmpTuple::NonExtended { network, distance } => {
-                (network, network, distance.saturating_add(1))
-            }
+/// entries for [`RouteTable::handle_rtmp`], and separately the ranges the
+/// router has poisoned (advertised at distance 31, "notify neighbor"). The
+/// hop count recorded is the distance from us, i.e. one more than the
+/// distance the router advertised from itself.
+type RouteTuples = Vec<(u16, u16, u8)>;
+type PoisonedRanges = Vec<(u16, u16)>;
+
+fn tuples_for_route_table(data: &RtmpDataPacket) -> (RouteTuples, PoisonedRanges) {
+    let mut routes = Vec::new();
+    let mut poisoned = Vec::new();
+    for t in &data.tuples {
+        let (lo, hi, distance) = match *t {
+            RtmpTuple::NonExtended { network, distance } => (network, network, distance),
             RtmpTuple::Extended { range_start, distance, range_end } => {
-                (range_start, range_end, distance.saturating_add(1))
+                (range_start, range_end, distance)
             }
-        })
-        .collect()
+        };
+        if distance >= RTMP_DISTANCE_UNREACHABLE {
+            poisoned.push((lo, hi));
+        } else {
+            routes.push((lo, hi, distance.saturating_add(1)));
+        }
+    }
+    (routes, poisoned)
 }
 
 #[cfg(test)]
@@ -108,10 +246,64 @@ mod tests {
         0x00, 0x00, 0x00, // Tuple 1: NonExtended, net 0, dist 0
     ];
 
+    /// Real RTMP Data packet from an AsanteTalk bridge: router 2.254 on
+    /// non-extended LocalTalk net 2, advertising net 2 (its own), the
+    /// extended EtherTalk range 3-5, and net 1.
+    const ASANTETALK_RTMP_PAYLOAD: &[u8] = &[
+        0x00, 0x02, // Router network: 2
+        0x08, // ID length: 8 bits
+        0xfe, // Node ID: 254
+        0x00, 0x00, 0x82, // Non-extended version indicator ($000082)
+        0x00, 0x02, 0x00, // Tuple 1: NonExtended, net 2, dist 0
+        0x00, 0x03, 0x80, 0x00, 0x05, 0x82, // Tuple 2: Extended, range 3-5, dist 0
+        0x00, 0x01, 0x00, // Tuple 3: NonExtended, net 1, dist 0
+    ];
+
     #[test]
     fn tuples_for_route_table_converts_and_increments_hop_count() {
         let data = RtmpDataPacket::parse(NETATALK_RTMP_PAYLOAD).unwrap();
-        assert_eq!(tuples_for_route_table(&data), vec![(0, 0, 1)]);
+        let (routes, poisoned) = tuples_for_route_table(&data);
+        assert_eq!(routes, vec![(0, 0, 1)]);
+        assert!(poisoned.is_empty());
+    }
+
+    #[test]
+    fn poisoned_tuples_are_separated() {
+        // Net 7 advertised at distance 31: withdrawn, not a route.
+        let payload: &[u8] = &[
+            0x00, 0x02, 0x08, 0xfe, // router 2.254
+            0x00, 0x00, 0x82, // version indicator
+            0x00, 0x07, 0x1f, // Tuple: NonExtended, net 7, dist 31
+            0x00, 0x01, 0x00, // Tuple: NonExtended, net 1, dist 0
+        ];
+        let data = RtmpDataPacket::parse(payload).unwrap();
+        let (routes, poisoned) = tuples_for_route_table(&data);
+        assert_eq!(routes, vec![(1, 1, 1)]);
+        assert_eq!(poisoned, vec![(7, 7)]);
+    }
+
+    #[test]
+    fn local_cable_range_nonextended_header() {
+        let data = RtmpDataPacket::parse(ASANTETALK_RTMP_PAYLOAD).unwrap();
+        // Arriving on LocalTalk: the header's net 2 is our cable.
+        assert_eq!(local_cable_range(Interface::LocalTalk, &data), Some((2, 2)));
+
+        // An unconfigured router (net 0) reveals nothing.
+        let data = RtmpDataPacket::parse(NETATALK_RTMP_PAYLOAD).unwrap();
+        assert_eq!(local_cable_range(Interface::LocalTalk, &data), None);
+    }
+
+    #[test]
+    fn local_cable_range_extended_first_tuple() {
+        // The same router seen from its EtherTalk side: first tuple is the
+        // extended cable range 3-5.
+        let payload: &[u8] = &[
+            0x00, 0x03, 0x08, 0xfe, // router 3.254
+            0x00, 0x03, 0x80, 0x00, 0x05, 0x82, // Tuple 1: Extended, 3-5, dist 0
+            0x00, 0x02, 0x00, // Tuple 2: NonExtended, net 2, dist 0
+        ];
+        let data = RtmpDataPacket::parse(payload).unwrap();
+        assert_eq!(local_cable_range(Interface::EtherTalk, &data), Some((3, 5)));
     }
 
     /// End-to-end: a real captured RTMP broadcast, once fed into the route
@@ -123,11 +315,41 @@ mod tests {
 
         let data = RtmpDataPacket::parse(NETATALK_RTMP_PAYLOAD).unwrap();
         let router = addr(0, 128);
-        table.handle_rtmp(router, &tuples_for_route_table(&data));
+        let (routes, _) = tuples_for_route_table(&data);
+        table.handle_rtmp(router, Interface::LocalTalk, &routes);
 
         assert_eq!(
             table.nbp_dispatch(NbpZone::All),
             NbpDispatch::RouterBroadcast(vec![router])
+        );
+    }
+
+    /// The AsanteTalk topology end-to-end: routes learned on LocalTalk are
+    /// tagged so DDP can reach the router over the LocalTalk cable even
+    /// though it has a nonzero network number.
+    #[test]
+    fn asantetalk_routes_are_tagged_localtalk() {
+        use crate::route_table::NextHop;
+
+        let table = RouteTable::new(LearningMode::Dynamic);
+        let data = RtmpDataPacket::parse(ASANTETALK_RTMP_PAYLOAD).unwrap();
+        let router = addr(2, 254);
+
+        if let Some((lo, hi)) = local_cable_range(Interface::LocalTalk, &data) {
+            table.set_local_range_for(Interface::LocalTalk, lo, hi);
+        }
+        let (routes, _) = tuples_for_route_table(&data);
+        table.handle_rtmp(router, Interface::LocalTalk, &routes);
+
+        // The router itself is on our cable.
+        assert_eq!(
+            table.resolve(2),
+            Some(NextHop::Local(Interface::LocalTalk))
+        );
+        // The EtherTalk range behind it routes via the router, on LocalTalk.
+        assert_eq!(
+            table.resolve(4),
+            Some(NextHop::Via { router, interface: Interface::LocalTalk })
         );
     }
 }

--- a/tailtalk/src/zip.rs
+++ b/tailtalk/src/zip.rs
@@ -1,0 +1,278 @@
+//! ZIP client actor.
+//!
+//! A resident service that owns the ZIP socket (socket 6) for the lifetime of
+//! the stack. After the addressing layer self-assigns a provisional address
+//! (LocalTalk settles on network 0, EtherTalk Phase 2 in the startup range
+//! $FF00–$FFFE), it asks a router — via a broadcast ZIP GetNetInfo request,
+//! which DDP sends on every configured cable — for each cable's real
+//! network-number range and zone name, then threads the answer into the rest
+//! of the stack. The reply's arrival interface decides which cable it
+//! describes:
+//!
+//! * LocalTalk: [`AddressingHandle::set_addr`] adopts the real network number
+//!   (0 → range start), so DDP source addresses become correct.
+//! * EtherTalk: a fresh address *inside* the advertised range is probed via
+//!   AARP and adopted, per the Phase 2 startup procedure.
+//! * [`RouteTable::set_local_range_for`] / [`RouteTable::insert_zone`] record
+//!   the cable range and zone, which is what NBP reads to answer zoned
+//!   lookups and what DDP uses to pick the right cable for a next hop.
+//!
+//! Because it stays resident it also honours **ZIP Notify** (a router telling us
+//! our zone/network changed) by re-running discovery, and exposes
+//! [`ZipHandle::refresh`] to force a re-check on demand — the RTMP listener
+//! calls this when a router first appears on a cable.
+//!
+//! If no router answers we keep the provisional addresses with no zone — the
+//! correct state for an isolated cable — and NBP keeps using the "*"
+//! (this-zone) convention. The zone is never cached in this actor:
+//! [`RouteTable`] is the single source of truth; this actor's job is to keep
+//! it fresh.
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use tailtalk_packets::aarp::AppleTalkAddress;
+use tailtalk_packets::ddp::DdpProtocolType;
+use tailtalk_packets::zip::{GetNetInfoReply, GetNetInfoRequest, Notify, ZIP_SOCKET};
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::MissedTickBehavior;
+
+use crate::addressing::AddressingHandle;
+use crate::ddp::{DdpAddress, DdpHandle, DdpSocket, Packet};
+use crate::route_table::{Interface, RouteTable};
+
+/// How long to wait for a router to answer before resending GetNetInfo.
+const GNI_TIMEOUT: Duration = Duration::from_secs(1);
+/// GetNetInfo transmissions per discovery round before giving up (staying zoneless).
+const GNI_MAX_ATTEMPTS: usize = 3;
+
+enum ZipCommand {
+    /// Force a fresh discovery round; the sender is signalled once it settles.
+    Refresh(oneshot::Sender<()>),
+}
+
+pub struct Zip {
+    sock: DdpSocket,
+    et_addressing: Option<AddressingHandle>,
+    lt_addressing: Option<AddressingHandle>,
+    route_table: RouteTable,
+    /// PRAM-style zone cache file: seeded into requests and rewritten on adopt.
+    zone_cache: Option<PathBuf>,
+    /// Last zone we sent to the router for re-confirmation.
+    remembered_zone: Option<String>,
+    request_rx: mpsc::Receiver<ZipCommand>,
+    /// GetNetInfo sends remaining in the current round; 0 means idle (settled or
+    /// gave up). Drives the retry timer.
+    attempts_left: usize,
+    /// Callers waiting for the current discovery round to settle.
+    refresh_waiters: Vec<oneshot::Sender<()>>,
+}
+
+impl Zip {
+    /// Spawn the ZIP actor and kick off the initial discovery round.
+    pub async fn spawn(
+        ddp: &DdpHandle,
+        et_addressing: Option<AddressingHandle>,
+        lt_addressing: Option<AddressingHandle>,
+        route_table: RouteTable,
+        zone_cache: Option<PathBuf>,
+    ) -> ZipHandle {
+        let sock = ddp
+            .new_sock(DdpProtocolType::Zip, Some(ZIP_SOCKET))
+            .await
+            .expect("failed to create ZIP sock");
+
+        let remembered_zone = zone_cache.as_deref().and_then(load_zone);
+
+        let (request_tx, request_rx) = mpsc::channel(8);
+
+        let zip = Self {
+            sock,
+            et_addressing,
+            lt_addressing,
+            route_table,
+            zone_cache,
+            remembered_zone,
+            request_rx,
+            attempts_left: 0,
+            refresh_waiters: Vec::new(),
+        };
+
+        tokio::spawn(async move { zip.run().await });
+
+        ZipHandle { request_tx }
+    }
+
+    async fn run(mut self) {
+        let mut retry = tokio::time::interval(GNI_TIMEOUT);
+        // Don't fire a catch-up burst if the loop is ever briefly starved.
+        retry.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        retry.tick().await; // consume the immediate first tick
+
+        // Initial discovery round.
+        self.start_discovery().await;
+
+        loop {
+            tokio::select! {
+                recv = self.sock.recv() => {
+                    match recv {
+                        Ok(pkt) => self.handle_packet(&pkt).await,
+                        Err(_) => break,
+                    }
+                }
+                _ = retry.tick() => {
+                    if self.attempts_left > 0 {
+                        self.attempts_left -= 1;
+                        if self.attempts_left == 0 {
+                            tracing::info!(
+                                "ZIP GetNetInfo: no router answered; staying on network 0 with no zone"
+                            );
+                            // Discovery gave up; wake any waiters (dropping the
+                            // sender resolves their await).
+                            self.refresh_waiters.clear();
+                        } else if let Err(e) = self.send_request().await {
+                            tracing::warn!("ZIP: failed to resend GetNetInfo: {e}");
+                        }
+                    }
+                }
+                cmd = self.request_rx.recv() => {
+                    match cmd {
+                        Some(ZipCommand::Refresh(done)) => {
+                            self.refresh_waiters.push(done);
+                            self.start_discovery().await;
+                        }
+                        None => break, // all handles dropped
+                    }
+                }
+            }
+        }
+    }
+
+    /// Begin a discovery round: send the first request and arm the retry budget.
+    async fn start_discovery(&mut self) {
+        self.attempts_left = GNI_MAX_ATTEMPTS;
+        if let Err(e) = self.send_request().await {
+            tracing::warn!("ZIP: failed to send GetNetInfo: {e}");
+        }
+    }
+
+    /// Broadcast a GetNetInfo request to node 255 on the ZIP socket.
+    async fn send_request(&self) -> Result<(), io::Error> {
+        let mut buf = [0u8; 64];
+        let n = GetNetInfoRequest {
+            zone: self.remembered_zone.clone().unwrap_or_default(),
+        }
+        .to_bytes(&mut buf)
+        .map_err(io::Error::other)?;
+
+        let dest = DdpAddress::new(
+            AppleTalkAddress { network_number: 0, node_number: 255 },
+            ZIP_SOCKET,
+        );
+        self.sock.send_to(&buf[..n], dest).await
+    }
+
+    async fn handle_packet(&mut self, pkt: &Packet) {
+        if let Ok(reply) = GetNetInfoReply::parse(&pkt.payload) {
+            // The reply describes the cable it arrived on. The actor only
+            // runs where the underlay is in-process, so the link is known.
+            let source = pkt.source;
+            self.adopt(reply, Interface::from(source)).await;
+            self.attempts_left = 0;
+            for waiter in self.refresh_waiters.drain(..) {
+                let _ = waiter.send(());
+            }
+        } else if Notify::parse(&pkt.payload).is_ok() {
+            tracing::info!("ZIP Notify received; re-running GetNetInfo");
+            self.start_discovery().await;
+        }
+    }
+
+    /// Thread a GetNetInfo reply into the addressing layer and route table.
+    async fn adopt(&mut self, reply: GetNetInfoReply, iface: Interface) {
+        let (lo, hi) = (reply.range_start, reply.range_end);
+
+        // Prefer the default zone when the router rejected ours or we sent none.
+        let zone = if reply.zone_invalid() || reply.zone.is_empty() {
+            reply
+                .default_zone
+                .filter(|z| !z.is_empty())
+                .or_else(|| (!reply.zone.is_empty()).then_some(reply.zone))
+        } else {
+            Some(reply.zone)
+        };
+
+        tracing::info!(
+            "ZIP GetNetInfo ({iface:?}): network range {lo}-{hi}, zone {}",
+            zone.as_deref().unwrap_or("<none>")
+        );
+
+        if lo != 0 {
+            match iface {
+                // Nonextended cable: adopt the real network number directly;
+                // the LLAP-probed node number stays valid.
+                Interface::LocalTalk => {
+                    if let Some(lt) = self.lt_addressing.clone() {
+                        lt.adopt_network_number(lo).await;
+                    }
+                }
+                // Extended cable: if our provisional (startup-range) address
+                // is outside the advertised range, probe for a fresh one
+                // inside it, per the Phase 2 startup procedure.
+                Interface::EtherTalk => {
+                    if let Some(et) = self.et_addressing.clone() {
+                        et.acquire_in_range(lo, hi).await;
+                    }
+                }
+            }
+            self.route_table.set_local_range_for(iface, lo, hi);
+        }
+
+        if let Some(zone) = zone {
+            self.route_table.insert_zone(&zone, &[(lo, hi)]);
+            if let Some(path) = &self.zone_cache {
+                save_zone(path, &zone);
+            }
+            self.remembered_zone = Some(zone);
+        }
+    }
+}
+
+/// Handle to the ZIP actor. Cheap to clone; the actor lives until every handle
+/// is dropped.
+#[derive(Clone)]
+pub struct ZipHandle {
+    request_tx: mpsc::Sender<ZipCommand>,
+}
+
+impl ZipHandle {
+    /// Force a fresh GetNetInfo exchange, returning once the actor has adopted a
+    /// reply or exhausted its retry budget (no router present).
+    pub async fn refresh(&self) -> Result<(), io::Error> {
+        let (tx, rx) = oneshot::channel();
+        self.request_tx
+            .send(ZipCommand::Refresh(tx))
+            .await
+            .map_err(|_| io::Error::other("ZIP actor shut down"))?;
+        // A dropped sender (discovery gave up) resolves as Err; either way the
+        // round is over.
+        let _ = rx.await;
+        Ok(())
+    }
+}
+
+/// Load a cached zone name (trimmed, non-empty) from `path`, if it exists.
+fn load_zone(path: &Path) -> Option<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+}
+
+/// Persist the learned zone name to `path` for the next startup.
+fn save_zone(path: &Path, zone: &str) {
+    if let Err(e) = std::fs::write(path, zone) {
+        tracing::warn!("ZIP: failed to cache zone to {}: {e}", path.display());
+    }
+}


### PR DESCRIPTION
This update stabilizes the foundational network layer, bringing TailTalk to a place thats more like Linux-style routing semantics. These changes are essential for complex topologies (i.e routers present) and reliable Netatalk integration.

- Strict Interface Tagging & Deduplication: NextHop routing and local cable ranges are now strictly bound to an explicit `Interface`. Replaced heuristic guessing with a unified `RouteTable::resolve()` API, serving as the single source of truth across DDP, NBP, and RTMP. This replaces the suuuper ugly duplication we had all over the place.
- ZIP & Dynamic Addressing: Wired in the Zone Information Protocol (ZIP) actor. EtherTalk Phase 2 now correctly probes the $FF00–$FFFE startup range and acquires an address within the real cable range once a GNI reply is received.
- Route Expiry & Poisoning: RTMP routes now age out dynamically (60s expiry, 10s purge tick). Distance-31 ("poisoned") tuples now correctly withdraw routes instead of adopting them.
- Router Discovery Controls: Added `--no-router-discovery` (`TalkStackBuilder::disable_router_discovery()`) to step out of the way for clients like Netatalk that run their own control plane on sockets 1 and 6. Added `zone_cache()` for PRAM-style persistence so we remember what zone (if any) we were previously part of instead of querying each time.
- AARP & Loopback Fixes: Capped AARP lookups with a 2-second timeout to prevent DDP thread starvation, and fixed `{0, N}` loopback shadowing on Phase 2 interfaces.
- Resolved a re-entrant `RwLock` deadlock in `RouteTable::replace_contents` that caused remote daemon synchronization to hang.