### PR TITLE
Add a printer query + settings tool for TailTalk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,38 +20,56 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "accesskit"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eca13c82f9a5cd813120b2e9b6a5d10532c6e4cd140c295cebd1f770095c8a5"
+checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "accesskit_atspi_common"
-version = "0.15.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb9cc46b7fb6987c4f891f0301b230b29d9e69b4854f060a0cf41fbc407ab77"
+checksum = "023da0e5097f46df7092d5280b02efb9bbf8d93298daeced42652463e357d636"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
  "atspi-common",
+ "phf",
  "serde",
  "zvariant",
 ]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.32.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d880a613f29621c90e801feec40f5dd61d837d7e20bf9b67676d45e7364a36"
+checksum = "5d10a236f96f87d70732e44520046785431ef01d5bcd6b041317bfadd2f88245"
 dependencies = [
  "accesskit",
  "hashbrown 0.16.1",
 ]
 
 [[package]]
-name = "accesskit_macos"
-version = "0.23.0"
+name = "accesskit_ios"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0ddfc3fe3d457d11cc1c4989105986a03583a1d54d0c25053118944b62e100"
+checksum = "750c4e9f6ce888dfe8a10c0f1b5ceb646a7854fd46579d74919219d1bb314083"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit 0.2.2",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce02dc63b43f0c9296af9ac946312a2dc8814427d7a64d2d600971dac55b6076"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -63,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_unix"
-version = "0.18.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d552169ef018149966ed139bb0311c6947b3343e9140d1b9f88d69da9528fd"
+checksum = "03e156ed3802e35eefe894ef2671bc6c889303d8a7e110b5e1b48f504b91362f"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -81,25 +99,26 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.30.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d277279d0a3b0c0021dd110b55aa1fe326b09ee2cbc338df28f847c7daf94e25"
+checksum = "106c2b961215864d1c2e703ee63269c25c4e80a577ffb2c1017b9c17dcdf83a1"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
  "hashbrown 0.16.1",
  "static_assertions",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.30.0"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db08dff285306264a1de127ea07bb9e7a1ed71bd8593c168d0731caa782516c9"
