### PR TITLE
NBP: Send a lookup per cable so replies can reach us

### DIFF
--- a/tailtalk-daemon/src/lib.rs
+++ b/tailtalk-daemon/src/lib.rs
@@ -702,7 +702,17 @@ async fn socket_pump_outbound(
                 continue;
             }
         };
-        if let Err(e) = sender.send_to_typed(&send.payload, addr, protocol).await {
+        // Both EtherTalk phases name the same cable; UNKNOWN leaves a
+        // broadcast unscoped, i.e. going out on every interface.
+        let iface = match send.iface {
+            1 | 2 => Some(tailtalk::route_table::Interface::EtherTalk),
+            3 => Some(tailtalk::route_table::Interface::LocalTalk),
+            _ => None,
+        };
+        if let Err(e) = sender
+            .send_to_typed(&send.payload, addr, protocol, iface)
+            .await
+        {
             tracing::warn!("socket {socket_id}: send failed: {e}");
         }
     }

--- a/tailtalk-daemon/tests/integration.rs
+++ b/tailtalk-daemon/tests/integration.rs
@@ -167,6 +167,7 @@ async fn ddp_socket_lifecycle() {
                 dest_socket: 2,
                 payload: vec![1, 2, 3],
                 ddp_type: 0,
+                iface: proto::AddressSource::Unknown as i32,
             }),
         )
         .await,

--- a/tailtalk-proto/proto/tailtalk.proto
+++ b/tailtalk-proto/proto/tailtalk.proto
@@ -142,6 +142,17 @@ message SendDatagram {
   // the socket was opened with. Clients whose socket API carries the DDP
   // type per datagram (e.g. Netatalk's netddp) set this on every send.
   uint32 ddp_type = 5;
+  // Restricts a {0, 255} broadcast to the cable named here, instead of
+  // sending it on every interface the daemon has. Both EtherTalk phases
+  // name the same cable. UNKNOWN (the default) means "every interface",
+  // which is what unicast sends always use — their cable follows from the
+  // destination address.
+  //
+  // Needed when the payload itself carries one of the sender's addresses,
+  // as an NBP lookup's reply tuple does: that address differs per
+  // interface, and only the one belonging to the cable the datagram goes
+  // out on can be reached by the nodes receiving it.
+  AddressSource iface = 6;
 }
 
 enum AddressSource {

--- a/tailtalk-proto/src/lib.rs
+++ b/tailtalk-proto/src/lib.rs
@@ -178,6 +178,7 @@ mod tests {
                 dest_socket: 2,
                 payload: vec![0xAA; 100],
                 ddp_type: 0,
+                iface: AddressSource::Unknown as i32,
             })),
         }
     }

--- a/tailtalk/src/ddp.rs
+++ b/tailtalk/src/ddp.rs
@@ -46,6 +46,12 @@ struct OutboundPacket {
     src_sock: SockNum,
     protocol: DdpProtocolType,
     payload: Box<[u8]>,
+    /// Restricts a link-layer broadcast to a single cable.
+    ///
+    /// Only consulted for the `{0, 255}` network-wide broadcast, which
+    /// otherwise goes out on every configured interface. Unicast is routed by
+    /// destination address, so the cable is not the caller's to choose.
+    iface: Option<Interface>,
 }
 
 #[derive(Debug, Clone)]
