### PR TITLE
ATP: ImageWriter LocalTalk quirks

### DIFF
--- a/tailtalk/src/atp.rs
+++ b/tailtalk/src/atp.rs
@@ -23,6 +23,10 @@ pub struct PendingRequestState {
     pub eom_seq: Option<u8>,
     pub raw_packet: Vec<u8>,
     pub destination: AtpAddress,
+    /// The bitmap we sent in the request, i.e. which response packet slots we
+    /// said we'd accept. Per ATP spec, a responder that fills exactly this
+    /// many slots doesn't need to set EOM - we already know it's done.
+    pub requested_bitmap: u8,
     /// Number of retransmissions sent so far (not counting the initial send).
     pub retry_count: u8,
 }
@@ -52,6 +56,7 @@ pub struct AtpSendRequest {
     pub address: AtpAddress,
     pub user_bytes: [u8; 4],
     pub data: Vec<u8>,
+    pub bitmap: u8,
     pub chan: AtpResponseChannel,
 }
 
@@ -225,17 +230,38 @@ impl AtpRequestor {
         self.cmd_tx.send(cmd).await.map_err(io::Error::other)
     }
 
+    /// Send a request and await its response, accepting up to 8 response packets
+    /// (bitmap `0xff`). Use [`send_request_with_bitmap`](Self::send_request_with_bitmap)
+    /// when the reply is known to always fit in fewer packets.
     pub async fn send_request(
         &self,
         address: AtpAddress,
         user_bytes: [u8; 4],
         data: Vec<u8>,
     ) -> Result<(Vec<u8>, [u8; 4]), io::Error> {
+        self.send_request_with_bitmap(address, user_bytes, data, 0xff).await
+    }
+
+    /// Send a request, advertising exactly which response packet slots (0-7) we'll
+    /// accept via `bitmap`. A responder that fills every requested slot is
+    /// recognized as complete immediately, without waiting for EOM — per ATP spec,
+    /// EOM only matters when the responder sends *fewer* packets than requested.
+    /// Pass `0x01` for requests whose reply is known to always be a single packet
+    /// (e.g. PAP OpenConn/CloseConn) to skip the stalled-retransmit fallback in
+    /// `retransmit_pending` for responders that never set EOM.
+    pub async fn send_request_with_bitmap(
+        &self,
+        address: AtpAddress,
+        user_bytes: [u8; 4],
+        data: Vec<u8>,
+        bitmap: u8,
+    ) -> Result<(Vec<u8>, [u8; 4]), io::Error> {
         let (tx, rx) = oneshot::channel();
         let cmd = AtpCommand::SendRequest(AtpSendRequest {
             address,
             user_bytes,
             data,
+            bitmap,
             chan: tx,
         });
 
@@ -424,7 +450,7 @@ impl Atp {
             xo: true,   // internal assumption: always exactly once for now
             eom: false, // EOM must be 0 for TReq packets according to AppleTalk specs
             sts: false,
-            bitmap_seq_num: 0xff, // 8 buffers/packets
+            bitmap_seq_num: req.bitmap,
             tid,
             user_bytes: req.user_bytes,
         };
@@ -475,6 +501,7 @@ impl Atp {
                     eom_seq: None,
                     raw_packet,
                     destination: req.address,
+                    requested_bitmap: req.bitmap,
                     retry_count: 0,
                 },
             );
@@ -589,6 +616,35 @@ impl Atp {
         }
     }
 
