### PR TITLE
GUI: Let width be automatically set

### DIFF
--- a/tailtalk-gui/ui/app.slint
+++ b/tailtalk-gui/ui/app.slint
@@ -5,13 +5,7 @@ import { Button, ComboBox, LineEdit, HorizontalBox, VerticalBox, CheckBox, Palet
 export { PrinterToolWindow, PrinterRow } from "printer_tool.slint";
 
 export component AppWindow inherits Window {
-    title: "TailTalk AFP Server";
-    min-width: 400px;
-    preferred-width: 540px;
-    // Height is deliberately left to the layout. Rows come and go at runtime
-    // (the EtherTalk picker, the three LaserWriter rows), so any fixed height is
-    // wrong for some combination of them: a hardcoded one used to clip the Start
-    // button off the bottom once enough options were enabled.
+    title: "TailTalk";
 
     in-out property <string> server-name: "TailTalk AFP";
     in property <[string]> ethernet-interfaces;


### PR DESCRIPTION
Same change as with the height, let Slint figure out the width needed. This prevents text clipping if the user has a font size that is larger or smaller than what I happen to be using locally.

Additionally changes the app name from TailTalk AFP Server to just TailTalk. We have grown well beyond just the original server, so lets just give it a simple name.