### PR TITLE
GUI: Fix Linux TashTalk button size

### DIFF
--- a/tailtalk-gui/ui/app.slint
+++ b/tailtalk-gui/ui/app.slint
@@ -133,6 +133,7 @@ export component AppWindow inherits Window {
                         model: root.ethernet-interfaces;
                         current-index <=> root.selected-ethernet;
                         horizontal-stretch: 1;
+                        preferred-height: self.min-height;
                         enabled: !root.running;
 
                     }
@@ -157,6 +158,7 @@ export component AppWindow inherits Window {
                         model: root.tashtalk-ports;
                         current-index <=> root.selected-tashtalk;
                         horizontal-stretch: 1;
+                        preferred-height: self.min-height;
                         enabled: !root.running;
 
                     }


### PR DESCRIPTION
It helps if I actually check all the options sizes on Linux hah. Fixed one issue and introduced another. Now the total size and buttons look normal.