+checksum = "d5b41e63a69f36d9f1f41e70464c7e5f72eee485ef26aab19f0b4f86e6c0a84c"
 dependencies = [
  "accesskit",
+ "accesskit_ios",
  "accesskit_macos",
  "accesskit_unix",
  "accesskit_windows",
@@ -557,7 +576,7 @@ dependencies = [
  "log",
  "num-rational",
  "num-traits",
- "pastey",
+ "pastey 0.1.1",
  "rayon",
  "thiserror 2.0.18",
  "v_frame",
@@ -1024,7 +1043,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1138,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "const-field-offset"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fcde4ca1211b5a94b573083c472ee19e86b19a441913f66e1cc5c41daf0255"
+checksum = "9713489fbc45a2d113f58d17448c73115d533ed27fd2f2d0e5e5c69663eaf19b"
 dependencies = [
  "const-field-offset-macro",
  "field-offset",
@@ -1148,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "const-field-offset-macro"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5387f5bbc9e9e6c96436ea125afa12614cebf8ac67f49abc08c1e7a891466c90"
+checksum = "9b5dc851b7ea80cc4f69aa28632385ffd3e0f88014d53db3f2e5a781896ca783"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1250,53 +1269,6 @@ name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
-
-[[package]]
-name = "cpp"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f6422bf20bc0654eac481a29a03e6d9121ad9f12345a03773b8a76a8701915"
-dependencies = [
- "cpp_macros",
-]
-
-[[package]]
-name = "cpp_build"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6fed3200ba0708c2adca5f6ed5ae202edd824bd4cbac7935a85edac9bcddce"
-dependencies = [
- "cc",
- "cpp_common",
- "proc-macro2",
- "regex",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
-name = "cpp_common"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7280a73ef92e18d27d2ec3005b57fe0043b51d1b506be86b0bf66f588f9857b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
-name = "cpp_macros"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc7fd49a5b246251229ea4d4bf94c8d418689a1f9986ef96e00b64992922169"
-dependencies = [
- "aho-corasick",
- "byteorder",
- "cpp_common",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -1913,21 +1885,20 @@ dependencies = [
 
 [[package]]
 name = "femtovg"
-version = "0.20.4"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35695993a8264f5dfa8facc135c003965cea40d83705b49e0f8c3a3b632a2171"
+checksum = "f43d05da42e81724c16d34a150fb7fda53d3f786e5a94673ee526ff8602f0f6a"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
  "fnv",
  "glow",
- "image",
  "imgref",
  "itertools 0.14.0",
  "log",
  "rgb",
  "slotmap",
- "ttf-parser 0.25.1",
+ "swash",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1958,6 +1929,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed_decimal"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c3c892f121fff406e5dd6b28c1b30096b95111c30701a899d4f2b18da6d1bd"
+dependencies = [
+ "displaydoc",
+ "smallvec",
+ "writeable",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -2021,18 +2003,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.10.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "font-types"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d9237c6d82152100c691fb77ea18037b402bcc7257d2c876a4ffac81bc22a1c"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
 dependencies = [
  "bytemuck",
 ]
@@ -2046,40 +2019,28 @@ dependencies = [
  "log",
  "slotmap",
  "tinyvec",
- "ttf-parser 0.25.1",
-]
-
-[[package]]
-name = "fontdue"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e57e16b3fe8ff4364c0661fdaac543fb38b29ea9bc9c2f45612d90adf931d2b"
-dependencies = [
- "hashbrown 0.15.5",
- "rayon",
- "ttf-parser 0.21.1",
+ "ttf-parser",
 ]
 
 [[package]]
 name = "fontique"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bbc252c93499b6d3635d692f892a637db0dbb130ce9b32bf20b28e0dcc470b"
+checksum = "274fa4f0f0a926ae182c7c076c078cce8a38471d15e61a102a02cac984be9813"
 dependencies = [
- "bytemuck",
- "hashbrown 0.16.1",
- "icu_locale_core",
+ "hashbrown 0.17.0",
  "linebender_resource_handle",
  "memmap2",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-text",
  "objc2-foundation 0.3.2",
- "read-fonts 0.35.0",
+ "parlance",
+ "read-fonts 0.39.2",
  "roxmltree",
  "smallvec",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows",
+ "windows-core",
  "yeslogic-fontconfig-sys",
 ]
 
@@ -2325,7 +2286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2407,9 +2368,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glow"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -2484,6 +2445,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "grid"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2496,14 +2463,13 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.3.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c020db12c71d8a12a3fe7607873cade3a01a6287e29d540c8723276221b9d8"
+checksum = "d12c7c642d4ce8c2e784b4751a6634bd89583912265add4a679a8882d123fbcd"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
- "core_maths",
- "read-fonts 0.35.0",
+ "read-fonts 0.39.2",
  "smallvec",
 ]
 
@@ -2519,10 +2485,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
- "rayon",
 ]
 
 [[package]]
@@ -2541,6 +2504,9 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -2682,12 +2648,13 @@ dependencies = [
 
 [[package]]
 name = "i-slint-backend-linuxkms"
-version = "1.15.1"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b8827952ecfbbf76c8cb5bc3388ca9124c34f2b4fe5dffcfe57800d2a484885"
+checksum = "68e76f2b13846ca54bba6b8eb3b5454b26879ad987396d0a2d8abedc31a6c469"
 dependencies = [
  "bytemuck",
  "calloop 0.14.4",
+ "cfg_aliases",
  "drm",
  "gbm",
  "glutin",
@@ -2697,39 +2664,21 @@ dependencies = [
  "i-slint-renderer-software",
  "input",
  "memmap2",
- "nix 0.30.1",
+ "nix 0.31.3",
  "raw-window-handle",
  "xkbcommon",
 ]
 
 [[package]]
-name = "i-slint-backend-qt"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9d5db3221f453439ec5ad9b6ac3bb8d2b4825b2f8734f0cde4b67d7336c3da"
-dependencies = [
- "const-field-offset",
- "cpp",
- "cpp_build",
- "i-slint-common",
- "i-slint-core",
- "i-slint-core-macros",
- "lyon_path",
- "pin-project",
- "pin-weak",
- "qttypes",
- "vtable",
-]
-
-[[package]]
 name = "i-slint-backend-selector"
-version = "1.15.1"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5a7e591a7257096e1f3da1bbb9ad6a140c307d0eee74f008a0b412fdb20dec"
+checksum = "2247a4590a02a466b2f4916cc789dfe66247f6af826f00eb84a2685259a45c1c"
 dependencies = [
  "cfg-if",
+ "cfg_aliases",
  "i-slint-backend-linuxkms",
- "i-slint-backend-qt",
+ "i-slint-backend-testing",
  "i-slint-backend-winit",
  "i-slint-common",
  "i-slint-core",
@@ -2738,10 +2687,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "i-slint-backend-winit"
-version = "1.15.1"
+name = "i-slint-backend-testing"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbf4789191740f939c9563b8850379122d7b5c1ceb09f9297b50ad53e408787"
+checksum = "521e901e3d47ab829c0ef500c63155776208707cd93259e6a7803ed627fa2786"
+dependencies = [
+ "cfg_aliases",
+ "i-slint-common",
+ "i-slint-core",
+ "i-slint-renderer-software",
+ "vtable",
+]
+
+[[package]]
+name = "i-slint-backend-winit"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a27c7e8f53418d3017362465367b6612b6e439a68097d627d1b91c94b885f0a6"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -2778,32 +2740,41 @@ dependencies = [
  "vtable",
  "wasm-bindgen",
  "web-sys",
- "windows 0.62.2",
+ "webbrowser",
+ "windows",
  "winit",
  "zbus",
 ]
 
 [[package]]
 name = "i-slint-common"
-version = "1.15.1"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7659797fd28d4df3ed275ff95bf730bdf4a88d253f07e1ee8d0032d70138c3a"
+checksum = "52e63f8ea55ba21e44567ae67d2b01a4f5d09bb1fab693b1e6c79d96bef9e456"
 dependencies = [
+ "derive_more",
  "fontique",
- "ttf-parser 0.25.1",
+ "htmlparser",
+ "icu_decimal",
+ "icu_locale_core",
+ "icu_provider",
+ "pulldown-cmark",
+ "resvg",
+ "skrifa 0.42.1",
 ]
 
 [[package]]
 name = "i-slint-compiler"
-version = "1.15.1"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a6f358d0d5389869d67cd6ab6f5acf98fe31827264a696593e9687213cff682"
+checksum = "45ea275b15a425c7f2f77481151e1f5f8f1ea83feae580273090ef6b9e192218"
 dependencies = [
  "annotate-snippets",
  "by_address",
+ "data-url",
  "derive_more",
- "fontdue",
  "i-slint-common",
+ "icu_normalizer",
  "image",
  "itertools 0.14.0",
  "linked_hash_set",
@@ -2816,18 +2787,22 @@ dependencies = [
  "resvg",
  "rowan",
  "rspolib",
+ "skrifa 0.42.1",
  "smol_str 0.3.6",
  "strum",
+ "swash",
  "typed-index-collections",
+ "unicode-segmentation",
  "url",
 ]
 
 [[package]]
 name = "i-slint-core"
-version = "1.15.1"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95591ff85f8e2ff11c8d26ea8429768c2b77866e0c7e7fd49348f23ad108b5c"
+checksum = "4e407dc2bd5385dcbdd9c1cf927213d2e4bacda667545abf8839c60f8290f754"
 dependencies = [
+ "async-channel",
  "auto_enums",
  "bitflags 2.11.0",
  "cfg-if",
@@ -2836,31 +2811,34 @@ dependencies = [
  "const-field-offset",
  "derive_more",
  "euclid",
- "htmlparser",
  "i-slint-common",
  "i-slint-core-macros",
+ "icu_normalizer",
  "image",
+ "ksni",
  "lyon_algorithms",
  "lyon_extra",
  "lyon_geom",
  "lyon_path",
  "num-traits",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "parley",
  "pin-project",
  "pin-weak",
  "portable-atomic",
- "pulldown-cmark",
  "raw-window-handle",
  "resvg",
  "rgb",
- "scoped-tls-hkt",
  "scopeguard",
- "skrifa 0.37.0",
+ "skrifa 0.42.1",
  "slab",
  "strum",
+ "swash",
  "sys-locale",
- "thiserror 2.0.18",
+ "taffy",
  "unicode-linebreak",
  "unicode-script",
  "unicode-segmentation",
@@ -2868,13 +2846,14 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "web-time",
+ "windows",
 ]
 
 [[package]]
 name = "i-slint-core-macros"
-version = "1.15.1"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc5f2f71682787dd5c6299555c0de635009eb269bbc54d6198e0d225b69fae4"
+checksum = "3a842640da4c4d0909d25cc5a51e1f9cde02bd48f7fdfa94df10d595d4e3c80a"
 dependencies = [
  "quote",
  "serde_json",
@@ -2883,9 +2862,9 @@ dependencies = [
 
 [[package]]
 name = "i-slint-renderer-femtovg"
-version = "1.15.1"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb6eccda447999bc6222988500b841b64c953988986af182334e7ba9a30f0edd"
+checksum = "78d0d99a18d66738b684758fe8460743a0aa0f64a96e05940942231a340085b1"
 dependencies = [
  "cfg-if",
  "const-field-offset",
@@ -2899,20 +2878,20 @@ dependencies = [
  "lyon_path",
  "pin-weak",
  "rgb",
- "ttf-parser 0.25.1",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "i-slint-renderer-skia"
-version = "1.15.1"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64546232c0370f291e65fc92a4f4fc777ea78d5f48467873cb968b1de52e9ab"
+checksum = "7b6eed7f3f0a9a3d3ca6e8b9d4ca233371d989351fdb2a7ab88ec368b99e7b57"
 dependencies = [
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
+ "clru",
  "const-field-offset",
  "derive_more",
  "glow",
@@ -2930,33 +2909,33 @@ dependencies = [
  "pin-weak",
  "raw-window-handle",
  "raw-window-metal",
- "read-fonts 0.35.0",
+ "read-fonts 0.39.2",
  "scoped-tls-hkt",
  "skia-safe",
  "softbuffer",
  "unicode-segmentation",
  "vtable",
- "windows 0.62.2",
+ "windows",
  "write-fonts",
 ]
 
 [[package]]
 name = "i-slint-renderer-software"
-version = "1.15.1"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a59be6c34935c4f8e41aa67a63518d5c59219c8eeb1d07af420bed8334fa31d7"
+checksum = "73496f164f8e471877c35e0fadb996dcc674922712abd9c2be2cbe80c58859bd"
 dependencies = [
  "bytemuck",
  "clru",
  "derive_more",
  "euclid",
- "fontdue",
  "i-slint-common",
  "i-slint-core",
  "integer-sqrt",
  "lyon_path",
  "num-traits",
- "skrifa 0.37.0",
+ "skrifa 0.42.1",
+ "swash",
  "zeno",
 ]
 
@@ -2972,7 +2951,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2999,6 +2978,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_decimal"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "288247df2e32aa776ac54fdd64de552149ac43cb840f2761811f0e8d09719dd4"
+dependencies = [
+ "displaydoc",
+ "fixed_decimal",
+ "icu_decimal_data",
+ "icu_locale",
+ "icu_locale_core",
+ "icu_plurals",
+ "icu_provider",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_decimal_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f14a5ca9e8af29eef62064f269078424283d90dbaffeac5225addf62aaabc22"
+
+[[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locale_core"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3011,6 +3028,12 @@ dependencies = [
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
@@ -3031,6 +3054,25 @@ name = "icu_normalizer_data"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_plurals"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a50023f1d49ad5c4333380328a0d4a19e4b9d6d842ec06639affd5ba47c8103"
+dependencies = [
+ "fixed_decimal",
+ "icu_locale",
+ "icu_plurals_data",
+ "icu_provider",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_plurals_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8485497155dc865f901decb93ecc20d3e467df67bfeceb91e3ba34e2b11e8e1d"
 
 [[package]]
 name = "icu_properties"
@@ -3060,12 +3102,35 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964"
+dependencies = [
+ "icu_collections",
+ "icu_locale",
+ "icu_provider",
+ "icu_segmenter_data",
+ "potential_utf",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
 
 [[package]]
 name = "id-arena"
@@ -3138,7 +3203,7 @@ dependencies = [
  "image-webp",
  "moxcms",
  "num-traits",
- "png 0.18.1",
+ "png",
  "qoi",
  "ravif",
  "rayon",
@@ -3184,9 +3249,9 @@ dependencies = [
 
 [[package]]
 name = "input"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdc09524a91f9cacd26f16734ff63d7dc650daffadd2b6f84d17a285bd875a9"
+checksum = "f9793345a65d71317763a33066b5d8351f8760dde8d4930fe9e39b5f14a7959d"
 dependencies = [
  "bitflags 2.11.0",
  "input-sys",
@@ -3321,7 +3386,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3398,7 +3463,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "thiserror 2.0.18",
- "windows 0.62.2",
+ "windows",
  "zbus",
 ]
 
@@ -3420,14 +3485,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
-name = "kurbo"
-version = "0.12.0"
+name = "ksni"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
+checksum = "814b44c24cd2cb236c3b8a41c7f08237b452a8e76ecaa81f1cec40b5b678215b"
 dependencies = [
- "arrayvec",
- "euclid",
- "smallvec",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "futures-channel",
+ "futures-lite",
+ "futures-util",
+ "pastey 0.2.3",
+ "serde",
+ "task-local",
+ "zbus",
 ]
 
 [[package]]
@@ -3482,7 +3554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3911,9 +3983,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
+checksum = "1dd04e60bc0b07438a6771710ee1698f98f6ebbc7f89b61264af1563b8aeb878"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -3923,9 +3995,9 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
  "once_cell",
- "png 0.17.16",
+ "png",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4014,9 +4086,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -4591,7 +4663,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
- "ttf-parser 0.25.1",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -4676,21 +4748,40 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
-name = "parley"
-version = "0.7.0"
+name = "parlance"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada5338c3a9794af7342e6f765b6e78740db37378aced034d7bf72c96b94ed94"
+checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
+
+[[package]]
+name = "parley"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1cfcf399c774719fb1fa51bc6b91e86bdf003b03202a0902f1827ba6750746"
 dependencies = [
  "fontique",
  "harfrust",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_segmenter",
  "linebender_resource_handle",
- "skrifa 0.37.0",
- "swash",
+ "parlance",
+ "parley_data",
+ "skrifa 0.42.1",
+]
+
+[[package]]
+name = "parley_data"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1d3755e2cc12c0625b0cd2f2773c6a37dd11d1531940c945ade4aeb78f2b145"
+dependencies = [
+ "icu_properties",
 ]
 
 [[package]]
@@ -4704,6 +4795,12 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pcap"
@@ -4783,6 +4880,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4851,19 +4991,6 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
-name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
@@ -4910,6 +5037,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -4954,7 +5083,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5132,17 +5261,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
-]
-
-[[package]]
-name = "qttypes"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7edf5b38c97ad8900ad2a8418ee44b4adceaa866a4a3405e2f1c909871d7ebd"
-dependencies = [
- "cpp",
- "cpp_build",
- "semver",
 ]
 
 [[package]]
@@ -5398,23 +5516,22 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
-dependencies = [
- "bytemuck",
- "core_maths",
- "font-types 0.10.1",
-]
-
-[[package]]
-name = "read-fonts"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
 dependencies = [
  "bytemuck",
- "font-types 0.11.2",
+ "font-types",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+dependencies = [
+ "bytemuck",
+ "font-types",
 ]
 
 [[package]]
@@ -5533,9 +5650,9 @@ dependencies = [
 
 [[package]]
 name = "resvg"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b563218631706d614e23059436526d005b50ab5f2d506b55a17eb65c5eb83419"
+checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
 dependencies = [
  "gif",
  "image-webp",
@@ -5543,7 +5660,7 @@ dependencies = [
  "pico-args",
  "rgb",
  "svgtypes",
- "tiny-skia",
+ "tiny-skia 0.12.0",
  "usvg",
  "zune-jpeg",
 ]
@@ -5771,7 +5888,7 @@ dependencies = [
  "core_maths",
  "log",
  "smallvec",
- "ttf-parser 0.25.1",
+ "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
  "unicode-properties",
@@ -5830,7 +5947,7 @@ dependencies = [
  "log",
  "memmap2",
  "smithay-client-toolkit 0.19.2",
- "tiny-skia",
+ "tiny-skia 0.11.4",
 ]
 
 [[package]]
@@ -6008,7 +6125,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.3.14",
+ "errno 0.2.8",
  "libc",
 ]
 
@@ -6070,9 +6187,9 @@ dependencies = [
 
 [[package]]
 name = "skia-bindings"
-version = "0.90.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6f96e00735f14a781aac8a6870c862b8cc831df6d8e4ad77ab78e11411b9af"
+checksum = "3e2d1c3ebd697c0cbded0145e9204a38fa6b268446051b7196d0a096414ea7f3"
 dependencies = [
  "bindgen",
  "cc",
@@ -6082,28 +6199,18 @@ dependencies = [
  "regex",
  "serde_json",
  "tar",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
 name = "skia-safe"
-version = "0.90.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a71c01d325d40b1031dee67d251a5e0132e79e2a9ec272149a4f4a0d4b8b3be"
+checksum = "9f512ac418a64194842dd05566320805dad1c957c521039db2486fd6368865bc"
 dependencies = [
  "bitflags 2.11.0",
  "skia-bindings",
- "windows 0.62.2",
-]
-
-[[package]]
-name = "skrifa"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
-dependencies = [
- "bytemuck",
- "read-fonts 0.35.0",
+ "windows",
 ]
 
 [[package]]
@@ -6114,6 +6221,16 @@ checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
 dependencies = [
  "bytemuck",
  "read-fonts 0.37.0",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.39.2",
 ]
 
 [[package]]
@@ -6140,12 +6257,11 @@ dependencies = [
 
 [[package]]
 name = "slint"
-version = "1.15.1"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25b87d458205e79efb30545cae083aec2ccb1b192c46a55ae6d54403cdacb33"
+checksum = "ce12038f57f8f3a423564b0c9301a2ab3fda4246e4cbadd6b97acf9124bdc315"
 dependencies = [
  "const-field-offset",
- "i-slint-backend-qt",
  "i-slint-backend-selector",
  "i-slint-common",
  "i-slint-core",
@@ -6162,22 +6278,22 @@ dependencies = [
 
 [[package]]
 name = "slint-build"
-version = "1.15.1"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064ef470cc8ab046319db94d0727f080fbd05322d07d774eb6de607d97defb8d"
+checksum = "76684c11441f775b10bbc7b0e6b3016a39f17efdd659ffca112f17cfd6bdaed1"
 dependencies = [
  "derive_more",
  "fontique",
  "i-slint-compiler",
  "spin_on",
- "toml_edit 0.24.1+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
 name = "slint-macros"
-version = "1.15.1"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecc09bbc42c780d5b7ed7d41f7573dfd67343e11cdac27c07b88a8f933958e6"
+checksum = "9f2a763e72e1e53c496f571d36327e777da1eb0d9e58fceb83890c2a83ee7223"
 dependencies = [
  "i-slint-compiler",
  "proc-macro2",
@@ -6402,18 +6518,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6449,7 +6565,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
 dependencies = [
- "kurbo 0.13.0",
+ "kurbo",
  "siphasher",
 ]
 
@@ -6527,6 +6643,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "taffy"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aea22054047c16c3f34d3ac473a2170be1424b1115b2a3adcf28cfb067c88859"
+dependencies = [
+ "arrayvec",
+ "grid",
+ "serde",
+ "slotmap",
+]
+
+[[package]]
 name = "tailtalk"
 version = "0.8.0"
 dependencies = [
@@ -6597,7 +6725,7 @@ dependencies = [
  "tailtalk",
  "tailtalk-packets",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -6649,6 +6777,15 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "task-local"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2972044a9e5e448a506a7ff6f0d03b566d8ef4cd6918a58fc59835a0f8666626"
+dependencies = [
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -6775,8 +6912,22 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
- "png 0.17.16",
- "tiny-skia-path",
+ "tiny-skia-path 0.11.4",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path 0.12.0",
 ]
 
 [[package]]
@@ -6784,6 +6935,17 @@ name = "tiny-skia-path"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -6897,21 +7059,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
@@ -6919,19 +7066,10 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.1",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -6945,26 +7083,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.24.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
-dependencies = [
- "indexmap",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow 1.0.1",
 ]
 
@@ -7109,12 +7235,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "ttf-parser"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
 name = "ttf-parser"
@@ -7283,16 +7403,16 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e419dff010bb12512b0ae9e3d2f318dfbdf0167fde7eb05465134d4e8756076f"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
 dependencies = [
  "base64",
  "data-url",
  "flate2",
  "fontdb",
  "imagesize",
- "kurbo 0.13.0",
+ "kurbo",
  "log",
  "pico-args",
  "roxmltree",
@@ -7301,7 +7421,8 @@ dependencies = [
  "siphasher",
  "strict-num",
  "svgtypes",
- "tiny-skia-path",
+ "tiny-skia-path 0.12.0",
+ "ttf-parser",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",
@@ -7362,9 +7483,9 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vtable"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "753be81c38dff787d177b5939af1fa16f72f0d0d21a6b7d74ae56e29cd26f2a6"
+checksum = "5ea953f65593feb5287b022b83c35046d1ff49c7417b6f5851a079d8a231fe31"
 dependencies = [
  "const-field-offset",
  "portable-atomic",
@@ -7374,9 +7495,9 @@ dependencies = [
 
 [[package]]
 name = "vtable-macro"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfcf6171aa2b0f85718ca5888ca32f6edf61d1849f8e4b3786ad890e5b68f68"
+checksum = "482a37f9777480673d3a99c80ac2edc69f92382230440946855fa27ebc47cba6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7684,6 +7805,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7731,46 +7868,14 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -7779,33 +7884,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -7814,22 +7893,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -7838,20 +7906,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -7859,17 +7916,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7889,25 +7935,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-numerics"
@@ -7915,26 +7945,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -7943,26 +7955,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -7971,7 +7964,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -8029,7 +8022,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -8069,7 +8062,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -8082,20 +8075,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -8426,15 +8410,15 @@ dependencies = [
 
 [[package]]
 name = "write-fonts"
-version = "0.43.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "886614b5ce857341226aa091f3c285e450683894acaaa7887f366c361efef79d"
+checksum = "cb731d4c4d93eacc69a1ad2f270f905788a98e4a3438267bcafbe08d3431c8d8"
 dependencies = [
- "font-types 0.10.1",
+ "font-types",
  "indexmap",
- "kurbo 0.12.0",
+ "kurbo",
  "log",
- "read-fonts 0.35.0",
+ "read-fonts 0.39.2",
 ]
 
 [[package]]
@@ -8754,6 +8738,7 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]

--- a/tailtalk-gui/main.rs
+++ b/tailtalk-gui/main.rs
@@ -18,6 +18,30 @@ slint::include_modules!();
 
 mod ipp_bridge;
 mod lw_bridge;
+mod printer_tool;
+
+/// The running stack's protocol handles, published for the Printer Tool window
+/// so it can talk to printers over the live stack rather than opening a second
+/// one (which would fail to reclaim an in-use TashTalk serial port). `None`
+/// whenever the server is stopped.
+#[derive(Clone)]
+pub struct PrinterHandles {
+    pub nbp: tailtalk::nbp::NbpHandle,
+    pub ddp: tailtalk::ddp::DdpHandle,
+    /// Watches on this stack's own AppleTalk address, one per configured
+    /// transport. The Printer Tool uses these to drop NBP registrations that
+    /// point back at us — chiefly the built-in LaserWriter emulator, which
+    /// answers the same `=:LaserWriter@*` lookup real printers do. Matching on
+    /// address rather than name means a real printer sharing the emulator's
+    /// name is still listed, and any future self-advertised printer is caught
+    /// without extra bookkeeping. Watches (not plain values) because AARP can
+    /// renumber the node after a conflict.
+    pub local_addrs: Vec<tokio::sync::watch::Receiver<Option<tailtalk_packets::aarp::AppleTalkAddress>>>,
+}
+
+/// Shared slot holding [`PrinterHandles`] while the stack is up. `std::sync::Mutex`
+/// (not tokio's) because the Slint menu callback reads it on the UI thread.
+type PrinterHandleStore = Arc<std::sync::Mutex<Option<PrinterHandles>>>;
 
 // ── Persisted user configuration ──────────────────────────────────────────────
 
@@ -248,6 +272,8 @@ fn main() -> anyhow::Result<()> {
     // only while running; dropping it releases the assertion.
     let keep_awake: Arc<std::sync::Mutex<Option<keepawake::KeepAwake>>> =
         Arc::new(std::sync::Mutex::new(None));
+    // Live NBP/DDP handles for the Printer Tool; populated while the stack runs.
+    let printer_handles: PrinterHandleStore = Arc::new(std::sync::Mutex::new(None));
 
     let (_log_guard, log_dir) = init_logging();
 
@@ -350,7 +376,20 @@ fn main() -> anyhow::Result<()> {
         ui_handle,
         active_handle.clone(),
         keep_awake.clone(),
+        printer_handles.clone(),
     ));
+
+    // ── Printer Tool (File menu) ─────────────────────────────────────────────
+    {
+        // Holds the window alive past the callback that created it; also lets a
+        // second invocation re-focus the existing window instead of opening another.
+        let window_slot: Rc<RefCell<Option<PrinterToolWindow>>> = Rc::new(RefCell::new(None));
+        let rt_handle = rt_handle.clone();
+        let printer_handles = printer_handles.clone();
+        ui.on_open_printer_tool(move || {
+            printer_tool::open(&rt_handle, printer_handles.clone(), window_slot.clone());
+        });
+    }
 
     let ui_weak = ui.as_weak();
     #[cfg(feature = "ethertalk")]
@@ -891,6 +930,7 @@ async fn server_loop(
     ui_weak: slint::Weak<AppWindow>,
     active: Arc<tokio::sync::Mutex<Option<ShutdownHandle>>>,
     keep_awake: Arc<std::sync::Mutex<Option<keepawake::KeepAwake>>>,
+    printer_handles: PrinterHandleStore,
 ) {
     let mut shutdown_handle: Option<ShutdownHandle> = None;
 
@@ -911,6 +951,7 @@ async fn server_loop(
             } => {
                 if let Some(h) = shutdown_handle.take() {
                     active.lock().await.take();
+                    printer_handles.lock().unwrap().take();
                     h.graceful_shutdown().await;
                     keep_awake.lock().unwrap().take();
                 }
@@ -931,6 +972,7 @@ async fn server_loop(
                     *laserwriter,
                     ready_tx,
                     ui_w.clone(),
+                    printer_handles.clone(),
                 ));
 
                 // Wait for the stack to finish initialising (AARP probe etc.)
@@ -966,6 +1008,7 @@ async fn server_loop(
             ServerCommand::Stop => {
                 if let Some(h) = shutdown_handle.take() {
                     active.lock().await.take();
+                    printer_handles.lock().unwrap().take();
                     h.graceful_shutdown().await;
                 }
                 keep_awake.lock().unwrap().take();
@@ -1873,6 +1916,7 @@ async fn run_server(
     laserwriter: Option<LaserWriterConfig>,
     ready_tx: tokio::sync::oneshot::Sender<(ShutdownHandle, ShutdownHandle)>,
     ui_weak: slint::Weak<AppWindow>,
+    printer_handles: PrinterHandleStore,
 ) {
     use tailtalk::{
         TalkStack,
@@ -2056,12 +2100,27 @@ async fn run_server(
         tracing::info!("AFP server running on {transport_desc}");
     }
 
+    // Publish the live handles so the Printer Tool can drive printers over this
+    // stack. Cleared below so the tool reports the server as stopped rather than
+    // holding handles to a dead stack.
+    *printer_handles.lock().unwrap() = Some(PrinterHandles {
+        nbp: stack.nbp.clone(),
+        ddp: stack.ddp.clone(),
+        local_addrs: [&stack.et_addressing, &stack.lt_addressing]
+            .into_iter()
+            .flatten()
+            .filter_map(|h| h.addr_watch())
+            .collect(),
+    });
+
     // Signal the GUI that the stack is up; hand over two shutdown handles —
     // one for server_loop (Stop button), one held by main for window-close cleanup.
     let _ = ready_tx.send((stack.shutdown_handle(), stack.shutdown_handle()));
 
     // Block until shutdown() is called (e.g. the user clicks Stop).
     stack.wait_for_shutdown().await;
+
+    printer_handles.lock().unwrap().take();
 
     set_stopped(ui_weak);
 }

--- a/tailtalk-gui/printer_tool.rs
+++ b/tailtalk-gui/printer_tool.rs
@@ -1,0 +1,856 @@
+//! The "Printer Tool" window: a master/detail view over the printers TailTalk
+//! already knows how to talk to. The sidebar lists what NBP finds; selecting a
+//! printer queries it and shows the result, plus whatever settings that family
+//! lets us change:
+//!
+//!   * StyleWriter — rename, over the ADSP management socket (`sw-rename`).
+//!   * LaserWriter — rename, default paper size and power-on startup page, as
+//!     PostScript over PAP (`pap-print`).
+//!
+//! The server has to be running: we borrow its live `NbpHandle`/`DdpHandle`
+//! rather than building a second stack, which couldn't reopen an in-use
+//! TashTalk serial port.
+
+use std::cell::RefCell;
+use std::io::Cursor;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use slint::{ComponentHandle, Model, VecModel, Weak};
+use tailtalk::{
+    adsp::{Adsp, AdspAddress, AdspStream},
+    atp::{Atp, AtpAddress},
+    ddp::DdpHandle,
+    pap::PapClient,
+    stylewriter::StyleWriterSession,
+};
+use tailtalk_packets::nbp::EntityName;
+use tokio::io::AsyncReadExt;
+use tokio::time::{Duration, timeout};
+
+use crate::{InfoRow, PrinterHandles, PrinterRow, PrinterToolWindow};
+
+/// One line of the information panel. The query tasks build these and hand them
+/// to the event loop, which turns them into Slint [`InfoRow`]s — `SharedString`
+/// isn't `Send`, so it can't cross that boundary.
+struct Line {
+    label: String,
+    value: String,
+    section: bool,
+}
+
+impl Line {
+    /// A heading row; `value` is unused.
+    fn section(label: &str) -> Line {
+        Line { label: label.to_string(), value: String::new(), section: true }
+    }
+
+    fn field(label: &str, value: impl Into<String>) -> Line {
+        Line { label: label.to_string(), value: value.into(), section: false }
+    }
+}
+
+fn to_model(lines: Vec<Line>) -> slint::ModelRc<InfoRow> {
+    let rows: Vec<InfoRow> = lines
+        .into_iter()
+        .map(|l| InfoRow {
+            label: l.label.into(),
+            value: l.value.into(),
+            is_section: l.section,
+        })
+        .collect();
+    Rc::new(VecModel::from(rows)).into()
+}
+
+/// The AppleTalk printer families the tool understands.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names, reason = "these are Apple's product names")]
+enum PrinterKind {
+    /// PostScript printer driven over PAP (NBP type "LaserWriter").
+    LaserWriter,
+    /// Color StyleWriter behind an EtherTalk adapter, driven over ADSP
+    /// (NBP type "ColorStyleWriter2400AT").
+    StyleWriter,
+}
+
+/// ADSP management socket — fixed at 129 on StyleWriter adapters (see `sw-rename`).
+const SW_MGMT_SOCKET: u8 = 129;
+
+/// Attention codes used by the StyleWriter name-change protocol.
+const ATTN_GET_NAME: u16 = 0x0011;
+const ATTN_SET_NAME: u16 = 0x0009;
+const ATTN_COMMIT: u16 = 0x0012;
+
+/// A printer found by [`discover`]; carries the real AppleTalk address that the
+/// Slint model rows (indexed 1:1) can't hold.
+#[derive(Clone)]
+struct Discovered {
+    name: String,
+    kind: PrinterKind,
+    net: u16,
+    node: u8,
+    socket: u8,
+}
+
+impl Discovered {
+    /// The advertised print endpoint, as an ADSP address (StyleWriter).
+    fn adsp_print_addr(&self) -> AdspAddress {
+        AdspAddress {
+            network_number: self.net,
+            node_number: self.node,
+            socket_number: self.socket,
+        }
+    }
+
+    /// The fixed management endpoint used for renaming (StyleWriter).
+    fn adsp_mgmt_addr(&self) -> AdspAddress {
+        AdspAddress {
+            network_number: self.net,
+            node_number: self.node,
+            socket_number: SW_MGMT_SOCKET,
+        }
+    }
+
+    /// The advertised print endpoint, as an ATP address (LaserWriter).
+    fn atp_addr(&self) -> AtpAddress {
+        AtpAddress {
+            network_number: self.net,
+            node_number: self.node,
+            socket_number: self.socket,
+        }
+    }
+
+    fn row(&self) -> PrinterRow {
+        PrinterRow {
+            name: self.name.as_str().into(),
+            kind: match self.kind {
+                PrinterKind::LaserWriter => "LaserWriter (PostScript)".into(),
+                PrinterKind::StyleWriter => "Color StyleWriter".into(),
+            },
+            address: format!("{}.{} socket {}", self.net, self.node, self.socket).into(),
+            is_stylewriter: self.kind == PrinterKind::StyleWriter,
+        }
+    }
+}
+
+/// Paper sizes the tool can set on a LaserWriter (mirrors `pap-print`).
+#[derive(Clone, Copy)]
+enum PaperSize {
+    Letter,
+    A4,
+    Legal,
+    Executive,
+    B5,
+}
+
+impl PaperSize {
+    /// Index order must match the ComboBox model in `printer_tool.slint`.
+    fn from_index(i: i32) -> PaperSize {
+        match i {
+            1 => PaperSize::A4,
+            2 => PaperSize::Legal,
+            3 => PaperSize::Executive,
+            4 => PaperSize::B5,
+            _ => PaperSize::Letter,
+        }
+    }
+
+    fn points(self) -> (u32, u32) {
+        match self {
+            PaperSize::Letter => (612, 792),
+            PaperSize::A4 => (595, 842),
+            PaperSize::Legal => (612, 1008),
+            PaperSize::Executive => (522, 756),
+            PaperSize::B5 => (516, 729),
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            PaperSize::Letter => "Letter",
+            PaperSize::A4 => "A4",
+            PaperSize::Legal => "Legal",
+            PaperSize::Executive => "Executive",
+            PaperSize::B5 => "B5",
+        }
+    }
+}
+
+/// Map a PostScript "w h" page-size string to the closest ComboBox index;
+/// unknown sizes fall back to Letter (0).
+fn pts_to_paper_index(pts: &str) -> i32 {
+    let mut nums = pts.split_whitespace().filter_map(|s| s.parse::<f32>().ok());
+    let (Some(w), Some(h)) = (nums.next(), nums.next()) else {
+        return 0;
+    };
+    let known: &[(f32, f32, i32)] = &[
+        (612.0, 792.0, 0),  // Letter
+        (595.0, 842.0, 1),  // A4
+        (612.0, 1008.0, 2), // Legal
+        (522.0, 756.0, 3),  // Executive
+        (516.0, 729.0, 4),  // B5
+    ];
+    for &(pw, ph, idx) in known {
+        if (w - pw).abs() < 5.0 && (h - ph).abs() < 5.0 {
+            return idx;
+        }
+    }
+    0
+}
+
+/// What a query produced.
+struct Queried {
+    lines: Vec<Line>,
+    /// LaserWriter only: current values for the editable controls.
+    settings: Option<LaserSettings>,
+}
+
+struct LaserSettings {
+    paper_index: i32,
+    startup_enabled: bool,
+    printer_name: String,
+}
+
+/// Reject names AppleTalk can't carry: `:`, `@` and `*` are NBP entity-name
+/// delimiters. `max` is the family's own length limit — 31 for the StyleWriter's
+/// Pascal-string rename, 32 for the LaserWriter's `PrinterName`.
+fn validate_name(name: &str, max: usize) -> anyhow::Result<()> {
+    if name.is_empty() || name.len() > max {
+        anyhow::bail!("name must be 1–{max} characters (got {})", name.len());
+    }
+    if name.contains([':', '@', '*']) {
+        anyhow::bail!("name cannot contain ':', '@', or '*'");
+    }
+    Ok(())
+}
+
+/// Escape a string for use inside a PostScript `(...)` literal.
+fn ps_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if matches!(c, '\\' | '(' | ')') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
+// ── Async operations (reuse the existing protocol code) ───────────────────────
+
+/// Discover LaserWriters and Color StyleWriters — the same batched NBP lookup
+/// the IPP bridge performs.
+async fn discover(handles: &PrinterHandles) -> anyhow::Result<Vec<Discovered>> {
+    const PATTERNS: [(PrinterKind, &str); 2] = [
+        (PrinterKind::LaserWriter, "=:LaserWriter@*"),
+        (PrinterKind::StyleWriter, "=:ColorStyleWriter2400AT@*"),
+    ];
+
+    // Our own address on each transport, so registrations belonging to this
+    // stack (chiefly the built-in LaserWriter emulator) can be dropped below.
+    let local: Vec<(u16, u8)> = handles
+        .local_addrs
+        .iter()
+        .filter_map(|w| w.borrow().map(|a| (a.network_number, a.node_number)))
+        .collect();
+
+    let names = PATTERNS
+        .iter()
+        .map(|(_, pattern)| {
+            EntityName::try_from(*pattern)
+                .map_err(|e| anyhow::anyhow!("bad entity name '{pattern}': {e}"))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    let mut found = Vec::new();
+    for ((kind, _), tuples) in PATTERNS.iter().zip(handles.nbp.lookup_many(names).await?) {
+        for t in tuples {
+            if t.entity_name.object.is_empty() {
+                continue;
+            }
+            if local.contains(&(t.network_number, t.node_id)) {
+                tracing::debug!(
+                    "Printer Tool: skipping own registration \"{}\" at {}.{}",
+                    t.entity_name.object,
+                    t.network_number,
+                    t.node_id
+                );
+                continue;
+            }
+            found.push(Discovered {
+                name: t.entity_name.object,
+                kind: *kind,
+                net: t.network_number,
+                node: t.node_id,
+                socket: t.socket_number,
+            });
+        }
+    }
+    Ok(found)
+}
+
+/// Query a StyleWriter's identity over a short-lived ADSP session (no page fed).
+async fn query_stylewriter(ddp: &DdpHandle, addr: AdspAddress) -> anyhow::Result<Queried> {
+    let mut session = StyleWriterSession::connect(ddp, addr, "TailTalk").await?;
+    let info = session.query_info().await;
+    let _ = session.abort().await;
+    let info = info?;
+
+    /// Render a raw status byte as hex, or a placeholder when unanswered.
+    fn raw(b: Option<u8>) -> String {
+        b.map_or_else(|| "no response".to_string(), |v| format!("0x{v:02X}"))
+    }
+
+    Ok(Queried {
+        lines: vec![
+            Line::section("Status"),
+            Line::field("Condition", info.error_text()),
+            Line::field(
+                "Buffer",
+                match info.buffer_idle() {
+                    Some(true) => format!("Idle ({})", raw(info.status_buffer)),
+                    Some(false) => format!("Busy — data draining ({})", raw(info.status_buffer)),
+                    None => raw(info.status_buffer),
+                },
+            ),
+            Line::section("Hardware"),
+            Line::field("Model", info.model_name()),
+            Line::field("Cartridge", info.cartridge_text()),
+            Line::field(
+                "Colour printing",
+                if info.color_capable() {
+                    "Yes"
+                } else if info.identity == "CS" {
+                    "No — black cartridge installed"
+                } else {
+                    "No — this model is mono only"
+                },
+            ),
+            // The printer's error vocabulary was never fully reverse-engineered
+            // (lpstyl documents three codes for '2' and nothing at all for '1'),
+            // so show the raw bytes rather than decode them into a guess.
+            Line::section("Raw protocol replies"),
+            Line::field(
+                "Identity  '?'",
+                if info.identity.is_empty() { "(empty)" } else { &info.identity },
+            ),
+            Line::field("Submodel  'p'", raw(info.submodel)),
+            Line::field("Config    'H'", raw(info.config_raw)),
+            Line::field("Status    '1'", raw(info.status_general)),
+            Line::field("Status    '2'", raw(info.status_error)),
+            Line::field("Buffer    'B'", raw(info.status_buffer)),
+        ],
+        settings: None,
+    })
+}
+
+/// Send one attention command and check the printer's two-byte acknowledgement.
+async fn attention(stream: &mut AdspStream, code: u16, payload: &[u8]) -> anyhow::Result<()> {
+    stream.send_attention(code, payload).await?;
+    let mut resp = [0u8; 2];
+    timeout(Duration::from_secs(30), stream.read_exact(&mut resp))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for reply to 0x{code:04X}"))??;
+    if resp != [0x00, 0x00] {
+        anyhow::bail!("unexpected reply to 0x{code:04X}: {resp:02X?}");
+    }
+    Ok(())
+}
+
+/// Rename a StyleWriter via its ADSP management socket (the `sw-rename` flow).
+async fn rename_stylewriter(
+    ddp: &DdpHandle,
+    mgmt_addr: AdspAddress,
+    new_name: &str,
+) -> anyhow::Result<String> {
+    validate_name(new_name, 31)?;
+
+    let mut stream = timeout(Duration::from_secs(10), Adsp::connect(ddp, mgmt_addr))
+        .await
+        .map_err(|_| anyhow::anyhow!("ADSP connect timed out — is socket {SW_MGMT_SOCKET} open?"))??;
+
+    // Pascal string: length byte followed by the name bytes.
+    let mut pascal = Vec::with_capacity(1 + new_name.len());
+    pascal.push(new_name.len() as u8);
+    pascal.extend_from_slice(new_name.as_bytes());
+
+    attention(&mut stream, ATTN_GET_NAME, &[0x00]).await?;
+    attention(&mut stream, ATTN_SET_NAME, &pascal).await?;
+    attention(&mut stream, ATTN_COMMIT, &[0x00]).await?;
+    stream.close().await?;
+
+    Ok(format!(
+        "Renamed to \"{new_name}\". Click Refresh in a moment to confirm re-registration."
+    ))
+}
+
+/// Run a PostScript job over PAP and return the printer's response lines, with
+/// PS status messages (`%%[ … ]%%`) filtered out.
+async fn run_ps_job(ddp: &DdpHandle, addr: AtpAddress, job: &str) -> anyhow::Result<Vec<String>> {
+    let (_, req, resp) = Atp::spawn(ddp, None).await;
+    let mut client = PapClient::new(req, resp);
+    client.connect(addr).await?;
+    client.print_stream(Cursor::new(job.as_bytes())).await?;
+
+    // A job that only sets things up may say nothing back; that isn't an error.
+    let bytes = match timeout(Duration::from_secs(15), client.read_response()).await {
+        Ok(r) => r?,
+        Err(_) => Vec::new(),
+    };
+    client.close().await?;
+
+    Ok(String::from_utf8_lossy(&bytes)
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("%%["))
+        .map(str::to_string)
+        .collect())
+}
+
+/// The properties [`query_laserwriter`] reports, in the order the printer prints
+/// them: panel label, and the PostScript that emits the value.
+const LASER_QUERIES: &[(&str, &str)] = &[
+    ("Product", "statusdict /product get printval"),
+    ("PS Version", "version printval"),
+    ("Firmware Rev", "statusdict /revision get printval"),
+    (
+        "Resolution",
+        "{ statusdict /resolution get } stopped \
+         { currentpagedevice /HWResolution get 0 get } if printval",
+    ),
+    ("RAM", "statusdict begin ramsize end printval"),
+    ("Page count", "statusdict begin pagecount end printval"),
+    ("Page size (pts)", "currentpagedevice /PageSize get printval"),
+    ("AppleTalk type", "statusdict /appletalktype get printval"),
+    ("Input trays", "currentpagedevice /InputAttributes get length ="),
+    (
+        "Tray 0 paper (pts)",
+        "currentpagedevice /InputAttributes get 0 get /PageSize get printval",
+    ),
+    ("Has manual feed", "currentpagedevice /ManualFeed known ="),
+    ("Startup page", "statusdict begin dostartpage end printval"),
+    ("Printer name", "40 string statusdict begin printername end printval"),
+];
+
+/// Assemble the query job. `printval` prints arrays space-separated on one line
+/// and everything else via `=`, so each property answers with exactly one line;
+/// every property is guarded so a printer missing one still answers the rest.
+fn laser_query_job() -> String {
+    let mut job = String::from(
+        "%!PS-Adobe-3.0\n\
+         %%EndComments\n\
+         errordict /handleerror {} put\n\
+         /printval {\n\
+           dup type /arraytype eq {\n\
+             { dup type /stringtype eq { print } { 20 string cvs print } ifelse ( ) print } forall\n\
+             (\\n) print\n\
+           } { = } ifelse\n\
+         } def\n",
+    );
+    for (_, expr) in LASER_QUERIES {
+        job.push_str(&format!("{{ {expr} }} stopped {{ (error) = }} if\n"));
+    }
+    job.push_str("flush\n%%EOF\n");
+    job
+}
+
+/// Pretty-print `ramsize`'s byte count.
+fn format_ram(value: &str) -> String {
+    let Ok(bytes) = value.parse::<u64>() else {
+        return value.to_string();
+    };
+    let mib = bytes as f64 / (1024.0 * 1024.0);
+    if mib.fract() == 0.0 {
+        format!("{} MiB", mib as u64)
+    } else {
+        format!("{mib:.1} MiB")
+    }
+}
+
+/// Query a LaserWriter over PAP: its PAP status string plus the PostScript
+/// Query Protocol capability dump.
+async fn query_laserwriter(ddp: &DdpHandle, addr: AtpAddress) -> anyhow::Result<Queried> {
+    let mut lines = vec![Line::section("Status")];
+
+    // PAP status string first (short, cheap).
+    let (_, req, _) = Atp::spawn(ddp, None).await;
+    match PapClient::get_status(req, addr).await {
+        Ok(status) => lines.push(Line::field("Condition", status)),
+        Err(e) => lines.push(Line::field("Condition", format!("Unavailable: {e}"))),
+    }
+    lines.push(Line::section("Printer"));
+
+    let replies = run_ps_job(ddp, addr, &laser_query_job()).await?;
+    let reply = |i: usize| replies.get(i).map(|s| s.trim()).unwrap_or_default();
+
+    for (i, (label, _)) in LASER_QUERIES.iter().enumerate() {
+        let value = reply(i);
+        let display = if value.is_empty() {
+            "no response".to_string()
+        } else if *label == "RAM" {
+            format_ram(value)
+        } else {
+            value.to_string()
+        };
+        lines.push(Line::field(label, display));
+    }
+
+    let by_label = |name: &str| {
+        LASER_QUERIES.iter().position(|(l, _)| *l == name).map(reply).unwrap_or_default()
+    };
+
+    Ok(Queried {
+        lines,
+        settings: Some(LaserSettings {
+            paper_index: pts_to_paper_index(by_label("Tray 0 paper (pts)")),
+            startup_enabled: by_label("Startup page") == "true",
+            printer_name: by_label("Printer name").to_string(),
+        }),
+    })
+}
+
+/// Apply a LaserWriter's editable settings in one NVRAM-writing job: its
+/// AppleTalk name, the default cassette paper size and the power-on startup
+/// (test) page flag. `exitserver` (password 0) makes all three persist across
+/// power cycles.
+async fn save_laserwriter(
+    ddp: &DdpHandle,
+    addr: AtpAddress,
+    size: PaperSize,
+    startup: bool,
+    name: &str,
+) -> anyhow::Result<String> {
+    validate_name(name, 32)?;
+    let (w, h) = size.points();
+    let escaped_name = ps_escape(name);
+    let job = format!(
+        "%!PS-Adobe-3.0\n\
+         %%EndComments\n\
+         serverdict begin 0 exitserver\n\
+         << /PageSize [{w} {h}] /InputAttributes << 0 << /PageSize [{w} {h}] >> >> >> setpagedevice\n\
+         statusdict begin {startup} setdostartpage end\n\
+         statusdict begin ({escaped_name}) setprintername end\n\
+         flush\n\
+         %%EOF\n"
+    );
+
+    let output = run_ps_job(ddp, addr, &job).await?;
+    let output: Vec<String> = output.into_iter().filter(|l| !l.trim().is_empty()).collect();
+
+    let mut msg = format!(
+        "Saved: name \"{name}\", default paper {} ({w}×{h} pts), startup page {}. \
+         Click Refresh in a moment to confirm re-registration.",
+        size.label(),
+        if startup { "on" } else { "off" }
+    );
+    if !output.is_empty() {
+        msg.push_str(&format!("\nPrinter responded:\n{}", output.join("\n")));
+    }
+    Ok(msg)
+}
+
+// ── Window wiring ─────────────────────────────────────────────────────────────
+
+/// Open (or re-focus) the Printer Tool window. `handles` is the running stack's
+/// shared handle store; `slot` keeps the window alive past the callback that
+/// created it.
+pub fn open(
+    rt: &tokio::runtime::Handle,
+    handles: Arc<Mutex<Option<PrinterHandles>>>,
+    slot: Rc<RefCell<Option<PrinterToolWindow>>>,
+) {
+    if let Some(existing) = slot.borrow().as_ref() {
+        let _ = existing.show();
+        return;
+    }
+
+    let window = match PrinterToolWindow::new() {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::error!("Printer Tool: failed to create window: {e}");
+            return;
+        }
+    };
+
+    // Discovered printers, kept 1:1 with the Slint model rows so a row index
+    // maps back to a real AppleTalk address.
+    let discovered: Arc<Mutex<Vec<Discovered>>> = Arc::new(Mutex::new(Vec::new()));
+
+    // Bumped whenever the selection changes or the list is refreshed. Background
+    // tasks capture the value they started with and drop their results if it no
+    // longer matches, so a slow query can't overwrite a newer selection's panel.
+    let generation: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
+
+    // ── Refresh ──────────────────────────────────────────────────────────────
+    {
+        let rt = rt.clone();
+        let handles = handles.clone();
+        let weak = window.as_weak();
+        let discovered = discovered.clone();
+        let generation = generation.clone();
+        window.on_refresh(move || {
+            generation.fetch_add(1, Ordering::SeqCst);
+            let Some(handles) = handles.lock().unwrap().clone() else {
+                set_status(&weak, "The AFP server is no longer running.");
+                return;
+            };
+            begin_busy(&weak, "Discovering printers…");
+            if let Some(w) = weak.upgrade() {
+                w.set_selected(-1);
+                w.set_detail_loaded(false);
+            }
+            let weak = weak.clone();
+            let discovered = discovered.clone();
+            rt.spawn(async move {
+                let result = discover(&handles).await;
+                slint::invoke_from_event_loop(move || {
+                    let Some(w) = weak.upgrade() else { return };
+                    match result {
+                        Ok(found) => {
+                            let rows: Vec<PrinterRow> = found.iter().map(Discovered::row).collect();
+                            let n = rows.len();
+                            *discovered.lock().unwrap() = found;
+                            w.set_printers(Rc::new(VecModel::from(rows)).into());
+                            w.set_selected(-1);
+                            w.set_status_text(if n == 0 {
+                                "No printers found. Is one powered on and on the same network?"
+                                    .into()
+                            } else {
+                                format!("Found {n} printer(s).").into()
+                            });
+                        }
+                        Err(e) => w.set_status_text(format!("Discovery failed: {e}").into()),
+                    }
+                    w.set_busy(false);
+                })
+                .ok();
+            });
+        });
+    }
+
+    // ── Query (auto-fired when a printer is selected) ────────────────────────
+    {
+        let rt = rt.clone();
+        let handles = handles.clone();
+        let weak = window.as_weak();
+        let discovered = discovered.clone();
+        let generation = generation.clone();
+        window.on_query(move |index| {
+            let my_gen = generation.fetch_add(1, Ordering::SeqCst) + 1;
+            let Some(printer) = discovered.lock().unwrap().get(index as usize).cloned() else {
+                return;
+            };
+            let Some(ddp) = handles.lock().unwrap().as_ref().map(|h| h.ddp.clone()) else {
+                set_status(&weak, "The AFP server is no longer running.");
+                return;
+            };
+
+            // Reset the detail pane and seed the name field from the NBP name;
+            // a LaserWriter query refines it with the printer's own PrinterName.
+            if let Some(w) = weak.upgrade() {
+                w.set_detail_loaded(false);
+                w.set_info_rows(to_model(Vec::new()));
+                w.set_error_text("".into());
+                w.set_edit_name(printer.name.as_str().into());
+            }
+            begin_busy(&weak, "Querying printer…");
+
+            if printer.kind == PrinterKind::LaserWriter {
+                poll_status(&rt, weak.clone(), ddp.clone(), printer.atp_addr(), &generation, my_gen);
+            }
+
+            let weak = weak.clone();
+            let discovered = discovered.clone();
+            let generation = generation.clone();
+            rt.spawn(async move {
+                let result = match printer.kind {
+                    PrinterKind::StyleWriter => {
+                        query_stylewriter(&ddp, printer.adsp_print_addr()).await
+                    }
+                    PrinterKind::LaserWriter => query_laserwriter(&ddp, printer.atp_addr()).await,
+                };
+                slint::invoke_from_event_loop(move || {
+                    let Some(w) = weak.upgrade() else { return };
+                    if generation.load(Ordering::SeqCst) != my_gen {
+                        return; // the selection moved on while we were querying
+                    }
+                    match result {
+                        Ok(q) => {
+                            w.set_info_rows(to_model(q.lines));
+                            if let Some(s) = q.settings {
+                                w.set_paper_index(s.paper_index);
+                                w.set_startup_enabled(s.startup_enabled);
+                                if !s.printer_name.is_empty() {
+                                    w.set_edit_name(s.printer_name.as_str().into());
+                                    rename_row(&w, &discovered, index as usize, &s.printer_name);
+                                }
+                            }
+                            w.set_detail_loaded(true);
+                            w.set_status_text("Ready.".into());
+                        }
+                        Err(e) => {
+                            w.set_error_text(e.to_string().into());
+                            w.set_status_text("Query failed.".into());
+                        }
+                    }
+                    w.set_busy(false);
+                })
+                .ok();
+            });
+        });
+    }
+
+    // ── Save (kind-dependent) ────────────────────────────────────────────────
+    {
+        let rt = rt.clone();
+        let handles = handles.clone();
+        let weak = window.as_weak();
+        let discovered = discovered.clone();
+        window.on_save(move |index| {
+            let Some(w) = weak.upgrade() else { return };
+            let Some(printer) = discovered.lock().unwrap().get(index as usize).cloned() else {
+                return;
+            };
+            let Some(ddp) = handles.lock().unwrap().as_ref().map(|h| h.ddp.clone()) else {
+                set_status(&weak, "The AFP server is no longer running.");
+                return;
+            };
+            begin_busy(&weak, "Saving…");
+            let weak = weak.clone();
+            let name = w.get_edit_name().to_string();
+            match printer.kind {
+                PrinterKind::StyleWriter => {
+                    rt.spawn(async move {
+                        let result =
+                            rename_stylewriter(&ddp, printer.adsp_mgmt_addr(), &name).await;
+                        finish_save(weak, result, None);
+                    });
+                }
+                PrinterKind::LaserWriter => {
+                    let size = PaperSize::from_index(w.get_paper_index());
+                    let startup = w.get_startup_enabled();
+                    rt.spawn(async move {
+                        let addr = printer.atp_addr();
+                        let result = save_laserwriter(&ddp, addr, size, startup, &name).await;
+                        // Re-query on success so the panel reflects what stuck.
+                        finish_save(weak, result, Some(index));
+                    });
+                }
+            }
+        });
+    }
+
+    if let Err(e) = window.show() {
+        tracing::error!("Printer Tool: failed to show window: {e}");
+        return;
+    }
+
+    window.invoke_refresh();
+    *slot.borrow_mut() = Some(window);
+}
+
+/// Re-check a LaserWriter's PAP status every few seconds for as long as it stays
+/// selected, so the Condition line doesn't sit stale between the much slower
+/// PostScript queries.
+fn poll_status(
+    rt: &tokio::runtime::Handle,
+    weak: Weak<PrinterToolWindow>,
+    ddp: DdpHandle,
+    addr: AtpAddress,
+    generation: &Arc<AtomicU64>,
+    my_gen: u64,
+) {
+    let generation = generation.clone();
+    rt.spawn(async move {
+        let mut ticker = tokio::time::interval(Duration::from_secs(5));
+        ticker.tick().await; // the initial query already left a fresh status
+        loop {
+            ticker.tick().await;
+            if generation.load(Ordering::SeqCst) != my_gen {
+                return;
+            }
+            let (_, req, _) = Atp::spawn(&ddp, None).await;
+            let status = PapClient::get_status(req, addr).await;
+
+            let weak = weak.clone();
+            let generation = generation.clone();
+            let posted = slint::invoke_from_event_loop(move || {
+                let Some(w) = weak.upgrade() else { return };
+                if generation.load(Ordering::SeqCst) != my_gen {
+                    return;
+                }
+                set_condition(&w, match status {
+                    Ok(s) if !s.is_empty() => s,
+                    Ok(_) => "No status string returned".to_string(),
+                    Err(e) => format!("Unavailable: {e}"),
+                });
+            });
+            if posted.is_err() {
+                return; // the Slint event loop is gone — the app is shutting down
+            }
+        }
+    });
+}
+
+/// Overwrite the info panel's Condition row in place.
+fn set_condition(w: &PrinterToolWindow, text: String) {
+    let model = w.get_info_rows();
+    for i in 0..model.row_count() {
+        let Some(mut row) = model.row_data(i) else { continue };
+        if !row.is_section && row.label.as_str() == "Condition" {
+            row.value = text.into();
+            model.set_row_data(i, row);
+            return;
+        }
+    }
+}
+
+/// Show the printer's real name in the sidebar row and our cached entry, so a
+/// rename appears without waiting for the next NBP refresh.
+fn rename_row(w: &PrinterToolWindow, discovered: &Mutex<Vec<Discovered>>, index: usize, name: &str) {
+    if let Some(d) = discovered.lock().unwrap().get_mut(index) {
+        d.name = name.to_string();
+    }
+    let model = w.get_printers();
+    if let Some(mut row) = model.row_data(index)
+        && row.name.as_str() != name
+    {
+        row.name = name.into();
+        model.set_row_data(index, row);
+    }
+}
+
+/// Flip the window into the busy state with a status message. Runs on the UI thread.
+fn begin_busy(weak: &Weak<PrinterToolWindow>, status: &str) {
+    if let Some(w) = weak.upgrade() {
+        w.set_busy(true);
+        w.set_status_text(status.into());
+    }
+}
+
+/// Set only the status line (no busy toggle). Runs on the UI thread.
+fn set_status(weak: &Weak<PrinterToolWindow>, status: &str) {
+    if let Some(w) = weak.upgrade() {
+        w.set_status_text(status.into());
+    }
+}
+
+/// Marshal a Save result back to the window. On success, `requery` (if given)
+/// re-runs the query for that row so the panel shows the persisted values —
+/// unless the user has moved on to another printer in the meantime.
+fn finish_save(weak: Weak<PrinterToolWindow>, result: anyhow::Result<String>, requery: Option<i32>) {
+    slint::invoke_from_event_loop(move || {
+        let Some(w) = weak.upgrade() else { return };
+        w.set_busy(false);
+        match result {
+            Ok(msg) => {
+                w.set_status_text(msg.into());
+                if requery == Some(w.get_selected()) {
+                    w.invoke_query(w.get_selected());
+                }
+            }
+            Err(e) => w.set_status_text(format!("Save failed: {e}").into()),
+        }
+    })
+    .ok();
+}

--- a/tailtalk-gui/ui/app.slint
+++ b/tailtalk-gui/ui/app.slint
@@ -1,5 +1,9 @@
 import { Button, ComboBox, LineEdit, HorizontalBox, VerticalBox, CheckBox, Palette, ProgressIndicator } from "std-widgets.slint";
 
+// Re-exported so `slint::include_modules!()` generates them for the Rust side;
+// the Printer Tool is a separate window opened from the File menu.
+export { PrinterToolWindow, PrinterRow } from "printer_tool.slint";
+
 export component AppWindow inherits Window {
     title: "TailTalk AFP Server";
     min-width: 400px;
@@ -56,6 +60,7 @@ export component AppWindow inherits Window {
     callback inspect-finder-info();
     callback save-finder-info();
     callback open-log-dir();
+    callback open-printer-tool();
     // Returns the input truncated to 1 character; registered in Rust.
     callback clamp-to-one(string) -> string;
 
@@ -74,6 +79,13 @@ export component AppWindow inherits Window {
             MenuItem {
                 title: "Inspect Finder Info…";
                 activated => { root.inspect-finder-info(); }
+            }
+            MenuItem {
+                // Needs the running stack's live NBP/DDP handles, so it can
+                // only be opened while the server is up.
+                title: "Printer Tool…";
+                enabled: root.running;
+                activated => { root.open-printer-tool(); }
             }
             MenuItem {
                 title: "Open Log Directory…";

--- a/tailtalk-gui/ui/printer_tool.slint
+++ b/tailtalk-gui/ui/printer_tool.slint
@@ -1,0 +1,315 @@
+import { Button, ComboBox, CheckBox, LineEdit, HorizontalBox, VerticalBox, ScrollView, TextEdit, Palette } from "std-widgets.slint";
+
+export struct PrinterRow {
+    name: string,
+    kind: string,
+    address: string,
+    is-stylewriter: bool,
+}
+
+/// One line of the queried information panel. A section row renders as a
+/// heading and ignores `value`; every other row is a label/value pair, kept in
+/// two columns so they line up under the proportional system font.
+export struct InfoRow {
+    label: string,
+    value: string,
+    is-section: bool,
+}
+
+export component PrinterToolWindow inherits Window {
+    title: "Printer Tool";
+    min-width: 620px;
+    min-height: 440px;
+    preferred-width: 760px;
+    preferred-height: 520px;
+
+    in property <[PrinterRow]> printers;
+    in-out property <int> selected: -1;
+    in property <bool> busy: false;
+    // Queried detail for the selected printer (read-only).
+    in property <[InfoRow]> info-rows;
+    // Set instead of `info-rows` when the query failed outright.
+    in property <string> error-text: "";
+    in-out property <string> status-text: "";
+    // True once a query has populated the editable controls below.
+    in property <bool> detail-loaded: false;
+
+    // Editable fields. Which apply depends on the selected printer's kind.
+    in-out property <string> edit-name;                 // StyleWriter rename
+    in-out property <int> paper-index: 0;               // LaserWriter default paper
+    in-out property <bool> startup-enabled: false;      // LaserWriter power-on test page
+
+    property <bool> has-selection: root.selected >= 0 && root.selected < root.printers.length;
+    property <bool> sel-is-sw: root.has-selection && root.printers[root.selected].is-stylewriter;
+    property <bool> sel-is-lw: root.has-selection && !root.sel-is-sw;
+
+    callback refresh();
+    callback query(int);
+    callback save(int);
+
+    HorizontalBox {
+        padding: 0;
+        spacing: 0;
+
+        // ── Sidebar: discovered printers ─────────────────────────────────────
+        Rectangle {
+            width: 240px;
+            background: Palette.alternate-background;
+
+            VerticalBox {
+                padding: 10px;
+                spacing: 8px;
+
+                HorizontalBox {
+                    padding: 0;
+                    Text {
+                        text: "Printers";
+                        font-weight: 700;
+                        vertical-alignment: center;
+                        horizontal-stretch: 1;
+                    }
+                    Button {
+                        text: "Refresh";
+                        enabled: !root.busy;
+                        clicked => { root.refresh(); }
+                    }
+                }
+
+                Rectangle {
+                    vertical-stretch: 1;
+                    ScrollView {
+                        VerticalBox {
+                            padding: 0;
+                            spacing: 2px;
+                            alignment: start;
+
+                            for row[i] in root.printers : Rectangle {
+                                height: 48px;
+                                border-radius: 6px;
+                                background: i == root.selected
+                                    ? Palette.accent-background
+                                    : (touch.has-hover ? Palette.background : transparent);
+
+                                touch := TouchArea {
+                                    clicked => {
+                                        root.selected = i;
+                                        root.query(i);
+                                    }
+                                }
+
+                                HorizontalBox {
+                                    padding-left: 8px;
+                                    padding-right: 8px;
+                                    spacing: 8px;
+                                    Text {
+                                        text: "🖨";
+                                        font-size: 20px;
+                                        vertical-alignment: center;
+                                    }
+                                    VerticalBox {
+                                        padding: 0;
+                                        spacing: 1px;
+                                        alignment: center;
+                                        horizontal-stretch: 1;
+                                        Text {
+                                            text: row.name;
+                                            font-weight: 600;
+                                            color: i == root.selected ? Palette.accent-foreground : Palette.foreground;
+                                            overflow: elide;
+                                        }
+                                        Text {
+                                            text: row.kind;
+                                            font-size: 11px;
+                                            color: i == root.selected ? Palette.accent-foreground : Palette.foreground.darker(0.2);
+                                            overflow: elide;
+                                        }
+                                    }
+                                }
+                            }
+
+                            if root.printers.length == 0 : Text {
+                                text: "No printers found.";
+                                color: Palette.foreground.darker(0.2);
+                                font-size: 12px;
+                                horizontal-alignment: center;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── Detail: selected printer ─────────────────────────────────────────
+        Rectangle {
+            background: Palette.background;
+            horizontal-stretch: 1;
+
+            if !root.has-selection : Text {
+                text: "Select a printer to view its information.";
+                color: Palette.foreground.darker(0.2);
+                horizontal-alignment: center;
+                vertical-alignment: center;
+            }
+
+            if root.has-selection : VerticalBox {
+                padding: 16px;
+                spacing: 10px;
+
+                // Header
+                Text {
+                    text: root.printers[root.selected].name;
+                    font-size: 18px;
+                    font-weight: 700;
+                    overflow: elide;
+                }
+                Text {
+                    text: root.printers[root.selected].kind + " — " + root.printers[root.selected].address;
+                    color: Palette.foreground.darker(0.2);
+                    font-size: 12px;
+                    overflow: elide;
+                }
+
+                // Queried information
+                Text { text: "Information"; font-weight: 700; }
+                Rectangle {
+                    border-radius: 8px;
+                    background: Palette.alternate-background;
+                    vertical-stretch: 1;
+                    min-height: 120px;
+
+                    // ScrollView (like TextEdit) is stretch-sized with no
+                    // preferred size of its own, so it must sit in a layout —
+                    // as a bare child of this Rectangle it would collapse to
+                    // zero and render nothing.
+                    VerticalLayout {
+                        padding: 12px;
+
+                        ScrollView {
+                            VerticalLayout {
+                                spacing: 4px;
+                                alignment: start;
+
+                                if root.error-text != "" : Text {
+                                    text: root.error-text;
+                                    color: #ef4444;
+                                    wrap: word-wrap;
+                                }
+
+                                if root.error-text == "" && root.info-rows.length == 0 : Text {
+                                    text: root.busy ? "Querying…" : "No information returned.";
+                                    color: Palette.foreground.darker(0.2);
+                                }
+
+                                for info[i] in root.info-rows : HorizontalLayout {
+                                    spacing: 12px;
+                                    // Sections get breathing room above, except
+                                    // the first, which sits flush with the top.
+                                    padding-top: info.is-section && i > 0 ? 10px : 0;
+
+                                    if info.is-section : Text {
+                                        text: info.label;
+                                        font-weight: 700;
+                                        horizontal-stretch: 1;
+                                    }
+
+                                    if !info.is-section : Text {
+                                        text: info.label;
+                                        width: 130px;
+                                        color: Palette.foreground.darker(0.2);
+                                        overflow: elide;
+                                    }
+                                    if !info.is-section : Text {
+                                        text: info.value;
+                                        horizontal-stretch: 1;
+                                        wrap: word-wrap;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Editable settings
+                Text { text: "Settings"; font-weight: 700; }
+
+                if root.sel-is-sw : HorizontalBox {
+                    padding: 0;
+                    Text { text: "Name"; min-width: 120px; vertical-alignment: center; }
+                    LineEdit {
+                        text <=> root.edit-name;
+                        placeholder-text: "Printer name (1–31 characters)";
+                        enabled: root.detail-loaded && !root.busy;
+                        horizontal-stretch: 1;
+                    }
+                }
+
+                if root.sel-is-lw : VerticalBox {
+                    padding: 0;
+
+                    HorizontalBox {
+                        padding: 0;
+                        Text { text: "Name"; min-width: 120px; vertical-alignment: center; }
+                        LineEdit {
+                            text <=> root.edit-name;
+                            placeholder-text: "Printer name (1–32 characters)";
+                            enabled: root.detail-loaded && !root.busy;
+                            horizontal-stretch: 1;
+                        }
+                    }
+
+                    HorizontalBox {
+                        padding: 0;
+                        Text { text: "Default Paper Size"; min-width: 120px; vertical-alignment: center; }
+                        ComboBox {
+                            model: ["Letter", "A4", "Legal", "Executive", "B5"];
+                            current-index <=> root.paper-index;
+                            enabled: root.detail-loaded && !root.busy;
+                            horizontal-stretch: 1;
+                        }
+                    }
+
+                    HorizontalBox {
+                        padding: 0;
+                        Text { text: "Startup Page"; min-width: 120px; vertical-alignment: center; }
+                        CheckBox {
+                            checked <=> root.startup-enabled;
+                            enabled: root.detail-loaded && !root.busy;
+                            accessible-description: "Print a test page at power-on";
+
+                            Tooltip {
+                                // Tooltip takes styled text, so plain strings
+                                // have to be wrapped.
+                                text: @markdown("Print a test page at power-on");
+                            }
+                        }
+                        Rectangle { horizontal-stretch: 1; }
+                    }
+                }
+
+                HorizontalBox {
+                    padding: 0;
+                    spacing: 8px;
+                    Rectangle {
+                        width: 10px;
+                        height: 10px;
+                        border-radius: 5px;
+                        background: root.busy ? #f59e0b : #22c55e;
+                        y: (parent.height - self.height) / 2;
+                    }
+                    Text {
+                        text: root.status-text;
+                        vertical-alignment: center;
+                        horizontal-stretch: 1;
+                        overflow: elide;
+                    }
+                    Button {
+                        text: "Save";
+                        primary: true;
+                        enabled: root.detail-loaded && !root.busy && root.edit-name != "";
+                        clicked => { root.save(root.selected); }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tailtalk/src/stylewriter.rs
+++ b/tailtalk/src/stylewriter.rs
@@ -90,6 +90,18 @@ pub struct StyleWriterInfo {
     pub submodel: Option<u8>,
     /// Status 'H' bit 0x80: a color ink cartridge is installed.
     pub color_cartridge: bool,
+    /// Raw reply to config query 'H' (0x01 = black installed, 0x81 = color
+    /// installed). Other bits are undocumented, so the raw byte is kept.
+    pub config_raw: Option<u8>,
+    /// Raw reply to status query '1'; lpstyl documents it only as "something
+    /// about the status of the printer", so we don't decode it.
+    pub status_general: Option<u8>,
+    /// Raw reply to error-status query '2'. Only three values are documented:
+    /// 0x00 and 0x80 both mean "nothing wrong", 0x04 means out of paper.
+    pub status_error: Option<u8>,
+    /// Raw reply to buffer query 'B' — a fill gauge whose scale differs per
+    /// model. Both 0x80 and 0x20 set means idle on the CS family.
+    pub status_buffer: Option<u8>,
 }
 
 impl StyleWriterInfo {
@@ -114,6 +126,40 @@ impl StyleWriterInfo {
     /// (and only with a color cartridge installed).
     pub fn color_capable(&self) -> bool {
         self.identity == "CS" && self.color_cartridge
+    }
+
+    /// Human-readable reading of error status '2'. Only 0x00/0x80 ("nothing
+    /// wrong") and 0x04 ("out of paper") are documented, so anything else is
+    /// reported verbatim rather than guessed at.
+    pub fn error_text(&self) -> String {
+        match self.status_error {
+            Some(0x00 | 0x80) => "Ready — no error reported".to_string(),
+            Some(0x04) => "Out of paper".to_string(),
+            Some(c) => format!("Unrecognised error code 0x{c:02X}"),
+            None => "No response to error-status query".to_string(),
+        }
+    }
+
+    /// True when the printer reports being out of paper.
+    pub fn out_of_paper(&self) -> bool {
+        self.status_error == Some(0x04)
+    }
+
+    /// Whether the print buffer reports idle, per the CS-family two-bit mask.
+    /// `None` when the printer didn't answer, or isn't a CS model (the gauge
+    /// scale differs per model and only the CS reading is characterised).
+    pub fn buffer_idle(&self) -> Option<bool> {
+        let b = self.status_buffer?;
+        (self.identity == "CS").then_some(b & SW2200_IDLE_MASK == SW2200_IDLE_MASK)
+    }
+
+    /// Which ink cartridge is installed, per config query 'H'.
+    pub fn cartridge_text(&self) -> &'static str {
+        match self.config_raw {
+            None => "unknown (no response)",
+            Some(_) if self.color_cartridge => "Color (CMY)",
+            Some(_) => "Black only",
+        }
     }
 }
 
@@ -266,18 +312,34 @@ impl StyleWriterSession {
 
         // 'D' then 'H' is lpstyl's cartridge probe; non-CS printers have no
         // color cartridge to report, so skip the query (and its 'D') there.
-        let color_cartridge = if identity == "CS" {
+        let config_raw = if identity == "CS" {
             write_flush(&mut self.data, b"D").await?;
-            let h = self
-                .poll_status(b'H', deadline)
-                .await
-                .ok_or_else(|| anyhow::anyhow!("No reply to cartridge query 'H'"))?;
-            h & 0x80 != 0
+            Some(
+                self.poll_status(b'H', deadline)
+                    .await
+                    .ok_or_else(|| anyhow::anyhow!("No reply to cartridge query 'H'"))?,
+            )
         } else {
-            false
+            None
         };
+        let color_cartridge = config_raw.is_some_and(|h| h & 0x80 != 0);
 
-        Ok(StyleWriterInfo { identity, submodel, color_cartridge })
+        // Live condition. Unlike the identify queries these are non-fatal: a
+        // printer that answers '?' but not '1'/'2'/'B' should still report the
+        // model it did give us, with the status shown as unavailable.
+        let status_general = self.poll_status(b'1', deadline).await;
+        let status_error = self.poll_status(b'2', deadline).await;
+        let status_buffer = self.poll_status(b'B', deadline).await;
+
+        Ok(StyleWriterInfo {
+            identity,
+            submodel,
+            color_cartridge,
+            config_raw,
+            status_general,
+            status_error,
+            status_buffer,
+        })
     }
 
     /// Poll until status 'B' reports idle (lpstyl `waitStatus()`/`waitNonBusy()`),
@@ -802,6 +864,80 @@ impl StyleWriterEncoder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build an info struct with the identify fields fixed to a Color
+    /// StyleWriter 2200, so status decoding can be exercised in isolation.
+    fn cs_info(config: Option<u8>, err: Option<u8>, buf: Option<u8>) -> StyleWriterInfo {
+        StyleWriterInfo {
+            identity: "CS".to_string(),
+            submodel: Some(0x02),
+            color_cartridge: config.is_some_and(|h| h & 0x80 != 0),
+            config_raw: config,
+            status_general: None,
+            status_error: err,
+            status_buffer: buf,
+        }
+    }
+
+    #[test]
+    fn test_error_status_decoding() {
+        // Both 0x00 and 0x80 are documented as "nothing wrong".
+        assert!(!cs_info(None, Some(0x00), None).out_of_paper());
+        assert!(!cs_info(None, Some(0x80), None).out_of_paper());
+        assert!(cs_info(None, Some(0x04), None).out_of_paper());
+
+        assert!(cs_info(None, Some(0x04), None).error_text().contains("Out of paper"));
+        assert!(cs_info(None, Some(0x80), None).error_text().contains("Ready"));
+
+        // An undocumented code is reported as unknown, not guessed at.
+        let odd = cs_info(None, Some(0x40), None);
+        assert!(!odd.out_of_paper());
+        assert!(odd.error_text().contains("0x40"), "{}", odd.error_text());
+
+        // No reply is distinct from a reply of zero.
+        assert!(cs_info(None, None, None).error_text().contains("No response"));
+    }
+
+    #[test]
+    fn test_buffer_idle_mask() {
+        // Idle needs both 0x80 and 0x20: 0xA2/0xA3 idle, 0x23 is a mid-drain
+        // gauge value that testing 0x20 alone would wrongly call idle.
+        assert_eq!(cs_info(None, None, Some(0xA3)).buffer_idle(), Some(true));
+        assert_eq!(cs_info(None, None, Some(0xA2)).buffer_idle(), Some(true));
+        assert_eq!(cs_info(None, None, Some(0x23)).buffer_idle(), Some(false));
+        assert_eq!(cs_info(None, None, Some(0x00)).buffer_idle(), Some(false));
+        assert_eq!(cs_info(None, None, None).buffer_idle(), None);
+
+        // The gauge scale is only characterised for the CS family.
+        let sw2 = StyleWriterInfo { identity: "SW".to_string(), ..cs_info(None, None, Some(0xA3)) };
+        assert_eq!(sw2.buffer_idle(), None);
+    }
+
+    #[test]
+    fn test_cartridge_decoding() {
+        // 'H' documents 0x01 = black installed, 0x81 = color installed.
+        let color = cs_info(Some(0x81), None, None);
+        assert!(color.color_cartridge);
+        assert!(color.color_capable());
+        assert_eq!(color.cartridge_text(), "Color (CMY)");
+
+        let black = cs_info(Some(0x01), None, None);
+        assert!(!black.color_cartridge);
+        assert!(!black.color_capable(), "black cartridge cannot print color");
+        assert_eq!(black.cartridge_text(), "Black only");
+
+        assert_eq!(cs_info(None, None, None).cartridge_text(), "unknown (no response)");
+
+        // Non-CS models are never color-capable even if 'H' somehow set 0x80.
+        let sw1 = StyleWriterInfo {
+            identity: "IJ10".to_string(),
+            submodel: None,
+            color_cartridge: true,
+            ..cs_info(Some(0x81), None, None)
+        };
+        assert!(!sw1.color_capable());
+        assert_eq!(sw1.model_name(), "Apple StyleWriter");
+    }
 
     #[test]
     fn test_encode_rect() {


### PR DESCRIPTION
A new "Printer Tool…" File menu item opens a master/detail window listing
the LaserWriters and Color StyleWriters NBP can find, and lets you inspect
and reconfigure them without going anywhere near a Mac. This is primarily
targeting what the classic Mac OS printer settings menu offers as I dont
think there is an equivalent for modern OS', requiring users to go back
to legacy tools just to do a simple name change..

It runs on the server's live NBP/DDP handles rather than standing up its
own stack, since a second TalkStack can't reopen a TashTalk serial port
that's already in use. So the menu item is only enabled while the server
is running, and run_server publishes its handles into a shared slot that's
cleared on shutdown. Discovery drops registrations that point back at us
by address rather than by name — our own LaserWriter emulator answers the
same =:LaserWriter@* lookup real printers do, and matching on address
means a real printer that happens to share the emulator's name still shows
up.

LaserWriters are interrogated with the PostScript Query Protocol, and
their name, default cassette paper size and power-on startup page can be
written back to NVRAM in a single exitserver job. Note that dostartpage
and printername are statusdict operators, not stored values: they have to
be invoked inside `statusdict begin … end` rather than fetched with `get`,
which returns the operator object itself. Because a rename changes the
printer's NBP registration, the query result also updates the sidebar row
so it doesn't sit stale until the next lookup.

StyleWriters reuse the sw-rename ADSP management flow on socket 129, and
their panel now shows the raw 'H'/'1'/'2'/'B' status replies next to the
parts we can actually decode (cartridge type, out of paper, buffer idle).
The error vocabulary was never fully reverse-engineered — lpstyl documents
three codes for '2' and nothing at all for '1' — so the rest is surfaced
verbatim rather than guessed at, which is also how we'll characterise it.

Queries run on the tokio runtime and report back through the Slint event
loop, so a reply can outlive the selection that asked for it. A generation
counter, bumped on every selection and refresh, lets a late reply notice
it's stale and drop itself instead of painting one printer's information
under another's header.

Example of it on my LaserWriter and StyleWriter
<img width="752" height="547" alt="Scherm­afbeelding 2026-07-23 om 8 16 24 PM" src="https://github.com/user-attachments/assets/0fedaeb6-ce42-40b2-93e1-36cf5415ba8b" />
<img width="756" height="552" alt="Scherm­afbeelding 2026-07-19 om 3 06 26 PM" src="https://github.com/user-attachments/assets/507f952b-19f8-4343-946b-e0bd68da067e" />

It isn't perfect and is still missing a few bells and whistles of the classic Mac OS one, but it has the core functionality I think. We can always extend it further
