### PR TITLE
PAP/ATP: Fix resource leak, TID aliasing, and unbounded reads

### DIFF
--- a/tailtalk-packets/src/pap.rs
+++ b/tailtalk-packets/src/pap.rs
@@ -27,18 +27,19 @@ impl TryFrom<u8> for PapFunction {
     type Error = PapError;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            1 => Ok(PapFunction::OpenConn),
-            2 => Ok(PapFunction::OpenConnReply),
-            3 => Ok(PapFunction::SendData),
-            4 => Ok(PapFunction::Data),
-            5 => Ok(PapFunction::Tickle),
-            6 => Ok(PapFunction::CloseConn),
-            7 => Ok(PapFunction::CloseConnReply),
-            8 => Ok(PapFunction::SendStatus),
-            9 => Ok(PapFunction::Status),
-            _ => Err(PapError::UnknownFunction { code: value }),
-        }
+        use PapFunction::*;
+        Ok(match value {
+            1 => OpenConn,
+            2 => OpenConnReply,
+            3 => SendData,
+            4 => Data,
+            5 => Tickle,
+            6 => CloseConn,
+            7 => CloseConnReply,
+            8 => SendStatus,
+            9 => Status,
+            _ => return Err(PapError::UnknownFunction { code: value }),
+        })
     }
 }
 