+    /// Remove a pending transaction, hand its accumulated data to the caller, and
+    /// (for XO transactions) send the Release that tells the responder it can
+    /// drop its retry cache entry for this TID.
+    async fn complete_transaction(&mut self, tid: u16, source: AtpAddress) {
+        let Some(mut state) = self.pending_transactions.remove(&tid) else {
+            return;
+        };
+
+        let mut full_data = Vec::new();
+        let expected_count = state
+            .eom_seq
+            .map(|e| e as usize + 1)
+            .unwrap_or(state.received_packets.len());
+        for i in 0..expected_count as u8 {
+            if let Some(p) = state.received_packets.remove(&i) {
+                full_data.extend_from_slice(&p);
+            }
+        }
+        let user_bytes = state.user_bytes.unwrap_or([0; 4]);
+        let xo = state.xo;
+
+        let _ = state.chan.send(Ok((full_data, user_bytes)));
+
+        if xo {
+            let rel = AtpSendRelease { destination: source, tid };
+            self.handle_send_release(rel).await;
+        }
+    }
+
     async fn handle_packet(&mut self, ddp: DdpPacket, payload: &mut [u8]) {
         let packet = match AtpPacket::parse(payload) {
             Ok(p) => p,
@@ -637,6 +693,7 @@ impl Atp {
             }
             AtpFunction::Response => {
                 // Client-side: handle response to our request
+                let mut is_complete = false;
                 if let std::collections::hash_map::Entry::Occupied(mut entry) =
                     self.pending_transactions.entry(packet.tid)
                 {
@@ -653,47 +710,33 @@ impl Atp {
                         }
 
                         // Check if complete
-                        let mut is_complete = false;
                         if let Some(eom) = state.eom_seq {
                             // if we have all packets from 0 to eom
                             if (0..=eom).all(|i| state.received_packets.contains_key(&i)) {
                                 is_complete = true;
                             }
-                        } else if state.received_packets.len() == 8 {
-                            // 8 packets received and no EOM
+                        } else if !state.received_packets.is_empty()
+                            && state.received_packets.len()
+                                == state.requested_bitmap.count_ones() as usize
+                        {
+                            // Filled every slot we asked for — per ATP spec, EOM isn't
+                            // required in this case since we already know the count.
                             is_complete = true;
-                        }
-
-                        if is_complete {
-                            let (_, mut state) = entry.remove_entry();
-                            let mut full_data = Vec::new();
-                            let expected_count = state.eom_seq.map(|e| e + 1).unwrap_or(8);
-                            for i in 0..expected_count {
-                                if let Some(p) = state.received_packets.remove(&i) {
-                                    full_data.extend_from_slice(&p);
-                                }
-                            }
-                            let user_bytes = state.user_bytes.unwrap_or([0; 4]);
-
-                            let _ = state.chan.send(Ok((full_data, user_bytes)));
-
-                            if state.xo {
-                                // send release
-                                let rel = AtpSendRelease {
-                                    destination: AtpAddress {
-                                        network_number: ddp.src_network_num,
-                                        node_number: ddp.src_node_id,
-                                        socket_number: ddp.src_sock_num,
-                                    },
-                                    tid: packet.tid,
-                                };
-                                self.handle_send_release(rel).await;
-                            }
                         }
                     } else {
                         tracing::warn!("ATP Response payload too short");
                         // We do not remove the transaction here, just ignore the bad packet
                     }
+                }
+                // `entry` (and its borrow of pending_transactions) is dropped here,
+                // so complete_transaction is free to remove it.
+                if is_complete {
+                    let source = AtpAddress {
+                        network_number: ddp.src_network_num,
+                        node_number: ddp.src_node_id,
+                        socket_number: ddp.src_sock_num,
+                    };
+                    self.complete_transaction(packet.tid, source).await;
                 }
             }
             AtpFunction::Release => {

--- a/tailtalk/src/pap.rs
+++ b/tailtalk/src/pap.rs
@@ -74,7 +74,7 @@ impl PapClient {
             tracing::info!("PAP: Sending OpenConn to {:?}", address);
             let (resp_data, resp_user_bytes) = self
                 .atp_requestor
-                .send_request(address, user_bytes, data.to_vec())
+                .send_request_with_bitmap(address, user_bytes, data.to_vec(), 0x01)
                 .await?;
 
             let reply = PapPacket::parse_from_atp(resp_user_bytes, &resp_data)?;
@@ -299,7 +299,7 @@ impl PapClient {
         let (ub, d) = close_pkt.to_atp_parts();
         // Must go to server_addr (per-connection socket), not remote_addr (NBP listening socket).
         self.atp_requestor
-            .send_request(self.server_addr, ub, d.to_vec())
+            .send_request_with_bitmap(self.server_addr, ub, d.to_vec(), 0x01)
             .await?;
         Ok(())
     }
@@ -313,7 +313,9 @@ impl PapClient {
             data: vec![],
         };
         let (ub, d) = pkt.to_atp_parts();
-        let (resp_data, resp_ub) = atp.send_request(address, ub, d.to_vec()).await?;
+        let (resp_data, resp_ub) = atp
+            .send_request_with_bitmap(address, ub, d.to_vec(), 0x01)
+            .await?;
 
         let reply = PapPacket::parse_from_atp(resp_ub, &resp_data)?;
 


### PR DESCRIPTION
The ImageWriter LocalTalk card seems to have been built on a Friday and is a painfully quirky little device. For ATP requests sent by us we were just defaulting to a bitmap of 8 packets for all types and just waited for the EOM flag. So far this worked OK, but, on the ImageWriter it responds with a single packet _without_ the EOM flag set. This then makes us wait forever on messages that will never come and we end up timing out and discarding the transaction.

It seems what classic Mac OS does for these is to just set it to 1 packet bitmap so the single packet response can be assumed to safely be the end of it. To make the same work for us I've added a new API "send_request_with_bitmap()" that lets the caller specify the bitmap size. For all ones where a single packet is the expectation we set it to 1, like OpenConn/OpenConnReply. This seems to make us able to talk properly to an ImageWriter.