### PR TITLE
GUI: Fix layout, enable EtherTalk on macOS if ChmodBPF is installed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6714,6 +6714,7 @@ dependencies = [
  "if-addrs",
  "ipp",
  "keepawake",
+ "libc",
  "mdns-sd",
  "rfd",
  "serde",

--- a/README.md
+++ b/README.md
@@ -122,6 +122,20 @@ Install npcap 1.88 from [npcap.com](https://npcap.com/#download)
 macOS 11 and later includes support for the CP2102N USB chip out of the box. For 10.12 through 10.15 the driver from Silicon
 Labs is required for the device to be recognised: https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads
 
+## EtherTalk
+
+EtherTalk is compiled into the GUI by default on macOS, where libpcap ships with the OS. On Linux and Windows it is opt-in:
+build with `cargo build -p tailtalk-gui --features ethertalk` once libpcap (`libpcap-dev`) or the npcap SDK is installed.
+
+### macOS
+
+Packet capture and injection go through `/dev/bpf*`, which is root-only out of the box. To use EtherTalk as a regular user,
+install the **ChmodBPF** package that ships inside the Wireshark disk image (or run `brew install --cask wireshark-chmodbpf`).
+It creates an `access_bpf` group, hands the BPF devices to it, and adds you to the group.
+
+Group membership only applies to new login sessions, so **log out and back in** afterwards. Until then, and if ChmodBPF is not
+installed at all, the GUI hides the Ethernet Interface picker rather than offering a transport that would fail to start.
+
 ## Existing Programs
 There are 4 demo programs I have written to verify the functionality of this software as I have developed it:
 
@@ -133,7 +147,8 @@ There are 4 demo programs I have written to verify the functionality of this sof
 - [tailtalk-gui](/examples/tailtalk-gui/) - A simple GUI for sharing a folder as a volume over EtherTalk and/or LocalTalk (via TashTalk).
 
 All of the examples run a complete copy of the stack using a raw socket (if EtherTalk is enabled) and thus need to be run as root,
- or the appropriate setcap applied to the compiled binary. If only using TashTalk then this is not required.
+ or the appropriate setcap applied to the compiled binary (on macOS, ChmodBPF instead, see [EtherTalk](#ethertalk)). If only
+ using TashTalk then this is not required.
 
 ## Testing
 

--- a/tailtalk-gui/Cargo.toml
+++ b/tailtalk-gui/Cargo.toml
@@ -11,6 +11,9 @@ path = "main.rs"
 [features]
 default = ["tashtalk"]
 tashtalk = ["dep:serialport"]
+# Opt-in elsewhere; always on for macOS via the target dependency below, since a
+# `default` list can't be made target-conditional. See build.rs for the cfg the
+# source actually gates on.
 ethertalk = ["tailtalk/ethertalk"]
 
 [dependencies]
@@ -36,6 +39,11 @@ toml = "^1.1"
 tracing = { workspace = true } #unified
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# macOS ships libpcap, so EtherTalk costs nothing to build here and is on by default.
+[target.'cfg(target_os = "macos")'.dependencies]
+tailtalk = { workspace = true, features = ["ethertalk"] }
+libc = "0.2"
 
 [build-dependencies]
 slint-build = "1"

--- a/tailtalk-gui/bpf.rs
+++ b/tailtalk-gui/bpf.rs
@@ -1,0 +1,63 @@
+//! Whether this process can open a BPF device, which is what EtherTalk needs
+//! before the GUI is willing to offer an Ethernet interface at all.
+//!
+//! libpcap captures and injects through a `/dev/bpf*` character device, opened
+//! read/write since we put AARP/DDP frames on the wire rather than only
+//! sniffing. Those devices are root-only as shipped; Wireshark's ChmodBPF
+//! package is the usual fix, creating an `access_bpf` group, handing the
+//! devices to it and adding the console user.
+//!
+//! So the check is whether that group exists and whether we are in it.
+//! Membership comes from `getgroups`, the login session's group list, which is
+//! what the kernel consults when pcap opens the device. A fresh ChmodBPF
+//! install therefore reads as unavailable until the user logs out and back in,
+//! which is when it genuinely starts working.
+
+/// True when this process should be able to open a BPF device for capture and
+/// injection.
+#[cfg(target_os = "macos")]
+pub fn capture_permitted() -> bool {
+    // SAFETY: takes no arguments and cannot fail.
+    if unsafe { libc::geteuid() } == 0 {
+        return true; // root opens the devices regardless of group membership.
+    }
+
+    // SAFETY: the name is NUL-terminated. `getgrnam` returns a pointer into a
+    // static buffer valid until the next getgr* call; we read it immediately.
+    let entry = unsafe { libc::getgrnam(c"access_bpf".as_ptr()) };
+    if entry.is_null() {
+        tracing::debug!("No access_bpf group: Wireshark's ChmodBPF package is not installed");
+        return false;
+    }
+    in_group(unsafe { (*entry).gr_gid })
+}
+
+/// Whether this process's group list includes `gid`.
+#[cfg(target_os = "macos")]
+fn in_group(gid: libc::gid_t) -> bool {
+    // SAFETY: no arguments, cannot fail.
+    if unsafe { libc::getegid() } == gid {
+        return true;
+    }
+
+    // SAFETY: a size of 0 asks for the count only, and permits a null buffer.
+    let count = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
+    if count <= 0 {
+        return false;
+    }
+
+    let mut groups = vec![0; count as usize];
+    // SAFETY: the buffer holds `count` gid_t, matching the size we pass.
+    let filled = unsafe { libc::getgroups(count, groups.as_mut_ptr()) };
+    if filled < 0 {
+        return false;
+    }
+    groups[..filled as usize].contains(&gid)
+}
+
+/// Non-macOS platforms have no ChmodBPF equivalent to gate on: EtherTalk is a
+/// deliberate opt-in there, so never hide what the user asked to compile in.
+#[cfg(not(target_os = "macos"))]
+pub fn capture_permitted() -> bool {
+    true
+}

--- a/tailtalk-gui/build.rs
+++ b/tailtalk-gui/build.rs
@@ -4,4 +4,15 @@ fn main() {
         slint_build::CompilerConfiguration::new().with_style("native".into()),
     )
     .unwrap();
+
+    // EtherTalk is on by default on macOS, where libpcap ships with the OS and
+    // its BPF devices open without root once ChmodBPF is installed. Elsewhere it
+    // stays opt-in, since pcap has to be installed separately (libpcap-dev, the
+    // Npcap SDK) and a missing one breaks the build outright. Cargo features
+    // cannot be made target-conditional, hence a cfg rather than a feature.
+    println!("cargo::rustc-check-cfg=cfg(ethertalk)");
+    let macos = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos");
+    if macos || std::env::var_os("CARGO_FEATURE_ETHERTALK").is_some() {
+        println!("cargo::rustc-cfg=ethertalk");
+    }
 }

--- a/tailtalk-gui/main.rs
+++ b/tailtalk-gui/main.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-#[cfg(any(feature = "ethertalk", feature = "tashtalk"))]
+#[cfg(any(ethertalk, feature = "tashtalk"))]
 use std::rc::Rc;
 #[cfg(feature = "tashtalk")]
 use std::cell::RefCell;
@@ -16,6 +16,8 @@ use tracing_subscriber::{EnvFilter, prelude::*};
 
 slint::include_modules!();
 
+#[cfg(ethertalk)]
+mod bpf;
 mod ipp_bridge;
 mod lw_bridge;
 mod printer_tool;
@@ -109,7 +111,7 @@ enum ServerCommand {
     Start {
         server_name: String,
         volume_name: String,
-        #[cfg(feature = "ethertalk")]
+        #[cfg(ethertalk)]
         ethernet: Option<String>,
         #[cfg(feature = "tashtalk")]
         tashtalk: Option<String>,
@@ -124,7 +126,7 @@ enum ServerCommand {
 
 // ── Interface enumeration ─────────────────────────────────────────────────────
 
-#[cfg(feature = "ethertalk")]
+#[cfg(ethertalk)]
 fn enumerate_ethernet() -> Vec<String> {
     let mut names = vec!["None".to_string()];
     if let Ok(ifaces) = if_addrs::get_if_addrs() {
@@ -282,16 +284,32 @@ fn main() -> anyhow::Result<()> {
 
     let ui = AppWindow::new()?;
 
+    // EtherTalk is only usable if libpcap can open a BPF device, which on macOS
+    // means the ChmodBPF `access_bpf` group (or root). An interface picker we
+    // know will fail at Start is worse than none, so it gives way to a note
+    // explaining the fix.
+    #[cfg(ethertalk)]
+    let ethertalk_ready = bpf::capture_permitted();
+    #[cfg(not(ethertalk))]
+    let ethertalk_ready = false;
+    if cfg!(ethertalk) && !ethertalk_ready {
+        tracing::info!(
+            "Hiding the Ethernet interface picker: this session is not in the access_bpf \
+             group. Install Wireshark's ChmodBPF package, then log out and back in."
+        );
+    }
+
     // Inform the UI which transport sections to show
-    ui.set_feature_ethertalk(cfg!(feature = "ethertalk"));
+    ui.set_feature_ethertalk(ethertalk_ready);
+    ui.set_ethertalk_needs_chmodbpf(cfg!(ethertalk) && !ethertalk_ready);
     ui.set_feature_tashtalk(cfg!(feature = "tashtalk"));
 
-    #[cfg(feature = "ethertalk")]
+    #[cfg(ethertalk)]
     let ethernet_names = enumerate_ethernet();
     #[cfg(feature = "tashtalk")]
     let tashtalk_devices = Rc::new(RefCell::new(enumerate_serial()));
 
-    #[cfg(feature = "ethertalk")]
+    #[cfg(ethertalk)]
     {
         let eth_model: slint::ModelRc<SharedString> = Rc::new(slint::VecModel::from(
             ethernet_names
@@ -328,9 +346,18 @@ fn main() -> anyhow::Result<()> {
             .into(),
     );
 
+    // Kept aside so a run without BPF access writes the saved interface back
+    // untouched, rather than clearing a setting the user cannot currently see.
+    #[cfg(ethertalk)]
+    let saved_ethernet;
+
     // Restore previously saved settings
     {
         let config = load_config();
+        #[cfg(ethertalk)]
+        {
+            saved_ethernet = config.ethernet_interface.clone();
+        }
         if let Some(ref v) = config.server_name {
             ui.set_server_name(v.as_str().into());
         }
@@ -340,8 +367,9 @@ fn main() -> anyhow::Result<()> {
         if let Some(ref v) = config.volume_path {
             ui.set_volume_path(v.as_str().into());
         }
-        #[cfg(feature = "ethertalk")]
-        if let Some(ref iface) = config.ethernet_interface
+        #[cfg(ethertalk)]
+        if ethertalk_ready
+            && let Some(ref iface) = config.ethernet_interface
             && let Some(idx) = ethernet_names.iter().position(|n| n == iface)
         {
             ui.set_selected_ethernet(idx as i32);
@@ -392,7 +420,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     let ui_weak = ui.as_weak();
-    #[cfg(feature = "ethertalk")]
+    #[cfg(ethertalk)]
     let eth_names = ethernet_names.clone();
     #[cfg(feature = "tashtalk")]
     let tash_devices = tashtalk_devices.clone();
@@ -405,14 +433,18 @@ fn main() -> anyhow::Result<()> {
                 tracing::warn!("Server command queue full; ignoring Stop");
             }
         } else {
-            #[cfg(feature = "ethertalk")]
-            let ethernet = {
-                let eth_idx = ui.get_selected_ethernet() as usize;
-                eth_names
-                    .get(eth_idx)
-                    .filter(|s| s.as_str() != "None")
-                    .cloned()
-            };
+            // Without BPF access the picker was never shown, so there is no
+            // selection to honour and EtherTalk stays out entirely.
+            #[cfg(ethertalk)]
+            let ethernet = ethertalk_ready
+                .then(|| {
+                    let eth_idx = ui.get_selected_ethernet() as usize;
+                    eth_names
+                        .get(eth_idx)
+                        .filter(|s| s.as_str() != "None")
+                        .cloned()
+                })
+                .flatten();
 
             #[cfg(feature = "tashtalk")]
             let tashtalk = {
@@ -425,7 +457,7 @@ fn main() -> anyhow::Result<()> {
 
             #[allow(unused_mut)]
             let mut any_transport = false;
-            #[cfg(feature = "ethertalk")]
+            #[cfg(ethertalk)]
             if ethernet.is_some() {
                 any_transport = true;
             }
@@ -527,9 +559,9 @@ fn main() -> anyhow::Result<()> {
                     { None }
                 },
                 ethernet_interface: {
-                    #[cfg(feature = "ethertalk")]
-                    { ethernet.clone() }
-                    #[cfg(not(feature = "ethertalk"))]
+                    #[cfg(ethertalk)]
+                    { if ethertalk_ready { ethernet.clone() } else { saved_ethernet.clone() } }
+                    #[cfg(not(ethertalk))]
                     { None }
                 },
                 pcap_enabled: ui.get_pcap_enabled(),
@@ -565,7 +597,7 @@ fn main() -> anyhow::Result<()> {
             let send_result = cmd_tx.try_send(ServerCommand::Start {
                 server_name: ui.get_server_name().to_string(),
                 volume_name: ui.get_volume_name().to_string(),
-                #[cfg(feature = "ethertalk")]
+                #[cfg(ethertalk)]
                 ethernet,
                 #[cfg(feature = "tashtalk")]
                 tashtalk,
@@ -939,7 +971,7 @@ async fn server_loop(
             ServerCommand::Start {
                 server_name,
                 volume_name,
-                #[cfg(feature = "ethertalk")]
+                #[cfg(ethertalk)]
                 ethernet,
                 #[cfg(feature = "tashtalk")]
                 tashtalk,
@@ -961,7 +993,7 @@ async fn server_loop(
                 tokio::spawn(run_server(
                     server_name,
                     volume_name,
-                    #[cfg(feature = "ethertalk")]
+                    #[cfg(ethertalk)]
                     ethernet,
                     #[cfg(feature = "tashtalk")]
                     tashtalk,
@@ -1907,7 +1939,7 @@ impl tailtalk::pap::PrintSink for LaserWriterSink {
 async fn run_server(
     server_name: String,
     volume_name: String,
-    #[cfg(feature = "ethertalk")] ethernet: Option<String>,
+    #[cfg(ethertalk)] ethernet: Option<String>,
     #[cfg(feature = "tashtalk")] tashtalk: Option<String>,
     volume: PathBuf,
     pcap_path: Option<PathBuf>,
@@ -1936,7 +1968,7 @@ async fn run_server(
     #[allow(unused_mut)]
     let mut stack_builder = TalkStack::builder();
 
-    #[cfg(feature = "ethertalk")]
+    #[cfg(ethertalk)]
     if let Some(ref intf) = ethernet {
         stack_builder = stack_builder.ethernet(intf);
     }
@@ -2084,18 +2116,18 @@ async fn run_server(
         }
     }
 
-    #[cfg(any(feature = "ethertalk", feature = "tashtalk"))]
+    #[cfg(any(ethertalk, feature = "tashtalk"))]
     {
-        #[cfg(all(feature = "ethertalk", feature = "tashtalk"))]
+        #[cfg(all(ethertalk, feature = "tashtalk"))]
         let transport_desc = match (&ethernet, &tashtalk) {
             (Some(eth), Some(tty)) => format!("{eth} + {tty}"),
             (Some(eth), None) => eth.clone(),
             (None, Some(tty)) => tty.clone(),
             (None, None) => unreachable!(),
         };
-        #[cfg(all(feature = "ethertalk", not(feature = "tashtalk")))]
+        #[cfg(all(ethertalk, not(feature = "tashtalk")))]
         let transport_desc = ethernet.as_deref().unwrap_or("(none)").to_string();
-        #[cfg(all(not(feature = "ethertalk"), feature = "tashtalk"))]
+        #[cfg(all(not(ethertalk), feature = "tashtalk"))]
         let transport_desc = tashtalk.as_deref().unwrap_or("(none)").to_string();
         tracing::info!("AFP server running on {transport_desc}");
     }

--- a/tailtalk-gui/ui/app.slint
+++ b/tailtalk-gui/ui/app.slint
@@ -7,9 +7,11 @@ export { PrinterToolWindow, PrinterRow } from "printer_tool.slint";
 export component AppWindow inherits Window {
     title: "TailTalk AFP Server";
     min-width: 400px;
-    min-height: 200px;
     preferred-width: 540px;
-    preferred-height: 495px;
+    // Height is deliberately left to the layout. Rows come and go at runtime
+    // (the EtherTalk picker, the three LaserWriter rows), so any fixed height is
+    // wrong for some combination of them: a hardcoded one used to clip the Start
+    // button off the bottom once enough options were enabled.
 
     in-out property <string> server-name: "TailTalk AFP";
     in property <[string]> ethernet-interfaces;
@@ -25,6 +27,9 @@ export component AppWindow inherits Window {
     // Set from Rust at startup to reflect compiled-in features
     in property <bool> feature-ethertalk: false;
     in property <bool> feature-tashtalk: false;
+    // EtherTalk is compiled in, but no BPF device can be opened, so the
+    // interface picker is replaced by a note on how to get access.
+    in property <bool> ethertalk-needs-chmodbpf: false;
     in-out property <string> error-message: "";
     in-out property <bool> pcap-enabled: false;
     in-out property <string> pcap-path;
@@ -130,6 +135,18 @@ export component AppWindow inherits Window {
                         horizontal-stretch: 1;
                         enabled: !root.running;
 
+                    }
+                }
+
+                if root.ethertalk-needs-chmodbpf : HorizontalBox {
+                    padding-top: 0; padding-bottom: 0;
+                    Text { text: "Ethernet Interface"; min-width: 140px; vertical-alignment: center; }
+                    Text {
+                        text: "Unavailable. Install Wireshark's ChmodBPF package, then log out and back in.";
+                        wrap: word-wrap;
+                        horizontal-stretch: 1;
+                        vertical-alignment: center;
+                        opacity: 0.7;
                     }
                 }
 


### PR DESCRIPTION
Tweaks the slint layout so it just dynamically resizes instead of having to tweak the height every time we modify the layout. This fixes the Linux app requiring a resize every time it is launched (sorry!) and on macOS when the EtherTalk feature was enabled in conjunction with the LaserWriter emulation feature enabled.

Additionally this enables EtherTalk support on macOS _if_ ChmodBPF from Wireshark was already installed on the system previously. This gives us a handy non-root way of capturing and sendung packets. We probe this at startup by checking if we are in the expected group, and if so showing the UI picker. If not it will look same as before.

Note that if both TashTalk USB and EtherTalk is enabled we will not route between them - they remain as two isolated interfaces that clients can connect to from each side, but not through us.