@@ -339,10 +340,12 @@ mod tests {
 
     #[test]
     fn test_atp_helpers() {
+        // A sequence number above 255 so the big-endian split across user bytes 2-3
+        // is actually exercised; a low-byte-only value would pass either way.
         let original = PapPacket {
             connection_id: 10,
             function: PapFunction::SendData,
-            sequence_num: 57,
+            sequence_num: 0x0139, // 313
             eof: false,
             data: b"Data Payload".to_vec(),
         };
@@ -350,11 +353,33 @@ mod tests {
         let (user_bytes, data) = original.to_atp_parts();
         assert_eq!(user_bytes[0], 10);
         assert_eq!(user_bytes[1], 3); // SendData
-        assert_eq!(user_bytes[2], 0); // reserved
-        assert_eq!(user_bytes[3], 57); // sequence_num
+        assert_eq!(user_bytes[2], 0x01); // sequence_num high byte
+        assert_eq!(user_bytes[3], 0x39); // sequence_num low byte
         assert_eq!(data, b"Data Payload");
 
         let parsed = PapPacket::parse_from_atp(user_bytes, data).expect("failed to parse from atp");
         assert_eq!(original, parsed);
+    }
+
+    #[test]
+    fn test_data_eof_flag_round_trip() {
+        // Data carries EOF in user byte 2 and has no sequence number; make sure the
+        // flag survives a round trip and doesn't get read back as a sequence number.
+        let original = PapPacket {
+            connection_id: 4,
+            function: PapFunction::Data,
+            sequence_num: 0,
+            eof: true,
+            data: b"tail".to_vec(),
+        };
+
+        let (user_bytes, data) = original.to_atp_parts();
+        assert_eq!(user_bytes[2], 1); // EOF set
+        assert_eq!(user_bytes[3], 0); // unused for Data
+
+        let parsed = PapPacket::parse_from_atp(user_bytes, data).expect("failed to parse from atp");
+        assert_eq!(original, parsed);
+        assert!(parsed.eof);
+        assert_eq!(parsed.sequence_num, 0);
     }
 }

--- a/tailtalk/src/atp.rs
+++ b/tailtalk/src/atp.rs
@@ -15,6 +15,14 @@ pub const ATP_MAX_DATA_PER_PACKET: usize = 578;
 // Type aliases for complex channel types
 type AtpResponseChannel = oneshot::Sender<Result<(Vec<u8>, [u8; 4]), io::Error>>;
 
+/// How long to wait for a response before retransmitting a pending request.
+const ATP_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// How often the actor wakes to check for expired retransmit deadlines. Finer than
+/// [`ATP_RETRY_INTERVAL`] so each transaction's deadline is honoured to within a tick
+/// rather than being rounded to the shared timer's phase.
+const ATP_RETRY_TICK: std::time::Duration = std::time::Duration::from_millis(250);
+
 pub struct PendingRequestState {
     pub chan: AtpResponseChannel,
     pub xo: bool,
@@ -29,12 +37,16 @@ pub struct PendingRequestState {
     pub requested_bitmap: u8,
     /// Number of retransmissions sent so far (not counting the initial send).
     pub retry_count: u8,
+    /// When this request next becomes eligible for retransmission. Tracked per
+    /// transaction so a request registered just before a timer tick still gets a
+    /// full [`ATP_RETRY_INTERVAL`] before its first retry.
+    pub retry_at: tokio::time::Instant,
 }
 
 type AtpTransactionMap = HashMap<u16, PendingRequestState>;
 
 // Helper struct since DdpAddress might be ambiguous if not imported carefully
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct AtpAddress {
     pub network_number: u16,
     pub node_number: u8,
@@ -47,6 +59,29 @@ impl From<tailtalk_packets::nbp::ServiceAddress> for AtpAddress {
             network_number: a.network_number,
             node_number: a.node_number,
             socket_number: a.socket_number,
+        }
+    }
+}
+
+impl From<AtpAddress> for crate::ddp::DdpAddress {
+    fn from(a: AtpAddress) -> Self {
+        crate::ddp::DdpAddress::new(
+            tailtalk_packets::aarp::AppleTalkAddress {
+                network_number: a.network_number,
+                node_number: a.node_number,
+            },
+            a.socket_number,
+        )
+    }
+}
+
+impl AtpAddress {
+    /// Build an address from the source fields of a received DDP packet.
+    fn from_ddp_source(ddp: &DdpPacket) -> Self {
+        Self {
+            network_number: ddp.src_network_num,
+            node_number: ddp.src_node_id,
+            socket_number: ddp.src_sock_num,
         }
     }
 }
@@ -101,68 +136,43 @@ pub struct AtpReceivedRequest {
     pub user_bytes: [u8; 4],
     pub data: Vec<u8>,
     pub response_sender: mpsc::Sender<AtpCommand>,
-    pub release_rx: Option<oneshot::Receiver<()>>,
     /// The ATP bitmap from the request: each set bit = one response packet the client will accept.
     /// bit 0 = packet 0, bit 1 = packet 1, ..., bit 7 = packet 7 (max 8 packets).
     pub bitmap: u8,
 }
 
 impl AtpReceivedRequest {
+    /// Number of response packets this request's bitmap allows us to send (1-8).
+    ///
+    /// IMPORTANT: Classic Mac OS sends bitmap=0x00 in ASP SPCommand TReqs, which is
+    /// non-standard per the ATP spec (0x00 means "no buffers"), but in practice it means
+    /// "no restriction": treat it the same as 0xFF (all 8 packets allowed). Clamping it
+    /// to 1 packet would silently truncate multi-packet responses and corrupt the
+    /// client's file offset.
+    pub fn max_packets(&self) -> usize {
+        let effective_bitmap = if self.bitmap == 0x00 { 0xFF } else { self.bitmap };
+        (effective_bitmap.count_ones() as usize).clamp(1, 8)
+    }
+
     /// Returns the maximum number of response data bytes this request can accept,
     /// derived from the client's ATP bitmap. Use this to cap response payloads
     /// before calling send_response so AFP/ASP layers can truncate cleanly.
     pub fn max_response_bytes(&self) -> usize {
-        let effective_bitmap = if self.bitmap == 0x00 { 0xFF } else { self.bitmap };
-        let max_packets = (effective_bitmap.count_ones() as usize).clamp(1, 8);
-        max_packets * ATP_MAX_DATA_PER_PACKET
+        self.max_packets() * ATP_MAX_DATA_PER_PACKET
     }
 
-    /// Send a response with automatic fragmentation.
+    /// Send a response with automatic fragmentation at the ATP packet limit.
     ///
     /// Respects the client's ATP bitmap: only sends as many packets as the client
-    /// declared it can receive (count of set bits in `self.bitmap`, max 8).
-    /// Sending more packets than the bitmap allows causes ASP error -1067 (aspBufTooSmall).
-    pub async fn send_response(&self, data: Vec<u8>, user_bytes: [u8; 4]) -> Result<(), io::Error> {
-        // The client bitmap tells us how many response packets it will accept.
-        // Each set bit in the bitmap corresponds to one acceptable packet (bit 0 = pkt 0, etc.).
-        //
-        // IMPORTANT: Classic Mac OS sends bitmap=0x00 in ASP SPCommand TReqs, which is non-standard
-        // per the ATP spec (0x00 means "no buffers"), but in practice it means "no restriction" —
-        // treat it the same as 0xFF (all 8 packets allowed). Clamping it to 1 packet would
-        // silently truncate multi-packet responses and corrupt the client's file offset.
-        let effective_bitmap = if self.bitmap == 0x00 {
-            0xFF
-        } else {
-            self.bitmap
-        };
-        let max_packets = (effective_bitmap.count_ones() as usize).clamp(1, 8);
-        let max_data = max_packets * ATP_MAX_DATA_PER_PACKET;
-
-        if data.len() > max_data {
-            tracing::warn!(
-                "ATP response truncated: {} bytes requested but client bitmap 0x{:02x} only allows {} bytes ({} packets)",
-                data.len(),
-                self.bitmap,
-                max_data,
-                max_packets
-            );
-        }
-
-        // Split data into chunks, honouring the client's bitmap limit
-        let mut packets: Vec<AtpResponse> = data[..data.len().min(max_data)]
-            .chunks(ATP_MAX_DATA_PER_PACKET)
-            .map(|chunk| AtpResponse {
-                data: chunk.to_vec(),
-                user_bytes,
-            })
-            .collect();
-
-        // ATP requires at least one TResp even for zero-length data.
-        if packets.is_empty() {
-            packets.push(AtpResponse { data: vec![], user_bytes });
-        }
-
-        self.send_response_internal(packets).await
+    /// declared it can receive. Sending more packets than the bitmap allows causes
+    /// ASP error -1067 (aspBufTooSmall).
+    pub async fn send_response(
+        &self,
+        data: impl AsRef<[u8]>,
+        user_bytes: [u8; 4],
+    ) -> Result<(), io::Error> {
+        self.send_response_chunked(data, user_bytes, ATP_MAX_DATA_PER_PACKET)
+            .await
     }
 
     /// Send a response fragmented at `chunk_size` bytes per ATP packet.
@@ -171,20 +181,32 @@ impl AtpReceivedRequest {
     /// `ATP_MAX_DATA_PER_PACKET`. PAP, for example, caps each packet at 512 bytes.
     pub async fn send_response_chunked(
         &self,
-        data: Vec<u8>,
+        data: impl AsRef<[u8]>,
         user_bytes: [u8; 4],
         chunk_size: usize,
     ) -> Result<(), io::Error> {
+        let data = data.as_ref();
         assert!(chunk_size > 0, "chunk_size must be positive");
-        let effective_bitmap = if self.bitmap == 0x00 { 0xFF } else { self.bitmap };
-        let max_packets = (effective_bitmap.count_ones() as usize).clamp(1, 8);
+        let max_packets = self.max_packets();
         let max_data = max_packets * chunk_size;
+
+        if data.len() > max_data {
+            tracing::warn!(
+                "ATP response truncated: {} bytes requested but client bitmap 0x{:02x} only allows {} bytes ({} packets of {})",
+                data.len(),
+                self.bitmap,
+                max_data,
+                max_packets,
+                chunk_size
+            );
+        }
 
         let mut packets: Vec<AtpResponse> = data[..data.len().min(max_data)]
             .chunks(chunk_size)
             .map(|chunk| AtpResponse { data: chunk.to_vec(), user_bytes })
             .collect();
 
+        // ATP requires at least one TResp even for zero-length data.
         if packets.is_empty() {
             packets.push(AtpResponse { data: vec![], user_bytes });
         }
@@ -289,8 +311,6 @@ pub struct Atp {
     cmd_tx: mpsc::Sender<AtpCommand>,
     // Map Transaction ID to pending request channel and XO status
     pending_transactions: AtpTransactionMap,
-    // Map (Source, TID) to release signal channel
-    pending_releases: HashMap<(AtpAddress, u16), oneshot::Sender<()>>,
     next_tid: u16,
 }
 
@@ -315,7 +335,6 @@ impl Atp {
             incoming_req_tx,
             cmd_tx: request_send.clone(),
             pending_transactions: HashMap::new(),
-            pending_releases: HashMap::new(),
             next_tid: 1, // Start TID at 1
         };
 
@@ -338,7 +357,7 @@ impl Atp {
     }
 
     async fn run(mut self) {
-        let mut retry_interval = tokio::time::interval(tokio::time::Duration::from_secs(2));
+        let mut retry_interval = tokio::time::interval(ATP_RETRY_TICK);
         retry_interval.tick().await; // skip the immediate first tick
 
         loop {
@@ -386,11 +405,18 @@ impl Atp {
         // ATP spec: give up after 8 retransmits (9 total attempts).
         const MAX_RETRIES: u8 = 8;
 
+        let now = tokio::time::Instant::now();
         let mut to_evict: Vec<u16> = Vec::new();
         let mut to_resend: Vec<(u16, Vec<u8>, AtpAddress)> = Vec::new();
 
+        // Only touch transactions whose own deadline has elapsed, so a request
+        // registered just before a tick still gets its full retry interval.
         for (tid, state) in &mut self.pending_transactions {
+            if now < state.retry_at {
+                continue;
+            }
             state.retry_count += 1;
+            state.retry_at = now + ATP_RETRY_INTERVAL;
             if state.retry_count > MAX_RETRIES {
                 to_evict.push(*tid);
             } else {
@@ -409,14 +435,7 @@ impl Atp {
         }
 
         for (tid, packet, dest_addr) in to_resend {
-            let dest = crate::ddp::DdpAddress::new(
-                tailtalk_packets::aarp::AppleTalkAddress {
-                    network_number: dest_addr.network_number,
-                    node_number: dest_addr.node_number,
-                },
-                dest_addr.socket_number,
-            );
-            if let Err(e) = self.sock.send_to(&packet, dest).await {
+            if let Err(e) = self.sock.send_to(&packet, dest_addr.into()).await {
                 tracing::warn!("ATP retransmit failed for TID {}: {}", tid, e);
             } else {
                 tracing::debug!("ATP retransmitting TID {}", tid);
@@ -424,25 +443,33 @@ impl Atp {
         }
     }
 
-    async fn handle_send_request(&mut self, req: AtpSendRequest) {
-        // Skip any TID that is still in pending_transactions to prevent aliasing a live
-        // transaction on wrapping. A freed TID is naturally eligible for reuse.
-        let tid = {
-            let start = self.next_tid;
-            loop {
-                let candidate = self.next_tid;
-                self.next_tid = self.next_tid.wrapping_add(1);
-                if !self.pending_transactions.contains_key(&candidate) {
-                    break candidate;
-                }
-                if self.next_tid == start {
-                    let _ = req.chan.send(Err(io::Error::new(
-                        io::ErrorKind::WouldBlock,
-                        "ATP: all transaction IDs in use",
-                    )));
-                    return;
-                }
+    /// Allocate a transaction ID that is not currently in flight.
+    ///
+    /// Skips any TID still in `pending_transactions` to prevent aliasing a live
+    /// transaction on wrapping, since a late response for a reused TID would otherwise be
+    /// misrouted into the wrong transaction's reassembly buffer. A freed TID is
+    /// naturally eligible for reuse. Returns `None` if all 65536 IDs are in flight.
+    fn allocate_tid(&mut self) -> Option<u16> {
+        let start = self.next_tid;
+        loop {
+            let candidate = self.next_tid;
+            self.next_tid = self.next_tid.wrapping_add(1);
+            if !self.pending_transactions.contains_key(&candidate) {
+                return Some(candidate);
             }
+            if self.next_tid == start {
+                return None;
+            }
+        }
+    }
+
+    async fn handle_send_request(&mut self, req: AtpSendRequest) {
+        let Some(tid) = self.allocate_tid() else {
+            let _ = req.chan.send(Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "ATP: all transaction IDs in use",
+            )));
+            return;
         };
 
         let packet = AtpPacket {
@@ -455,13 +482,8 @@ impl Atp {
             user_bytes: req.user_bytes,
         };
 
-        let mut buf = [0u8; 600]; // DDP max is 586
-
-        let header_len = packet
-            .to_bytes(&mut buf)
-            .expect("failed to serialize ATP header");
-
-        let total_len = header_len + req.data.len();
+        // Check the length before serializing: the copy below would otherwise panic
+        // on an out-of-range slice for oversized data.
         if req.data.len() > ATP_MAX_DATA_PER_PACKET {
             tracing::error!(
                 "ATP request data too large: {} (max {})",
@@ -475,20 +497,18 @@ impl Atp {
             return;
         }
 
-        buf[header_len..total_len].copy_from_slice(&req.data);
+        let mut buf = [0u8; 600]; // DDP max is 586
 
-        // Construct DdpAddress
-        let dest = crate::ddp::DdpAddress::new(
-            tailtalk_packets::aarp::AppleTalkAddress {
-                network_number: req.address.network_number,
-                node_number: req.address.node_number,
-            },
-            req.address.socket_number,
-        );
+        let header_len = packet
+            .to_bytes(&mut buf)
+            .expect("failed to serialize ATP header");
+
+        let total_len = header_len + req.data.len();
+        buf[header_len..total_len].copy_from_slice(&req.data);
 
         let raw_packet = buf[..total_len].to_vec();
 
-        if let Err(e) = self.sock.send_to(&buf[..total_len], dest).await {
+        if let Err(e) = self.sock.send_to(&buf[..total_len], req.address.into()).await {
             let _ = req.chan.send(Err(io::Error::other(e)));
         } else {
             self.pending_transactions.insert(
@@ -503,6 +523,7 @@ impl Atp {
                     destination: req.address,
                     requested_bitmap: req.bitmap,
                     retry_count: 0,
+                    retry_at: tokio::time::Instant::now() + ATP_RETRY_INTERVAL,
                 },
             );
         }
@@ -533,24 +554,20 @@ impl Atp {
 
             buf[header_len..total_len].copy_from_slice(&node.data);
 
-            let dest = crate::ddp::DdpAddress::new(
-                tailtalk_packets::aarp::AppleTalkAddress {
-                    network_number: resp.destination.network_number,
-                    node_number: resp.destination.node_number,
-                },
-                resp.destination.socket_number,
-            );
-
-            if let Err(e) = self.sock.send_to(&buf[..total_len], dest).await {
+            if let Err(e) = self.sock.send_to(&buf[..total_len], resp.destination.into()).await {
                 tracing::error!("Failed to send ATP response packet {}: {}", i, e);
             }
         }
-
     }
 
     async fn handle_send_alo(&mut self, alo: AtpSendAlo) {
-        let tid = self.next_tid;
-        self.next_tid = self.next_tid.wrapping_add(1);
+        // Allocate through the same collision-checked path as real requests: a TID
+        // that aliased a live transaction would let a stray response for this ALO be
+        // reassembled into that transaction's buffer.
+        let Some(tid) = self.allocate_tid() else {
+            tracing::warn!("ATP: no free TID for ALO packet, dropping");
+            return;
+        };
 
         let packet = AtpPacket {
             function: AtpFunction::Request,
@@ -567,15 +584,7 @@ impl Atp {
             .to_bytes(&mut buf)
             .expect("failed to serialize ATP ALO header");
 
-        let dest = crate::ddp::DdpAddress::new(
-            tailtalk_packets::aarp::AppleTalkAddress {
-                network_number: alo.address.network_number,
-                node_number: alo.address.node_number,
-            },
-            alo.address.socket_number,
-        );
-
-        if let Err(e) = self.sock.send_to(&buf[..header_len], dest).await {
+        if let Err(e) = self.sock.send_to(&buf[..header_len], alo.address.into()).await {
             tracing::warn!("Failed to send ATP ALO packet: {}", e);
         }
         // No pending transaction registered — any response is silently discarded.
@@ -603,15 +612,7 @@ impl Atp {
             .to_bytes(&mut buf)
             .expect("failed to serialize ATP release header");
 
-        let dest = crate::ddp::DdpAddress::new(
-            tailtalk_packets::aarp::AppleTalkAddress {
-                network_number: rel.destination.network_number,
-                node_number: rel.destination.node_number,
-            },
-            rel.destination.socket_number,
-        );
-
-        if let Err(e) = self.sock.send_to(&buf[..header_len], dest).await {
+        if let Err(e) = self.sock.send_to(&buf[..header_len], rel.destination.into()).await {
             tracing::error!("Failed to send ATP Release: {}", e);
         }
     }
@@ -624,20 +625,40 @@ impl Atp {
             return;
         };
 
-        let mut full_data = Vec::new();
         let expected_count = state
             .eom_seq
             .map(|e| e as usize + 1)
             .unwrap_or(state.received_packets.len());
+
+        // Reassemble in sequence order. The caller is only signalled complete once every
+        // slot below EOM has arrived, so a gap here means the completion check let a
+        // partial transaction through. Report it rather than silently handing back a
+        // short buffer, which upper layers would read as a truncated (but successful) reply.
+        let mut full_data = Vec::new();
+        let mut missing = None;
         for i in 0..expected_count as u8 {
-            if let Some(p) = state.received_packets.remove(&i) {
-                full_data.extend_from_slice(&p);
+            match state.received_packets.remove(&i) {
+                Some(p) => full_data.extend_from_slice(&p),
+                None => {
+                    missing = Some(i);
+                    break;
+                }
             }
         }
-        let user_bytes = state.user_bytes.unwrap_or([0; 4]);
-        let xo = state.xo;
 
-        let _ = state.chan.send(Ok((full_data, user_bytes)));
+        let result = match missing {
+            Some(i) => {
+                debug_assert!(false, "ATP: completed TID {tid} missing response packet {i}");
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("ATP: incomplete response, missing packet {i} of {expected_count}"),
+                ))
+            }
+            None => Ok((full_data, state.user_bytes.unwrap_or([0; 4]))),
+        };
+
+        let xo = state.xo;
+        let _ = state.chan.send(result);
 
         if xo {
             let rel = AtpSendRelease { destination: source, tid };
@@ -663,27 +684,12 @@ impl Atp {
                     Vec::new()
                 };
 
-                let from = AtpAddress {
-                    network_number: ddp.src_network_num,
-                    node_number: ddp.src_node_id,
-                    socket_number: ddp.src_sock_num,
-                };
-
-                let release_rx = if packet.xo {
-                    let (tx, rx) = oneshot::channel();
-                    self.pending_releases.insert((from, packet.tid), tx);
-                    Some(rx)
-                } else {
-                    None
-                };
-
                 let req = AtpReceivedRequest {
                     transaction_id: packet.tid,
-                    source: from,
+                    source: AtpAddress::from_ddp_source(&ddp),
                     user_bytes: packet.user_bytes,
                     data: request_data,
                     response_sender: self.cmd_tx.clone(),
-                    release_rx,
                     bitmap: packet.bitmap_seq_num,
                 };
 
@@ -731,29 +737,19 @@ impl Atp {
                 // `entry` (and its borrow of pending_transactions) is dropped here,
                 // so complete_transaction is free to remove it.
                 if is_complete {
-                    let source = AtpAddress {
-                        network_number: ddp.src_network_num,
-                        node_number: ddp.src_node_id,
-                        socket_number: ddp.src_sock_num,
-                    };
-                    self.complete_transaction(packet.tid, source).await;
+                    self.complete_transaction(packet.tid, AtpAddress::from_ddp_source(&ddp))
+                        .await;
                 }
             }
             AtpFunction::Release => {
-                let from = AtpAddress {
-                    network_number: ddp.src_network_num,
-                    node_number: ddp.src_node_id,
-                    socket_number: ddp.src_sock_num,
-                };
+                // We send TRel to close out our own XO requests, but nothing in this
+                // stack waits on an inbound one: responders here build each reply on
+                // demand rather than keeping a retry cache to be released. Log and drop.
                 tracing::debug!(
                     "Received ATP Release packet from {:?} tid={}",
-                    from,
+                    AtpAddress::from_ddp_source(&ddp),
                     packet.tid
                 );
-
-                if let Some(chan) = self.pending_releases.remove(&(from, packet.tid)) {
-                    let _ = chan.send(());
-                }
             }
         }
     }

--- a/tailtalk/src/pap.rs
+++ b/tailtalk/src/pap.rs
@@ -13,6 +13,45 @@ use tokio::time::{Duration, interval};
 /// us to respond with 8 (i.e quantum size) ATP fragments per SendData request.
 pub const PAP_MAX_DATA_PER_PACKET: usize = 512;
 
+/// Default cap on how much printer stdout [`PapClient::read_response`] will accumulate
+/// before giving up. A printer stuck in a PostScript error loop can emit output forever;
+/// without a bound the read never returns and the buffer grows unchecked.
+pub const PAP_DEFAULT_MAX_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
+
+/// How many recent replies to keep for answering printer retransmits. The PAP flow
+/// quantum caps outstanding SendData requests at 8, so 8 covers every request that can
+/// still be in flight.
+const PAP_REPLY_CACHE_LEN: usize = 8;
+
+/// Advance a PAP sequence number.
+///
+/// Spec: sequence numbers run 1–65535 then wrap back to 1; 0 is reserved to mean
+/// "unsequenced" and must never be produced by normal advancement.
+fn next_pap_seq(seq: u16) -> u16 {
+    if seq == u16::MAX { 1 } else { seq + 1 }
+}
+
+/// A reply we sent, kept so an identical retransmit gets the identical answer.
+type CachedReply = (u16, [u8; 4], Vec<u8>);
+
+/// Look up a cached reply by sequence number.
+fn cached_reply(cache: &std::collections::VecDeque<CachedReply>, seq: u16) -> Option<&CachedReply> {
+    cache.iter().find(|(s, _, _)| *s == seq)
+}
+
+/// Record a reply, evicting the oldest once the cache is full.
+fn remember_reply(
+    cache: &mut std::collections::VecDeque<CachedReply>,
+    seq: u16,
+    user_bytes: [u8; 4],
+    data: Vec<u8>,
+) {
+    if cache.len() == PAP_REPLY_CACHE_LEN {
+        cache.pop_front();
+    }
+    cache.push_back((seq, user_bytes, data));
+}
+
 #[derive(Debug)]
 pub struct PapClient {
     atp_requestor: AtpRequestor,
@@ -22,12 +61,19 @@ pub struct PapClient {
     remote_addr: AtpAddress,
     /// The printer's connection socket from OpenConnReply — used for all post-connect traffic.
     server_addr: AtpAddress,
-    /// Next SendData (read) sequence number. Continues across jobs for the
-    /// connection's lifetime — restarting it makes papd-style servers see stale retransmits.
+    /// Next SendData (read) sequence number. Reset by [`connect`](Self::connect), then
+    /// continues across every job for that connection's lifetime. Restarting it
+    /// mid-connection makes papd-style servers see stale retransmits.
     read_seq: u16,
     /// Override the read buffer size per SendData cycle. When `None`, capacity is
     /// `bitmap_count × PAP_MAX_DATA_PER_PACKET` derived from the printer's per-request bitmap.
     pub chunk_size: Option<usize>,
+    /// Cap on bytes accumulated by [`read_response`](Self::read_response).
+    /// Defaults to [`PAP_DEFAULT_MAX_RESPONSE_BYTES`].
+    pub max_response_bytes: usize,
+    /// Overall deadline for a single [`read_response`](Self::read_response) call.
+    /// Defaults to 60 s; `None` waits indefinitely for the printer's EOF.
+    pub response_timeout: Option<Duration>,
 }
 
 impl PapClient {
@@ -37,18 +83,12 @@ impl PapClient {
             atp_responder,
             connection_id: 0,
             flow_quantum: 8,
-            remote_addr: AtpAddress {
-                network_number: 0,
-                node_number: 0,
-                socket_number: 0,
-            },
-            server_addr: AtpAddress {
-                network_number: 0,
-                node_number: 0,
-                socket_number: 0,
-            },
+            remote_addr: AtpAddress::default(),
+            server_addr: AtpAddress::default(),
             read_seq: 1,
             chunk_size: None,
+            max_response_bytes: PAP_DEFAULT_MAX_RESPONSE_BYTES,
+            response_timeout: Some(Duration::from_secs(60)),
         }
     }
 
@@ -71,11 +111,22 @@ impl PapClient {
         let deadline = tokio::time::Instant::now() + timeout;
 
         loop {
+            // Check before sending too: the ATP retry budget alone runs ~16 s, which
+            // would otherwise blow past a shorter caller-supplied timeout.
+            if tokio::time::Instant::now() >= deadline {
+                return Err(anyhow!("PAP OpenConn timed out after {:?}", timeout));
+            }
+
             tracing::info!("PAP: Sending OpenConn to {:?}", address);
-            let (resp_data, resp_user_bytes) = self
-                .atp_requestor
-                .send_request_with_bitmap(address, user_bytes, data.to_vec(), 0x01)
-                .await?;
+            let request = self.atp_requestor.send_request_with_bitmap(
+                address,
+                user_bytes,
+                data.to_vec(),
+                0x01,
+            );
+            let (resp_data, resp_user_bytes) = tokio::time::timeout_at(deadline, request)
+                .await
+                .map_err(|_| anyhow!("PAP OpenConn timed out after {:?}", timeout))??;
 
             let reply = PapPacket::parse_from_atp(resp_user_bytes, &resp_data)?;
 
@@ -94,11 +145,13 @@ impl PapClient {
             let result = ((reply.data[2] as u16) << 8) | (reply.data[3] as u16);
 
             if result != 0 {
-                if tokio::time::Instant::now() >= deadline {
+                // Per PAP spec, retry every 2 seconds, but never sleep past the deadline.
+                let retry_at = tokio::time::Instant::now() + Duration::from_secs(2);
+                if retry_at >= deadline {
                     return Err(anyhow!("PAP OpenConn failed with result code: {} (server busy)", result));
                 }
                 tracing::info!("PAP: Server busy (result={}), retrying in 2s", result);
-                tokio::time::sleep(Duration::from_secs(2)).await;
+                tokio::time::sleep_until(retry_at).await;
                 continue;
             }
 
@@ -126,11 +179,19 @@ impl PapClient {
         let mut last_activity = tokio::time::Instant::now();
         let mut tickle_interval = interval(Duration::from_secs(30));
         tickle_interval.tick().await; // skip the immediate first tick
-        let mut eof_sent = false;
-        // Skip the 30-s Tickle wait after EOF; return on the next printer SendData or a short deadline.
-        let mut eof_deadline: Option<tokio::time::Instant> = None;
-        // Retransmit of the same seq must get the identical reply, not fresh source bytes.
-        let mut last_reply: Option<(u16, [u8; 4], Vec<u8>)> = None;
+
+        // Once EOF is sent the job is delivered; all that remains is draining SendData
+        // requests the printer already had in flight, each of which holds an XO slot open
+        // until answered. `drain_deadline` bounds that wait so we never sit through the
+        // 30-s Tickle cycle for a printer that has nothing more to send.
+        let mut drain_deadline: Option<tokio::time::Instant> = None;
+
+        // A retransmit must get the byte-identical reply, never fresh source bytes:
+        // answering a duplicate with new data silently drops a chunk of the job. The
+        // printer may have up to `flow_quantum` (max 8) requests outstanding, so keep
+        // more than just the most recent reply.
+        let mut reply_cache: std::collections::VecDeque<CachedReply> =
+            std::collections::VecDeque::with_capacity(PAP_REPLY_CACHE_LEN);
 
         loop {
             tokio::select! {
@@ -152,32 +213,37 @@ impl PapClient {
                         PapFunction::SendData => {
                             let seq_num = pap_req.sequence_num;
 
+                            // A sequence number we have already answered is a retransmit
+                            // (our reply was lost). Replay the identical bytes, since reading
+                            // fresh ones from `source` would silently drop a chunk of the
+                            // job. Cache membership is the test rather than an ordering
+                            // comparison, so this stays correct across the 65535→1 wrap.
                             if seq_num != 0
-                                && let Some((seq, ub, chunk)) = &last_reply
-                                && *seq == seq_num
+                                && let Some((_, ub, chunk)) = cached_reply(&reply_cache, seq_num)
                             {
                                 let _ = req
-                                    .send_response_chunked(chunk.clone(), *ub, PAP_MAX_DATA_PER_PACKET)
+                                    .send_response_chunked(chunk, *ub, PAP_MAX_DATA_PER_PACKET)
                                     .await;
                                 continue;
                             }
 
-                            let max_packets = if req.bitmap == 0x00 { 8 } else { req.bitmap.count_ones() as usize }.clamp(1, 8);
-                            let capacity = self.chunk_size.unwrap_or(max_packets * PAP_MAX_DATA_PER_PACKET);
+                            let capacity = self
+                                .chunk_size
+                                .unwrap_or(req.max_packets() * PAP_MAX_DATA_PER_PACKET);
 
-                            let (n, buf) = if eof_sent {
-                                // Each ATP SendData is an XO transaction; the printer's slot stays
-                                // locked until it gets a response, so drain in-flight ones with EOF.
-                                (0, vec![])
+                            let buf = if drain_deadline.is_some() {
+                                // Post-EOF: answer in-flight requests with another EOF so the
+                                // printer can release its XO slots. Never touch `source` again.
+                                Vec::new()
                             } else {
                                 tracing::info!("PAP received SendData seq={}", seq_num);
                                 let mut buf = vec![0u8; capacity];
                                 let n = source.read(&mut buf).await?;
                                 buf.truncate(n);
-                                (n, buf)
+                                buf
                             };
 
-                            let eof = n == 0;
+                            let eof = buf.is_empty();
                             let pap_resp = PapPacket {
                                 connection_id: self.connection_id,
                                 function: PapFunction::Data,
@@ -186,25 +252,28 @@ impl PapClient {
                                 data: buf,
                             };
                             let (user_bytes, chunk_data) = pap_resp.to_atp_parts();
-                            req.send_response_chunked(chunk_data.to_vec(), user_bytes, PAP_MAX_DATA_PER_PACKET).await?;
+                            req.send_response_chunked(chunk_data, user_bytes, PAP_MAX_DATA_PER_PACKET).await?;
                             if seq_num != 0 {
-                                last_reply = Some((seq_num, user_bytes, chunk_data.to_vec()));
+                                remember_reply(&mut reply_cache, seq_num, user_bytes, chunk_data.to_vec());
                             }
 
-                            if eof && !eof_sent {
-                                tracing::info!("PAP: EOF sent");
-                                eof_sent = true;
-                                eof_deadline = Some(tokio::time::Instant::now() + Duration::from_millis(500));
-                            } else if eof_sent {
-                                // Drained the in-flight SendData after our EOF; safe to return.
-                                return Ok(());
+                            match (eof, drain_deadline) {
+                                // First EOF: the job is delivered. Give the printer a brief
+                                // window to drain anything already in flight, then finish.
+                                (true, None) => {
+                                    tracing::info!("PAP: EOF sent");
+                                    drain_deadline =
+                                        Some(tokio::time::Instant::now() + Duration::from_millis(500));
+                                }
+                                // Answered an in-flight request after EOF; nothing left to drain.
+                                (_, Some(_)) => return Ok(()),
+                                (false, None) => {}
                             }
                         }
                         PapFunction::Tickle => {
                             tracing::debug!("PAP: Received Tickle from printer");
-                            if eof_sent {
-                                return Ok(());
-                            }
+                            // A Tickle is not a SendData, so it says nothing about whether the
+                            // printer still has requests in flight. Let `drain_deadline` decide.
                         }
                         PapFunction::CloseConn => {
                             let reply = PapPacket {
@@ -215,8 +284,8 @@ impl PapClient {
                                 data: vec![],
                             };
                             let (ub, d) = reply.to_atp_parts();
-                            let _ = req.send_response(d.to_vec(), ub).await;
-                            if eof_sent {
+                            let _ = req.send_response(d, ub).await;
+                            if drain_deadline.is_some() {
                                 return Ok(());
                             }
                             return Err(anyhow!("Printer closed the connection before the job completed"));
@@ -241,13 +310,15 @@ impl PapClient {
                     let _ = self.atp_requestor.send_alo(self.server_addr, ub).await;
                 }
 
+                // Fires only after EOF; `pending()` parks this arm for the rest of the job.
                 _ = async {
-                    match eof_deadline {
+                    match drain_deadline {
                         Some(d) => tokio::time::sleep_until(d).await,
                         None => std::future::pending().await,
                     }
                 } => {
-                    // Short deadline after EOF elapsed with no further printer activity.
+                    // Nothing further arrived after EOF, so the printer had no requests
+                    // left in flight and the job is done.
                     return Ok(());
                 }
             }
@@ -255,7 +326,20 @@ impl PapClient {
     }
 
     /// Pull the printer's PS stdout by issuing SendData requests until the printer sends EOF.
+    ///
+    /// Bounded by [`max_response_bytes`](Self::max_response_bytes) and
+    /// [`response_timeout`](Self::response_timeout). A printer stuck emitting output,
+    /// a PostScript error loop for instance, would otherwise never yield EOF.
     pub async fn read_response(&mut self) -> Result<Vec<u8>> {
+        match self.response_timeout {
+            Some(t) => tokio::time::timeout(t, self.read_response_inner())
+                .await
+                .map_err(|_| anyhow!("PAP: printer sent no EOF within {:?}", t))?,
+            None => self.read_response_inner().await,
+        }
+    }
+
+    async fn read_response_inner(&mut self) -> Result<Vec<u8>> {
         let mut response = Vec::new();
 
         loop {
@@ -276,12 +360,18 @@ impl PapClient {
                 return Err(anyhow!("Expected PAP Data response, got {:?}", data_pkt.function));
             }
 
-            // Spec: sequence numbers run 1–65535 then wrap back to 1; 0 is reserved (unsequenced).
-            self.read_seq = if self.read_seq == 65535 { 1 } else { self.read_seq + 1 };
+            self.read_seq = next_pap_seq(self.read_seq);
 
             response.extend_from_slice(&data_pkt.data);
             if data_pkt.eof {
                 break;
+            }
+
+            if response.len() > self.max_response_bytes {
+                return Err(anyhow!(
+                    "PAP: printer output exceeded {} bytes without EOF",
+                    self.max_response_bytes
+                ));
             }
         }
 
@@ -298,9 +388,18 @@ impl PapClient {
         };
         let (ub, d) = close_pkt.to_atp_parts();
         // Must go to server_addr (per-connection socket), not remote_addr (NBP listening socket).
-        self.atp_requestor
+        let (resp_data, resp_ub) = self
+            .atp_requestor
             .send_request_with_bitmap(self.server_addr, ub, d.to_vec(), 0x01)
             .await?;
+
+        let reply = PapPacket::parse_from_atp(resp_ub, &resp_data)?;
+        if reply.function != PapFunction::CloseConnReply {
+            return Err(anyhow!(
+                "Expected PAP CloseConnReply, got {:?}",
+                reply.function
+            ));
+        }
         Ok(())
     }
 
@@ -318,15 +417,21 @@ impl PapClient {
             .await?;
 
         let reply = PapPacket::parse_from_atp(resp_ub, &resp_data)?;
+        if reply.function != PapFunction::Status {
+            return Err(anyhow!("Expected PAP Status reply, got {:?}", reply.function));
+        }
 
         // Status reply: 4 unused bytes, then a pascal string (length byte then content).
-        if reply.data.len() > 5 {
-            let len = reply.data[4] as usize;
-            let end = (5 + len).min(reply.data.len());
-            Ok(String::from_utf8_lossy(&reply.data[5..end]).to_string())
-        } else {
-            Ok("".to_string())
-        }
+        // A well-formed reply with an empty string is exactly 5 bytes, so anything
+        // shorter is malformed rather than merely empty.
+        let Some(&len) = reply.data.get(4) else {
+            return Err(anyhow!(
+                "PAP Status reply too short ({} bytes, need at least 5)",
+                reply.data.len()
+            ));
+        };
+        let end = (5 + len as usize).min(reply.data.len());
+        Ok(String::from_utf8_lossy(&reply.data[5..end]).to_string())
     }
 }
 
@@ -547,7 +652,7 @@ impl PapServer {
                         data: status_payload,
                     };
                     let (ub, d) = reply.to_atp_parts();
-                    let _ = req.send_response(d.to_vec(), ub).await;
+                    let _ = req.send_response(d, ub).await;
                 }
                 PapFunction::OpenConn => {
                     if pap.data.len() < 2 {
@@ -594,7 +699,7 @@ impl PapServer {
             data: reply_data,
         };
         let (ub, d) = reply.to_atp_parts();
-        if let Err(e) = open_req.send_response(d.to_vec(), ub).await {
+        if let Err(e) = open_req.send_response(d, ub).await {
             tracing::warn!("PAP: failed to send OpenConnReply: {e}");
             return Ok(());
         }
@@ -619,7 +724,6 @@ impl PapServer {
             }
         };
 
-        // Spec: sequence numbers run 1–65535 then wrap to 1; 0 is reserved (unsequenced).
         let mut seq: u16 = 1;
         let mut pull = Box::pin(make_pull(seq));
 
@@ -632,8 +736,9 @@ impl PapServer {
         let mut pending_read: Option<(crate::atp::AtpReceivedRequest, u16)> = None;
         // Next expected client read sequence number, for spotting retransmits.
         let mut read_seq: u16 = 1;
-        // Re-sent verbatim if the client retransmits this read (reply lost on the wire).
-        let mut last_read_reply: Option<(u16, [u8; 4], Vec<u8>)> = None;
+        // Re-sent verbatim if the client retransmits a read (reply lost on the wire).
+        let mut read_reply_cache: std::collections::VecDeque<CachedReply> =
+            std::collections::VecDeque::with_capacity(PAP_REPLY_CACHE_LEN);
 
         let mut last_activity = tokio::time::Instant::now();
         let mut tickle_interval = interval(Duration::from_secs(30));
@@ -698,7 +803,7 @@ impl PapServer {
                                 response_ready = true;
                             }
 
-                            seq = if seq == 65535 { 1 } else { seq + 1 };
+                            seq = next_pap_seq(seq);
                             pull = Box::pin(make_pull(seq));
                         }
                         Err(_) => {
@@ -733,13 +838,13 @@ impl PapServer {
                             // A retransmit of an already-answered read means our reply
                             // was lost; anything else out of sequence is stale (papd's rseq check).
                             if pap.sequence_num != 0 && pap.sequence_num != read_seq {
-                                match &last_read_reply {
-                                    Some((seq, ub, chunk)) if *seq == pap.sequence_num => {
+                                match cached_reply(&read_reply_cache, pap.sequence_num) {
+                                    Some((_, ub, chunk)) => {
                                         let _ = req
-                                            .send_response_chunked(chunk.clone(), *ub, PAP_MAX_DATA_PER_PACKET)
+                                            .send_response_chunked(chunk, *ub, PAP_MAX_DATA_PER_PACKET)
                                             .await;
                                     }
-                                    _ => {
+                                    None => {
                                         tracing::debug!("PAP: ignoring stale client read seq={}", pap.sequence_num);
                                     }
                                 }
@@ -760,7 +865,7 @@ impl PapServer {
                                 data: vec![],
                             };
                             let (ub, d) = reply.to_atp_parts();
-                            let _ = req.send_response(d.to_vec(), ub).await;
+                            let _ = req.send_response(d, ub).await;
                             if !job_data.is_empty() {
                                 tracing::warn!(
                                     "PAP: client closed mid-job, discarding {} partial bytes",
@@ -795,7 +900,7 @@ impl PapServer {
                                 data: status_payload,
                             };
                             let (ub, d) = reply.to_atp_parts();
-                            let _ = req.send_response(d.to_vec(), ub).await;
+                            let _ = req.send_response(d, ub).await;
                         }
                         PapFunction::OpenConn => {
                             // Single-session server: refuse with a busy result; the driver retries every 2s.
@@ -810,7 +915,7 @@ impl PapServer {
                                 data: reply_data,
                             };
                             let (ub, d) = reply.to_atp_parts();
-                            let _ = req.send_response(d.to_vec(), ub).await;
+                            let _ = req.send_response(d, ub).await;
                         }
                         _ => {}
                     }
@@ -835,12 +940,9 @@ impl PapServer {
 
             // Answer a waiting client read once this job's output is ready; eof on the
             // final chunk tells the driver we're done, then we reset for the next job.
-            if response_ready && pending_read.is_some() {
-                let (req, this_seq) = pending_read.take().unwrap();
-                let max_packets =
-                    if req.bitmap == 0x00 { 8 } else { req.bitmap.count_ones() as usize }.clamp(1, 8);
+            if response_ready && let Some((req, this_seq)) = pending_read.take() {
                 let remaining = stdout.len().saturating_sub(stdout_pos);
-                let take = remaining.min(max_packets * PAP_MAX_DATA_PER_PACKET);
+                let take = remaining.min(req.max_packets() * PAP_MAX_DATA_PER_PACKET);
                 let chunk = stdout[stdout_pos..stdout_pos + take].to_vec();
                 let eof = stdout_pos + take >= stdout.len();
                 stdout_pos += take;
@@ -853,11 +955,11 @@ impl PapServer {
                 };
                 let (ub, d) = reply.to_atp_parts();
                 let _ = req
-                    .send_response_chunked(d.to_vec(), ub, PAP_MAX_DATA_PER_PACKET)
+                    .send_response_chunked(d, ub, PAP_MAX_DATA_PER_PACKET)
                     .await;
                 if this_seq != 0 {
-                    read_seq = if read_seq == 65535 { 1 } else { read_seq + 1 };
-                    last_read_reply = Some((this_seq, ub, d.to_vec()));
+                    read_seq = next_pap_seq(read_seq);
+                    remember_reply(&mut read_reply_cache, this_seq, ub, d.to_vec());
                 }
                 if eof {
                     // This job's output is fully served; ready for the next job.
@@ -1020,4 +1122,81 @@ fn pqp_font_answer(font_list: &str) -> String {
         .collect();
     lines.push("*".to_string());
     lines.join("\r")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+
+    #[test]
+    fn seq_wraps_past_zero() {
+        assert_eq!(next_pap_seq(1), 2);
+        assert_eq!(next_pap_seq(65534), 65535);
+        // 0 is reserved for "unsequenced" and must be skipped on wrap.
+        assert_eq!(next_pap_seq(65535), 1);
+    }
+
+    #[test]
+    fn reply_cache_answers_retransmits_out_of_order() {
+        let mut cache: VecDeque<CachedReply> = VecDeque::new();
+        for seq in 1..=4u16 {
+            remember_reply(&mut cache, seq, [0, 4, 0, 0], vec![seq as u8]);
+        }
+
+        // A retransmit of any still-cached seq must replay its own bytes, not the
+        // most recent reply; answering with fresh data would drop part of the job.
+        for seq in 1..=4u16 {
+            let (_, _, data) = cached_reply(&cache, seq).expect("reply should be cached");
+            assert_eq!(data, &vec![seq as u8]);
+        }
+        assert!(cached_reply(&cache, 9).is_none());
+    }
+
+    #[test]
+    fn reply_cache_evicts_oldest_when_full() {
+        let mut cache: VecDeque<CachedReply> = VecDeque::new();
+        for seq in 1..=(PAP_REPLY_CACHE_LEN as u16 + 2) {
+            remember_reply(&mut cache, seq, [0, 4, 0, 0], vec![seq as u8]);
+        }
+
+        assert_eq!(cache.len(), PAP_REPLY_CACHE_LEN);
+        // The two oldest aged out; everything within the flow quantum is retained.
+        assert!(cached_reply(&cache, 1).is_none());
+        assert!(cached_reply(&cache, 2).is_none());
+        assert!(cached_reply(&cache, 3).is_some());
+        assert!(cached_reply(&cache, PAP_REPLY_CACHE_LEN as u16 + 2).is_some());
+    }
+
+    #[test]
+    fn reply_cache_survives_sequence_wrap() {
+        // Around the 65535→1 wrap the cache holds both high and low numbers at once.
+        // Lookup is by membership, not ordering, so a fresh seq=1 after the wrap is
+        // only treated as a retransmit if it is genuinely still cached.
+        let mut cache: VecDeque<CachedReply> = VecDeque::new();
+        remember_reply(&mut cache, 65534, [0, 4, 0, 0], vec![0xAA]);
+        remember_reply(&mut cache, 65535, [0, 4, 0, 0], vec![0xBB]);
+
+        assert!(cached_reply(&cache, 1).is_none(), "post-wrap seq=1 is new, not a retransmit");
+        assert_eq!(cached_reply(&cache, 65535).unwrap().2, vec![0xBB]);
+    }
+
+    #[test]
+    fn pqp_answers_uam_query_with_no_authentication() {
+        let attrs = PrinterAttributes::default();
+        // Answering anything but "*" makes the LaserWriter driver believe a login is
+        // required and abort the query session.
+        assert_eq!(pqp_answer(&attrs, "RBIUAMListQuery", "fallback"), "*");
+        // Unrecognised queries fall back to the driver's own default.
+        assert_eq!(pqp_answer(&attrs, "SomeUnknownQuery", "fallback"), "fallback");
+    }
+
+    #[test]
+    fn pqp_stdout_answers_each_block_with_trailing_cr() {
+        let attrs = PrinterAttributes::default();
+        let job = b"%!PS-Adobe-3.0 Query\r\
+                    %%?BeginQuery: RBIUAMListQuery\r(*)= flush\r%%?EndQuery: *\r\
+                    %%?BeginFeatureQuery: *LanguageLevel\r%%?EndFeatureQuery: 1\r";
+        assert_eq!(pqp_stdout(&attrs, job), b"*\r2\r".to_vec());
+    }
 }


### PR DESCRIPTION
ATP:
- Remove pending_releases and release_rx. Inbound TRel senders were stored per XO request but only freed on a matching release, and nothing ever read release_rx, so unreleased transactions leaked for the life of the socket. We still send TRel, just don't track inbound.
- Route ALO through the collision-checked TID allocator. Tickles took next_tid unchecked and could alias a live transaction, misrouting a stray response into the wrong reply buffer.
- Per-transaction retransmit deadlines instead of a shared 2s tick.
- Error on a completed transaction missing a fragment instead of returning a short buffer that reads as a successful truncated reply.

PAP client:
- Keep the last 8 replies rather than one when answering retransmits. The printer can have that many SendData requests outstanding, and a retransmit missing the single-entry cache was answered with freshly read source bytes, silently dropping a chunk of the job. Lookup is by cache membership, so this survives the 65535 to 1 sequence wrap.
- Bound read_response by size and time; it looped until the printer sent EOF, and every caller already wrapped it in a timeout.
- Honour connect_with_timeout's deadline, previously only checked after a busy reply.
- Collapse the three post-EOF exit paths into one drain deadline.

Cleanup: fold send_response into send_response_chunked, hoist bitmap arithmetic into max_packets(), add From<AtpAddress> for DdpAddress, and add tests for sequence wrap and reply-cache replay.