@@ -67,17 +73,21 @@ pub struct DdpSocketSender {
 
 impl DdpSocketSender {
     pub async fn send_to(&self, buf: &[u8], addr: DdpAddress) -> Result<(), Error> {
-        self.send_to_typed(buf, addr, None).await
+        self.send_to_typed(buf, addr, None, None).await
     }
 
     /// Like [`Self::send_to`], but stamps `protocol` on this datagram instead
     /// of the type the socket was opened with. Used to serve clients whose
     /// socket API carries the DDP type per datagram rather than per socket.
+    ///
+    /// `iface` restricts a `{0, 255}` broadcast to one cable; see
+    /// [`DdpSocket::send_to_iface`].
     pub async fn send_to_typed(
         &self,
         buf: &[u8],
         addr: DdpAddress,
         protocol: Option<DdpProtocolType>,
+        iface: Option<Interface>,
     ) -> Result<(), Error> {
         if buf.len() > 586 {
             return Err(io::Error::new(
@@ -95,6 +105,7 @@ impl DdpSocketSender {
                     payload: buf.into(),
                     src_sock: self.sock_num,
                     protocol: protocol.unwrap_or(self.protocol),
+                    iface,
                 };
                 sender.send(DdpCommand::SendPkt(pkt)).await.map_err(|_| {
                     io::Error::new(io::ErrorKind::BrokenPipe, "DDP processor shut down")
@@ -102,7 +113,7 @@ impl DdpSocketSender {
             }
             DdpSender::Remote(client) => {
                 client
-                    .send_datagram(self.sock_num, addr.addr, addr.sock, buf)
+                    .send_datagram(self.sock_num, addr.addr, addr.sock, buf, iface)
                     .await?;
             }
         }
@@ -141,6 +152,31 @@ impl DdpSocket {
     }
 
     pub async fn send_to(&self, buf: &[u8], addr: DdpAddress) -> Result<(), Error> {
+        self.send_to_inner(buf, addr, None).await
+    }
+
+    /// Send a `{0, 255}` broadcast on one cable only, instead of on every
+    /// configured interface.
+    ///
+    /// Needed whenever the payload itself names an address of ours — an NBP
+    /// lookup's reply tuple, say — because that address differs per interface
+    /// and only the one belonging to the cable the datagram goes out on is
+    /// reachable by the nodes that receive it.
+    pub async fn send_to_iface(
+        &self,
+        buf: &[u8],
+        addr: DdpAddress,
+        iface: Interface,
+    ) -> Result<(), Error> {
+        self.send_to_inner(buf, addr, Some(iface)).await
+    }
+
+    async fn send_to_inner(
+        &self,
+        buf: &[u8],
+        addr: DdpAddress,
+        iface: Option<Interface>,
+    ) -> Result<(), Error> {
         if buf.len() > 586 {
             tracing::error!(
                 "DDP payload length {} exceeds maximum allowed (586 bytes)",
@@ -162,6 +198,7 @@ impl DdpSocket {
                     payload: buf.into(),
                     src_sock: self.sock_num,
                     protocol: self.protocol,
+                    iface,
                 };
                 sender.send(DdpCommand::SendPkt(pkt)).await.map_err(|_| {
                     io::Error::new(io::ErrorKind::BrokenPipe, "DDP processor shut down")
@@ -169,7 +206,7 @@ impl DdpSocket {
             }
             DdpSender::Remote(client) => {
                 client
-                    .send_datagram(self.sock_num, addr.addr, addr.sock, buf)
+                    .send_datagram(self.sock_num, addr.addr, addr.sock, buf, iface)
                     .await?;
             }
         }
@@ -430,24 +467,30 @@ impl DdpProcessor {
     async fn handle_outbound(&mut self, packet: OutboundPacket) {
         // Network-wide broadcast {0, 255}: send on every configured interface so
         // all nodes on each cable receive it, regardless of their network number.
+        // A caller that scoped the send to one cable gets only that one.
         if packet.dest.addr.network_number == 0 && packet.dest.addr.node_number == 255 {
+            let wanted = |iface| packet.iface.is_none_or(|only| only == iface);
             let mut sent = false;
-            if self.et_addressing.is_some() {
+            if self.et_addressing.is_some() && wanted(Interface::EtherTalk) {
                 let et_addr = self.et_addr().await.unwrap();
                 let dest_node = Node::EtherTalkPhase2(Addressing::APPLETALK_BROADCAST_MULTICAST);
                 self.send_ddp_to_node(&packet, dest_node, et_addr).await;
                 sent = true;
             }
-            if self.lt_addressing.is_some() {
+            if self.lt_addressing.is_some() && wanted(Interface::LocalTalk) {
                 let lt_addr = self.lt_addr().await.unwrap();
                 self.send_ddp_to_node(&packet, Node::LocalTalk(255), lt_addr).await;
                 sent = true;
             }
             if !sent {
                 tracing::error!(
-                    "DDP: dropping packet to {}.{} — no interfaces configured",
+                    "DDP: dropping packet to {}.{} — no interfaces configured{}",
                     packet.dest.addr.network_number,
                     packet.dest.addr.node_number,
+                    match packet.iface {
+                        Some(iface) => format!(" for the requested cable ({iface:?})"),
+                        None => String::new(),
+                    },
                 );
             }
             return;

--- a/tailtalk/src/nbp.rs
+++ b/tailtalk/src/nbp.rs
@@ -132,24 +132,18 @@ impl Nbp {
                                     z => self.route_table.nbp_dispatch(NbpZone::Named(z)),
                                 };
 
-                                // The reply address we advertise in the tuple: when
-                                // asking a router, use our address on that router's
-                                // cable so replies forwarded from other networks can
-                                // route back; otherwise the primary address.
-                                let reply_iface = match &dispatch {
-                                    NbpDispatch::RouterBroadcast(routers) => routers
-                                        .first()
-                                        .and_then(|r| self.route_table.interface_for_net(r.network_number)),
-                                    _ => None,
-                                };
-                                let our_addr = self.addr_on(reply_iface).await;
-
-                                let tuple = NbpTuple {
-                                    network_number: our_addr.network_number,
-                                    node_id: our_addr.node_number,
+                                // The request tuple names the address replies come
+                                // back to — responders answer the tuple, not the
+                                // DDP source. It is therefore built per outgoing
+                                // copy, from our address on the cable that copy
+                                // goes out on, and never shared across cables.
+                                let name = lookup.request;
+                                let make_tuple = |addr: AppleTalkAddress| NbpTuple {
+                                    network_number: addr.network_number,
+                                    node_id: addr.node_number,
                                     socket_number: 2,
                                     enumerator: 0,
-                                    entity_name: lookup.request,
+                                    entity_name: name.clone(),
                                 };
 
                                 let mut buf = [0u8; 1024];
@@ -160,15 +154,22 @@ impl Nbp {
                                         // router ("A-ROUTER") handles the whole request, so
                                         // stop at the first successful send — asking several
                                         // would only duplicate every reply.
-                                        let packet = NbpPacket {
-                                            operation: NbpOperation::BroadcastRequest,
-                                            transaction_id: tid,
-                                            tuples: vec![tuple],
-                                        };
-                                        let size = packet.to_bytes(&mut buf).expect("failed to serialize");
-
                                         let mut result = Err(io::Error::other("no routers to send BrRq to"));
                                         for router in routers {
+                                            // Our address on this router's cable, so
+                                            // replies it forwards back from other
+                                            // networks have somewhere to land. Resolved
+                                            // per router, since the loop may fall
+                                            // through to one on the other interface.
+                                            let iface = self.route_table.interface_for_net(router.network_number);
+                                            let our_addr = self.addr_on(iface).await;
+                                            let packet = NbpPacket {
+                                                operation: NbpOperation::BroadcastRequest,
+                                                transaction_id: tid,
+                                                tuples: vec![make_tuple(our_addr)],
+                                            };
+                                            let size = packet.to_bytes(&mut buf).expect("failed to serialize");
+
                                             let dest = crate::ddp::DdpAddress::new(router, 2);
                                             match self.sock.send_to(&buf[..size], dest).await {
                                                 Ok(()) => {
@@ -187,16 +188,44 @@ impl Nbp {
                                         result
                                     }
                                     NbpDispatch::LocalBroadcast | NbpDispatch::ZoneUnknown => {
-                                        let packet = NbpPacket {
-                                            operation: NbpOperation::Lookup,
-                                            transaction_id: tid,
-                                            tuples: vec![tuple],
-                                        };
-                                        let size = packet.to_bytes(&mut buf).expect("failed to serialize");
+                                        // One LkUp per cable, each carrying our address
+                                        // on that cable. A single broadcast fanned out
+                                        // by DDP would put one interface's address in
+                                        // front of both cables' nodes, and the ones that
+                                        // cannot reach it — LocalTalk devices handed our
+                                        // EtherTalk address, typically — would answer
+                                        // into the void.
+                                        let ifaces = [Interface::EtherTalk, Interface::LocalTalk]
+                                            .into_iter()
+                                            .filter(|i| self.has_iface(*i));
 
-                                        let dest_addr = tailtalk_packets::aarp::AppleTalkAddress { network_number: 0, node_number: 255 };
-                                        let dest = crate::ddp::DdpAddress::new(dest_addr, 2);
-                                        self.sock.send_to(&buf[..size], dest).await
+                                        let mut result = Err(io::Error::other(
+                                            "no interfaces configured to broadcast NBP LkUp on",
+                                        ));
+                                        for iface in ifaces {
+                                            let our_addr = self.addr_on(Some(iface)).await;
+                                            let packet = NbpPacket {
+                                                operation: NbpOperation::Lookup,
+                                                transaction_id: tid,
+                                                tuples: vec![make_tuple(our_addr)],
+                                            };
+                                            let size = packet.to_bytes(&mut buf).expect("failed to serialize");
+
+                                            let dest_addr = tailtalk_packets::aarp::AppleTalkAddress { network_number: 0, node_number: 255 };
+                                            let dest = crate::ddp::DdpAddress::new(dest_addr, 2);
+                                            // One cable failing must not cancel the
+                                            // lookup on the other, so any success wins.
+                                            match self.sock.send_to_iface(&buf[..size], dest, iface).await {
+                                                Ok(()) => result = Ok(()),
+                                                Err(e) => {
+                                                    tracing::warn!("NBP LkUp: failed to send on {iface:?}: {e}");
+                                                    if result.is_err() {
+                                                        result = Err(e);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        result
                                     }
                                 };
 
@@ -285,6 +314,14 @@ impl Nbp {
                 io::ErrorKind::NotFound,
                 "entity name and sock num not registered",
             )));
+        }
+    }
+
+    /// Whether the given interface is configured on this stack.
+    fn has_iface(&self, iface: Interface) -> bool {
+        match iface {
+            Interface::EtherTalk => self.et_addressing.is_some(),
+            Interface::LocalTalk => self.lt_addressing.is_some(),
         }
     }
 

--- a/tailtalk/src/remote.rs
+++ b/tailtalk/src/remote.rs
@@ -19,6 +19,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
 use crate::ddp::Packet;
+use crate::route_table::Interface;
 
 /// Where to reach the daemon.
 #[derive(Debug, Clone)]
@@ -180,6 +181,7 @@ impl RemoteClient {
         dest: AppleTalkAddress,
         dest_socket: u8,
         payload: &[u8],
+        iface: Option<Interface>,
     ) -> io::Result<()> {
         let req = proto::Request {
             id: 0,
@@ -192,6 +194,13 @@ impl RemoteClient {
                 dest_socket: dest_socket as u32,
                 payload: payload.to_vec(),
                 ddp_type: 0, // use the type the socket was opened with
+                // Phase 2 stands in for "the EtherTalk cable"; the daemon
+                // maps either phase back to the same interface.
+                iface: match iface {
+                    Some(Interface::EtherTalk) => proto::AddressSource::EthertalkPhase2 as i32,
+                    Some(Interface::LocalTalk) => proto::AddressSource::Localtalk as i32,
+                    None => proto::AddressSource::Unknown as i32,
+                },
             })),
         };
         self.req_tx

--- a/tailtalk/tests/nbp_dual_interface.rs
+++ b/tailtalk/tests/nbp_dual_interface.rs
@@ -1,0 +1,154 @@
+//! NBP lookups on a stack with both cables configured.
+//!
+//! An NBP responder answers the address in the request's tuple, not the DDP
+//! source address, so a lookup broadcast on two cables needs a tuple per
+//! cable. Getting this wrong is invisible on a single-interface stack and
+//! silently breaks discovery on the non-primary one: devices reply to an
+//! address they have no route to.
+
+use std::time::Duration;
+
+use tailtalk::{
+    DataLinkPacket, DataLinkProtocol, OutboundHandle,
+    addressing::{Addressing, Node},
+    ddp::DdpProcessor,
+    nbp::Nbp,
+    route_table::{LearningMode, RouteTable},
+};
+use tailtalk_packets::{
+    aarp::{AddressSource, AppleTalkAddress},
+    ddp::DdpPacket as DdpHeaders,
+    nbp::{EntityName, NbpOperation, NbpPacket},
+};
+use tokio::sync::mpsc;
+
+const ET_ADDR: AppleTalkAddress = AppleTalkAddress {
+    network_number: 5501,
+    node_number: 40,
+};
+const LT_NODE: u8 = 12;
+
+/// An NBP packet lifted off the wire, with the cable it went out on.
+struct SentNbp {
+    dest_node: Node,
+    packet: NbpPacket,
+}
+
+/// Pull NBP datagrams out of the link-layer frames the stack emits, ignoring
+/// the AARP/LLAP traffic addressing produces on the way up.
+fn extract_nbp(frames: &[DataLinkPacket]) -> Vec<SentNbp> {
+    frames
+        .iter()
+        .filter(|f| f.protocol == DataLinkProtocol::Ddp)
+        .filter_map(|f| {
+            // Short-form DDP (LocalTalk, no router known) has a 5-byte header;
+            // long form has the full 13.
+            let header_len = if f.ddp_long { DdpHeaders::LEN } else { 5 };
+            let packet = NbpPacket::from_bytes(&f.payload[header_len..]).ok()?;
+            Some(SentNbp {
+                dest_node: f.dest_node,
+                packet,
+            })
+        })
+        .collect()
+}
+
+/// Build a stack with an EtherTalk and a LocalTalk interface, returning its
+/// NBP handle and the channel every outgoing frame lands in.
+async fn dual_interface_stack() -> (tailtalk::nbp::NbpHandle, mpsc::Receiver<DataLinkPacket>) {
+    let (out_tx, out_rx) = mpsc::channel(100);
+    let outbound = OutboundHandle::new(out_tx);
+
+    let et = Addressing::spawn(
+        Some([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]),
+        outbound.clone(),
+        Some(ET_ADDR),
+        AddressSource::EtherTalkPhase2,
+    );
+    // No MAC means LocalTalk, which probes its node number via LLAP ENQ and
+    // settles on network 0.
+    let lt = Addressing::spawn(
+        None,
+        outbound.clone(),
+        Some(AppleTalkAddress {
+            network_number: 0,
+            node_number: LT_NODE,
+        }),
+        AddressSource::LocalTalk,
+    );
+
+    let route_table = RouteTable::new(LearningMode::Static);
+    let ddp = DdpProcessor::spawn(
+        Some(et.clone()),
+        Some(lt.clone()),
+        outbound.clone(),
+        route_table.clone(),
+    );
+    let nbp = Nbp::spawn(&ddp, Some(et), Some(lt), route_table).await;
+
+    // Let the LocalTalk ENQ probe finish so its address is settled before the
+    // lookup asks for it.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    (nbp, out_rx)
+}
+
+/// The reply tuple must name our address on the cable each copy goes out on.
+#[tokio::test]
+async fn local_lookup_names_our_address_on_each_cable() {
+    let (nbp, mut out_rx) = dual_interface_stack().await;
+
+    // The lookup itself blocks for its reply-collection window; we only care
+    // about what went out on the wire.
+    tokio::spawn(async move {
+        let _ = nbp
+            .lookup(EntityName {
+                object: "=".into(),
+                entity_type: "LaserWriter".into(),
+                zone: "*".into(),
+            })
+            .await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let mut frames = Vec::new();
+    while let Ok(frame) = out_rx.try_recv() {
+        frames.push(frame);
+    }
+    let sent = extract_nbp(&frames);
+
+    let lookups: Vec<&SentNbp> = sent
+        .iter()
+        .filter(|s| matches!(s.packet.operation, NbpOperation::Lookup))
+        .collect();
+    assert_eq!(
+        lookups.len(),
+        2,
+        "expected one LkUp per cable, got {}",
+        lookups.len()
+    );
+
+    let et = lookups
+        .iter()
+        .find(|s| matches!(s.dest_node, Node::EtherTalkPhase2(_) | Node::EtherTalkPhase1(_)))
+        .expect("no LkUp broadcast on the EtherTalk cable");
+    let lt = lookups
+        .iter()
+        .find(|s| matches!(s.dest_node, Node::LocalTalk(255)))
+        .expect("no LkUp broadcast on the LocalTalk cable");
+
+    let et_tuple = &et.packet.tuples[0];
+    assert_eq!(et_tuple.network_number, ET_ADDR.network_number);
+    assert_eq!(et_tuple.node_id, ET_ADDR.node_number);
+
+    // The regression: this used to carry the EtherTalk address, which no
+    // LocalTalk device could route a reply to.
+    let lt_tuple = &lt.packet.tuples[0];
+    assert_eq!(lt_tuple.network_number, 0);
+    assert_eq!(lt_tuple.node_id, LT_NODE);
+
+    // Both copies belong to one transaction, so replies from either cable are
+    // collected into the same lookup.
+    assert_eq!(et.packet.transaction_id, lt.packet.transaction_id);
+}


### PR DESCRIPTION
An NBP responder answers the address carried in the request's tuple, not the DDP source address. A lookup built one tuple, from the primary (i.e. EtherTalk) address, and handed it to DDP as a {0, 255} broadcast — which fans out onto every cable. LocalTalk devices therefore received a request asking them to reply to our EtherTalk address, which they have no route to on an unrouted segment, so their replies went nowhere and discovery came back empty. Only the non-primary interface was affected, which is why this stayed invisible until both were enabled at once.

Broadcast one LkUp per cable instead, each carrying our address on that cable, under a shared transaction ID so replies from either still land in the same lookup. This needs a broadcast that DDP does not fan out, so DdpSocket grows send_to_iface, carried to the daemon as a new SendDatagram.iface field (unset keeps the fan-out, which is what every unicast send wants — there, routing picks the cable).

Fix the same class of bug in the BrRq path, where the reply address was resolved from the first router in the list but the send loop could fall through to a router on the other interface: resolve it per router.

The responder side already replied to the tuple, and from the address on the interface the request arrived on, so it needed no change.