### PR TITLE
Add ImageWriter support over PAP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3373,6 +3373,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "iw-print-example"
+version = "0.9.1"
+dependencies = [
+ "anyhow",
+ "clap",
+ "tailtalk",
+ "tailtalk-packets",
+ "tokio",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "examples/aep-echo",
   "examples/pap-print",
   "examples/pap-capture",
+  "examples/iw-print",
   "examples/afp-server",
   "examples/adsp-stylewriter",
   "examples/sw-rename",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ drivers - All it needs is a raw socket and/or TashTalk compatible device (for Lo
 It provides a complete AppleTalk stack, with multiple copies of it able to run on the same machine
 at the same time.
 
-I started this project to be able to copy files to/from my old Macs, print to LaserWriters and networked StyleWriters, and be able
+I started this project to be able to copy files to/from my old Macs, print to LaserWriters, ImageWriters and networked StyleWriters, and be able
 to write modern async software to communicate with them. Currently TailTalk only works in a routerless setup - work is in progress
 to make it gracefully join router present networks but it is not yet in the mainline code.
 
@@ -28,7 +28,7 @@ This is the current user facing program for use with TashTalk USB. It includes a
 every Mac that shipped with a LocalTalk port. It also can import Stuff-It archives and floppy disk images and load them in to
 the share path preserving the resource forks and make them available to remote clients.
 
-It additionally supports sharing LocalTalk capable LaserWriters and StyleWriters to modern networks as AirPrint / IPP printers,
+It additionally supports sharing LocalTalk capable LaserWriters, ImageWriters and StyleWriters to modern networks as AirPrint / IPP printers,
 and sharing modern printers to classic Macs. The latest release can be found here:
 
 [https://github.com/FeralFirmware/TailTalk/releases/latest](https://github.com/FeralFirmware/TailTalk/releases/latest)
@@ -158,6 +158,7 @@ Beyond unit tests I have found the best way to test this software is with real h
 - PowerBook G3 running Mac OS 9.2 via Ethernet
 - LaserWriter 4/600 PS via AsanteTalk
 - Color StyleWriter 2200 via EtherTalk adapter
+- ImageWriter II with the LocalTalk Option Card
 - Macintosh SE/30 running System 7.1 via AsanteTalk
 - Macintosh Classic running System 6.0.8 via AsanteTalk
 

--- a/examples/iw-print/Cargo.toml
+++ b/examples/iw-print/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "iw-print-example"
+version.workspace = true
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "iw-print"
+path = "main.rs"
+
+[dependencies]
+anyhow = { workspace = true } #unified
+clap = { workspace = true } #unified
+tailtalk = { workspace = true, features = ["ethertalk"] } #unified
+tailtalk-packets = { workspace = true } #unified
+tokio = { workspace = true, features = ["io-util", "process"] } #unified
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/iw-print/main.rs
+++ b/examples/iw-print/main.rs
@@ -1,0 +1,240 @@
+use clap::Parser;
+use std::process::Stdio;
+use std::time::Duration;
+use tailtalk::{TalkStack, atp::AtpAddress, imagewriter::ImageWriter};
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+const HELLO_WORLD_JOB: &str = "%!PS-Adobe-2.0\n\
+    %%Title: TailTalk ImageWriter Test Page\n\
+    %%Creator: TailTalk iw-print\n\
+    %%EndComments\n\
+    /Courier findfont 24 scalefont setfont\n\
+    /msg (Hello from TailTalk!) def\n\
+    msg stringwidth pop 612 exch sub 2 div 396 moveto\n\
+    msg show\n\
+    showpage\n\
+    %%EOF\n";
+
+/// Colour variant: one line per ribbon band, so a glance at the page shows
+/// whether every band of the colour ribbon is actually being struck.
+const COLOR_TEST_JOB: &str = "%!PS-Adobe-2.0\n\
+    %%Title: TailTalk ImageWriter Colour Test Page\n\
+    %%Creator: TailTalk iw-print\n\
+    %%EndComments\n\
+    /Courier findfont 24 scalefont setfont\n\
+    /line { moveto show } bind def\n\
+    1 0 0 setrgbcolor (Red    - Hello from TailTalk!) 108 500 line\n\
+    0 1 0 setrgbcolor (Green  - Hello from TailTalk!) 108 460 line\n\
+    0 0 1 setrgbcolor (Blue   - Hello from TailTalk!) 108 420 line\n\
+    1 1 0 setrgbcolor (Yellow - Hello from TailTalk!) 108 380 line\n\
+    0 0 0 setrgbcolor (Black  - Hello from TailTalk!) 108 340 line\n\
+    showpage\n\
+    %%EOF\n";
+
+#[derive(Parser, Debug)]
+#[command(about = "Print a 'Hello world!' test page on an Apple ImageWriter II via PAP")]
+struct Args {
+    /// Network interface to bind to (EtherTalk)
+    #[arg(short, long)]
+    interface: Option<String>,
+
+    /// TashTalk serial port path (LocalTalk)
+    #[arg(short, long)]
+    tashtalk: Option<String>,
+
+    /// NBP object name of the printer to look up, e.g. "ImageWriter LQ".
+    /// The NBP type is always "ImageWriter"; "=" matches any.
+    #[arg(short, long, default_value = "=")]
+    printer: String,
+
+    /// Path to the Ghostscript executable
+    #[arg(long, default_value = "gs")]
+    ghostscript: String,
+
+    /// Write a LocalTalk pcap capture to this file
+    #[arg(long)]
+    pcap: Option<String>,
+
+    /// Query the printer's status and exit without printing anything
+    #[arg(long)]
+    status_only: bool,
+
+    /// Force the monochrome path even if a colour ribbon is installed
+    #[arg(long)]
+    mono: bool,
+
+    /// Poll the printer's status this often (in seconds) while the job streams.
+    /// 0 disables polling.
+    #[arg(long, default_value_t = 0)]
+    watch: u64,
+}
+
+async fn render_hello_world(gs_path: &str, color: bool) -> anyhow::Result<Vec<u8>> {
+    // `iwhic` is the colour twin of `iwhi`.
+    let device = if color {
+        "-sDEVICE=iwhic"
+    } else {
+        "-sDEVICE=iwhi"
+    };
+    let job = if color {
+        COLOR_TEST_JOB
+    } else {
+        HELLO_WORLD_JOB
+    };
+
+    let mut child = Command::new(gs_path)
+        .args([
+            "-q",
+            "-dNOPAUSE",
+            "-dBATCH",
+            "-dSAFER",
+            device,
+            // Force Letter rather than inheriting the build's default paper
+            // size: the device crashes on a page wider than 612pt or a height
+            // that isn't a multiple of 24pt, and A4's 842pt is not (many
+            // Ghostscript builds default to A4).
+            "-dDEVICEWIDTHPOINTS=612",
+            "-dDEVICEHEIGHTPOINTS=792",
+            "-dFIXEDMEDIA",
+            "-sOutputFile=-",
+            "-",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("failed to launch Ghostscript ('{}'): {}", gs_path, e))?;
+
+    let mut stdin = child.stdin.take().expect("stdin was piped");
+    stdin.write_all(job.as_bytes()).await?;
+    drop(stdin); // EOF tells Ghostscript the job is complete
+
+    let output = child.wait_with_output().await?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "Ghostscript exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    if output.stdout.is_empty() {
+        anyhow::bail!("Ghostscript produced no output");
+    }
+    Ok(output.stdout)
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt().init();
+
+    let args = Args::parse();
+
+    if args.interface.is_none() && args.tashtalk.is_none() {
+        anyhow::bail!("at least one of --interface or --tashtalk is required");
+    }
+
+    let mut builder = TalkStack::builder();
+    if let Some(ref intf) = args.interface {
+        builder = builder.ethernet(intf);
+    }
+    if let Some(ref tty) = args.tashtalk {
+        builder = builder.localtalk(tty);
+    }
+    if let Some(ref path) = args.pcap {
+        builder = builder.pcap_capture(path);
+    }
+    let stack = builder
+        .build()
+        .await
+        .expect("failed to build AppleTalk stack");
+
+    let tuples = ImageWriter::lookup(&stack.nbp, &args.printer).await?;
+    let printer = tuples
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("ImageWriter not found on network"))?;
+    println!(
+        "Found {} at {}.{} socket {}",
+        printer.entity_name, printer.network_number, printer.node_id, printer.socket_number
+    );
+    let printer_addr: AtpAddress = printer.service_address().into();
+
+    // Status needs no connection, so this works even if the printer is mid-job.
+    let status = ImageWriter::status_of(&stack.ddp, printer_addr).await?;
+    println!("Status word: 0x{:04X}", status.raw);
+    println!("  Ribbon:       {}", status.ribbon_text());
+    println!(
+        "  Sheet feeder: {}",
+        if status.sheet_feeder() {
+            "installed"
+        } else {
+            "not installed"
+        }
+    );
+    println!("  Busy:         {}", status.busy());
+    println!("  Printing:     {}", status.active());
+    match status.error_text() {
+        Some(e) => println!("  Errors:       {e}"),
+        None => println!("  Errors:       none"),
+    }
+
+    if args.status_only {
+        return Ok(());
+    }
+    if status.out_of_paper() {
+        anyhow::bail!("printer reports no paper loaded, refusing to print");
+    }
+
+    let color = status.color_ribbon() && !args.mono;
+    println!(
+        "Rendering the {} test page via Ghostscript",
+        if color { "colour" } else { "monochrome" }
+    );
+    let raster = render_hello_world(&args.ghostscript, color).await?;
+    println!("Rendered {} bytes", raster.len());
+
+    let mut client = ImageWriter::connect(&stack.ddp, printer_addr).await?;
+    if args.watch > 0 {
+        print_watching(&mut client, &raster, Duration::from_secs(args.watch)).await?;
+    } else {
+        client.print_bytes(&raster).await?;
+    }
+    client.close().await?;
+
+    Ok(())
+}
+
+/// Stream the job while polling the printer, to show what the option card
+/// reports as a page goes through. The status socket is separate from the one
+/// carrying the job, so the poll runs alongside the print rather than between
+/// chunks of it.
+async fn print_watching(
+    client: &mut ImageWriter,
+    raster: &[u8],
+    every: Duration,
+) -> anyhow::Result<()> {
+    let status = client.status_handle();
+    let mut ticker = tokio::time::interval(every);
+    ticker.tick().await; // the first tick is immediate
+
+    tokio::select! {
+        result = client.print_bytes(raster) => result?,
+        // Never returns, so the job is always what ends the select.
+        _ = async {
+            loop {
+                ticker.tick().await;
+                match status.read().await {
+                    // Busy stays set for the whole job: that is our own connection.
+                    Ok(s) => println!(
+                        "  [status] 0x{:04X} printing={} {}",
+                        s.raw,
+                        s.active(),
+                        s.error_text().unwrap_or_else(|| "no errors".to_string())
+                    ),
+                    Err(e) => eprintln!("  [status] poll failed: {e}"),
+                }
+            }
+        } => {}
+    }
+    Ok(())
+}

--- a/examples/nbp-lookup/main.rs
+++ b/examples/nbp-lookup/main.rs
@@ -20,6 +20,10 @@ struct Args {
     /// Entity to look up in Object:Type@Zone format. Use = as wildcard.
     #[arg(default_value = "=:=@*")]
     entity: String,
+
+    /// If no results are found, retry up to this many additional times
+    #[arg(short, long, default_value_t = 0)]
+    retries: u32,
 }
 
 #[tokio::main]
@@ -63,12 +67,11 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    println!("Looking up '{}'...", entity);
-    match stack.nbp.lookup(entity).await {
-        Ok(tuples) => {
-            if tuples.is_empty() {
-                println!("No results found.");
-            } else {
+    let mut attempt = 0;
+    loop {
+        println!("Looking up '{}'...", entity);
+        match stack.nbp.lookup(entity.clone()).await {
+            Ok(tuples) if !tuples.is_empty() => {
                 println!("Found {} result(s):", tuples.len());
                 for t in &tuples {
                     println!(
@@ -76,9 +79,31 @@ async fn main() -> anyhow::Result<()> {
                         t.entity_name, t.network_number, t.node_id, t.socket_number
                     );
                 }
+                break;
+            }
+            Ok(_) => {
+                if attempt >= args.retries {
+                    println!("No results found.");
+                    break;
+                }
+                attempt += 1;
+                println!(
+                    "No results found, retrying ({}/{})...",
+                    attempt, args.retries
+                );
+            }
+            Err(e) => {
+                if attempt >= args.retries {
+                    eprintln!("Lookup failed: {}", e);
+                    break;
+                }
+                attempt += 1;
+                eprintln!(
+                    "Lookup failed: {}, retrying ({}/{})...",
+                    e, attempt, args.retries
+                );
             }
         }
-        Err(e) => eprintln!("Lookup failed: {}", e),
     }
 
     // The pcap writer runs on its own thread and drains a channel; give it a

--- a/tailtalk-gui/ipp_bridge.rs
+++ b/tailtalk-gui/ipp_bridge.rs
@@ -25,6 +25,7 @@ use tailtalk::{
     adsp::AdspAddress,
     atp::{Atp, AtpAddress},
     ddp::DdpHandle,
+    imagewriter::{self, ImageWriter},
     nbp::NbpHandle,
     pap::PapClient,
     stylewriter::{
@@ -169,6 +170,7 @@ struct JobRecord {
 }
 
 /// Which AppleTalk print path a discovered printer uses.
+#[allow(clippy::enum_variant_names, reason = "these are Apple's product names")]
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum PrinterKind {
     /// PostScript printer driven over PAP (NBP type "LaserWriter").
@@ -176,6 +178,10 @@ enum PrinterKind {
     /// Color StyleWriter behind an EtherTalk adapter, driven over ADSP
     /// (NBP type "ColorStyleWriter2400AT").
     StyleWriter,
+    /// Apple ImageWriter II driven over PAP (NBP type "ImageWriter"). No
+    /// PostScript interpreter, so every job is rasterized by Ghostscript rather
+    /// than handed to the printer as-is.
+    ImageWriter,
 }
 
 /// StyleWriters print at a fixed 360 dpi.
@@ -185,6 +191,18 @@ const SW_DPI: u32 = 360;
 const SW_LEFT_MARGIN_PX: usize = 72;
 const SW_TOP_MARGIN_ROWS: usize = 90;
 const SW_BOTTOM_MARGIN_ROWS: usize = 90;
+
+/// Ghostscript's `iwhi`/`iwhic` devices (ImageWriter II) are 160x144 dpi; report the
+/// lower (vertical) figure for `printer-resolution-*` since IPP wants one
+/// symmetric value and this errs toward not overstating detail.
+const IW_DPI: u32 = 144;
+/// Physical carriage width. Ghostscript's `iwhi` device page geometry crashes
+/// if asked for anything wider.
+const IW_MAX_WIDTH_PT: f32 = 612.0;
+/// Page height must be an exact multiple of this many points (48 dots at
+/// 144dpi). Anything else makes gdevadmp's internal band-buffer sizing return a
+/// negative "unexpected value" and abort the whole job.
+const IW_HEIGHT_GRANULARITY_PT: f32 = 24.0;
 
 #[derive(Clone)]
 struct PrinterCaps {
@@ -226,12 +244,87 @@ impl Printer {
     }
 }
 
+/// How long after a job finishes a printer stays safe from pruning. A printer
+/// that has just ejected a page can still be slow to answer NBP.
+const PRUNE_GRACE: Duration = Duration::from_secs(60);
+
+/// Which printers currently have a job on them, so discovery doesn't prune a
+/// printer we are in the middle of using.
+///
+/// A printer busy with a job may not answer NBP for the length of that job,
+/// which on an ImageWriter is minutes, and one missed lookup is otherwise
+/// enough to unregister it. Registrations are held for as long as a job is
+/// running and for [`PRUNE_GRACE`] after the last one finishes.
+#[derive(Default)]
+struct ActivePrinters(std::sync::Mutex<HashMap<String, PrinterActivity>>);
+
+#[derive(Default)]
+struct PrinterActivity {
+    /// Jobs in flight. Counted rather than a flag: jobs queue on `job_locks`,
+    /// so a second can be waiting while the first still holds the printer.
+    jobs: usize,
+    /// When the last job finished, starting the grace period.
+    idle_since: Option<Instant>,
+}
+
+impl ActivePrinters {
+    /// Protect `key` until the returned guard drops.
+    fn begin(self: &Arc<Self>, key: String) -> PrintingGuard {
+        let mut map = self.0.lock().unwrap();
+        let entry = map.entry(key.clone()).or_default();
+        entry.jobs += 1;
+        entry.idle_since = None;
+        PrintingGuard { owner: self.clone(), key }
+    }
+
+    /// Whether `key` is printing or still inside the grace period. Expired
+    /// entries are dropped here so the map doesn't grow with every job.
+    fn protected(&self, key: &str) -> bool {
+        let mut map = self.0.lock().unwrap();
+        let Some(activity) = map.get(key) else {
+            return false;
+        };
+        if activity.jobs > 0 {
+            return true;
+        }
+        match activity.idle_since {
+            Some(t) if t.elapsed() < PRUNE_GRACE => true,
+            _ => {
+                map.remove(key);
+                false
+            }
+        }
+    }
+}
+
+/// Holds a printer's registration open for the life of a job. Releasing on drop
+/// means an aborted or panicking job still starts the grace period rather than
+/// pinning the printer forever.
+struct PrintingGuard {
+    owner: Arc<ActivePrinters>,
+    key: String,
+}
+
+impl Drop for PrintingGuard {
+    fn drop(&mut self) {
+        let mut map = self.owner.0.lock().unwrap();
+        if let Some(activity) = map.get_mut(&self.key) {
+            activity.jobs = activity.jobs.saturating_sub(1);
+            if activity.jobs == 0 {
+                activity.idle_since = Some(Instant::now());
+            }
+        }
+    }
+}
+
 struct BridgeState {
     printers: Arc<RwLock<Vec<Printer>>>,
     ddp: DdpHandle,
     jobs: RwLock<HashMap<u32, Arc<Mutex<JobRecord>>>>,
     next_job_id: AtomicU32,
     start_time: Instant,
+    /// Printers with a job on them, exempt from discovery pruning.
+    active: Arc<ActivePrinters>,
     /// Per-printer locks (keyed by printer key) serialising print sessions:
     /// LaserWriters accept one PAP connection at a time (and connect() gives
     /// up after 60s of busy-retries); StyleWriters likewise hold a single
@@ -255,14 +348,17 @@ pub async fn run(
         }
     };
 
+    let active: Arc<ActivePrinters> = Arc::new(ActivePrinters::default());
+
     let ddp2 = ddp.clone();
     let nbp2 = nbp.clone();
     let printers2 = printers.clone();
     let mdns2 = mdns.clone();
     let token2 = token.clone();
     let bridged2 = bridged_names.clone();
+    let active2 = active.clone();
 
-    discover(&nbp, &ddp, &printers, &mdns, &bridged_names).await;
+    discover(&nbp, &ddp, &printers, &mdns, &bridged_names, &active).await;
 
     let state = Arc::new(BridgeState {
         printers: printers.clone(),
@@ -270,6 +366,7 @@ pub async fn run(
         jobs: RwLock::new(HashMap::new()),
         next_job_id: AtomicU32::new(1),
         start_time: Instant::now(),
+        active,
         job_locks: std::sync::Mutex::new(HashMap::new()),
     });
 
@@ -298,7 +395,9 @@ pub async fn run(
         loop {
             tokio::select! {
                 _ = token2.cancelled() => break,
-                _ = interval.tick() => discover(&nbp2, &ddp2, &printers2, &mdns2, &bridged2).await,
+                _ = interval.tick() => {
+                    discover(&nbp2, &ddp2, &printers2, &mdns2, &bridged2, &active2).await
+                }
             }
         }
     });
@@ -361,6 +460,7 @@ fn printer_key(kind: PrinterKind, name: &str, addr: ServiceAddress) -> String {
     match kind {
         PrinterKind::LaserWriter => format!("{key}-{a}"),
         PrinterKind::StyleWriter => format!("{key}-{a}-sw"),
+        PrinterKind::ImageWriter => format!("{key}-{a}-iw"),
     }
 }
 
@@ -370,11 +470,13 @@ async fn discover(
     printers: &Arc<RwLock<Vec<Printer>>>,
     mdns: &ServiceDaemon,
     bridged_names: &crate::lw_bridge::BridgedNames,
+    active: &Arc<ActivePrinters>,
 ) {
     // (kind, NBP type pattern) for each supported printer family.
-    let lookups: [(PrinterKind, &str); 2] = [
+    let lookups: [(PrinterKind, &str); 3] = [
         (PrinterKind::LaserWriter, "=:LaserWriter@*"),
         (PrinterKind::StyleWriter, "=:ColorStyleWriter2400AT@*"),
+        (PrinterKind::ImageWriter, "=:ImageWriter@*"),
     ];
 
     let entities: Vec<(PrinterKind, EntityName)> = lookups
@@ -421,7 +523,12 @@ async fn discover(
     let mut current_keys: HashSet<String> = {
         let mut current = printers.write().await;
         current.retain(|p| {
+            // A printer we are printing to may go quiet on NBP for the whole
+            // job, so keep it registered until the job has been done a while.
             if new_keys.contains(&p.key) || !lookup_ok.contains(&p.kind) {
+                true
+            } else if active.protected(&p.key) {
+                tracing::debug!("IPP bridge: '{}' missed a lookup but has a job on it", p.name);
                 true
             } else {
                 if let Ok(rx) = mdns.unregister(&p.mdns_fullname) { drop(rx); }
@@ -461,6 +568,15 @@ async fn discover(
                     Err(e) => {
                         tracing::warn!("IPP bridge: StyleWriter caps query for '{name}' failed ({e}), using defaults");
                         default_stylewriter_caps()
+                    }
+                }
+            }
+            PrinterKind::ImageWriter => {
+                match query_imagewriter_caps(ddp, addr.into()).await {
+                    Ok(caps) => caps,
+                    Err(e) => {
+                        tracing::warn!("IPP bridge: ImageWriter caps query for '{name}' failed ({e}), using defaults");
+                        default_imagewriter_caps()
                     }
                 }
             }
@@ -532,6 +648,49 @@ fn default_stylewriter_caps() -> PrinterCaps {
         media_default: "na_letter_8.5x11in".to_string(),
         tray_sources: vec!["main".into()],
     }
+}
+
+/// Fallback caps when an ImageWriter is discovered but its status query fails.
+/// Assume mono: a black ribbon is the common case, and printing a colour job
+/// through the colour Ghostscript device onto a black ribbon wastes a page,
+/// whereas mono on a colour ribbon still prints correctly (in black).
+fn default_imagewriter_caps() -> PrinterCaps {
+    PrinterCaps {
+        dpi: IW_DPI,
+        color: false,
+        model: "Apple ImageWriter II".to_string(),
+        media_default: "na_letter_8.5x11in".to_string(),
+        tray_sources: vec!["main".into()],
+    }
+}
+
+/// Query an ImageWriter's LocalTalk Option Card for the one capability it
+/// exposes: whether a colour ribbon is installed.
+///
+/// The sheet-feeder bit deliberately does not become a second `media-source`:
+/// the feeder replaces the friction/tractor path rather than adding a
+/// selectable tray, and there is no command to choose between them.
+async fn query_imagewriter_caps(ddp: &DdpHandle, addr: AtpAddress) -> anyhow::Result<PrinterCaps> {
+    let status = ImageWriter::status_of(ddp, addr).await?;
+
+    tracing::info!(
+        "IPP bridge: ImageWriter status 0x{:04X} ribbon={} feeder={} busy={}{}",
+        status.raw,
+        status.ribbon_text(),
+        status.sheet_feeder(),
+        status.busy(),
+        status.error_text().map(|e| format!(" error='{e}'")).unwrap_or_default(),
+    );
+
+    Ok(PrinterCaps {
+        color: status.color_ribbon(),
+        model: if status.color_ribbon() {
+            "Apple ImageWriter II (color ribbon)".to_string()
+        } else {
+            "Apple ImageWriter II".to_string()
+        },
+        ..default_imagewriter_caps()
+    })
 }
 
 /// Query a StyleWriter's model and installed cartridge over a short-lived
@@ -676,6 +835,35 @@ fn parse_pts_to_media(pts: &str) -> &'static str {
         }
     }
     "na_letter_8.5x11in"
+}
+
+/// A PWG media name → its nominal (width, height) in points, derived from
+/// `MEDIA_DIMENSIONS_HMM` so there is no second table to keep in step. Rounded
+/// to the nearest point: metric sizes don't land on whole points (true A4 is
+/// 595.28x841.89pt) and the forced page geometry doesn't need sub-point
+/// precision. Falls back to Letter for anything unrecognized.
+fn media_to_pts(name: &str) -> (f32, f32) {
+    let hmm_to_pt = |hmm: i32| (hmm as f32 * 72.0 / 2540.0).round();
+    media_dimensions_hmm(name)
+        .map(|(w, h)| (hmm_to_pt(w), hmm_to_pt(h)))
+        .unwrap_or((612.0, 792.0))
+}
+
+/// Clamp a requested page size to what Ghostscript's `iwhi` device can
+/// actually produce without crashing (see `IW_MAX_WIDTH_PT` /
+/// `IW_HEIGHT_GRANULARITY_PT`). Floors rather than rounds so the forced page
+/// is never taller/wider than the paper actually loaded.
+fn imagewriter_safe_page(w: f32, h: f32) -> (f32, f32) {
+    let w = w.min(IW_MAX_WIDTH_PT);
+    let h = (h / IW_HEIGHT_GRANULARITY_PT).floor().max(1.0) * IW_HEIGHT_GRANULARITY_PT;
+    (w, h)
+}
+
+/// `iwhic` is the colour twin of `iwhi`, driving the four-band colour ribbon.
+/// Mono jobs stay on `iwhi` even with a colour ribbon fitted, where they strike
+/// the ribbon's black band directly instead of laying down a composite.
+fn imagewriter_gs_device(color: bool) -> &'static str {
+    if color { "iwhic" } else { "iwhi" }
 }
 
 fn ipp_bytes(resp: IppRequestResponse) -> axum::response::Response {
@@ -853,11 +1041,15 @@ async fn handle_ipp(
                 let mut locks = state.job_locks.lock().unwrap();
                 locks.entry(printer.key.clone()).or_default().clone()
             };
+            // Held for the life of the job, whichever family runs it, so
+            // discovery leaves the printer registered while it is in use.
+            let active_guard = state.active.begin(printer.key.clone());
             match printer.kind {
                 PrinterKind::LaserWriter => {
                     let addr: AtpAddress = printer.addr.into();
                     let dpi = printer.caps.dpi;
                     tokio::spawn(async move {
+                        let _active_guard = active_guard;
                         job.lock().await.state_message = "Rasterizing".to_string();
                         let (ps, page_count) = match rasterize_to_ps(doc, &fmt, &tray, dpi, job_id).await {
                             Ok(r) => r,
@@ -912,7 +1104,89 @@ async fn handle_ipp(
                     );
                     tokio::spawn(run_stylewriter_job(
                         job, ddp, addr, doc, fmt, color, quality, username, job_lock, job_id,
+                        active_guard,
                     ));
+                }
+                PrinterKind::ImageWriter => {
+                    let addr: AtpAddress = printer.addr.into();
+                    let media_pts = job_media_pts(&parsed, &printer.caps.media_default);
+                    let wants_color = job_color_mode(&parsed).as_deref() != Some("monochrome");
+                    let caps_color = printer.caps.color;
+                    tracing::info!(
+                        "IPP: ImageWriter job {job_id}: media={media_pts:?}pt wants_color={wants_color}"
+                    );
+                    tokio::spawn(async move {
+                        let _active_guard = active_guard;
+                        // One socket, read twice: once now to pick the device, and
+                        // again once we hold the printer.
+                        let status = imagewriter::StatusHandle::new(&ddp, addr).await;
+
+                        // The ribbon can be swapped between discovery and now, and
+                        // the status call needs no connection, so ask again rather
+                        // than rasterize for a ribbon that has since changed.
+                        let color = match status.read().await {
+                            Ok(s) if s.out_of_paper() => {
+                                let msg = s.error_text().unwrap_or_else(|| "Out of paper".to_string());
+                                tracing::error!("IPP: ImageWriter job {job_id} refused: {msg}");
+                                let mut j = job.lock().await;
+                                j.state = JobState::Aborted;
+                                j.state_message = msg;
+                                return;
+                            }
+                            Ok(s) => wants_color && s.color_ribbon(),
+                            Err(e) => {
+                                // Not fatal: the job can still print, it just uses
+                                // the ribbon seen at discovery.
+                                tracing::warn!("IPP: ImageWriter job {job_id} status query failed ({e})");
+                                wants_color && caps_color
+                            }
+                        };
+                        job.lock().await.state_message = "Rasterizing".to_string();
+                        let raster = match rasterize_for_imagewriter(doc, &fmt, media_pts, color, job_id).await {
+                            Ok(r) => r,
+                            Err(e) => {
+                                tracing::error!("IPP: ImageWriter rasterize failed: {e}");
+                                let mut j = job.lock().await;
+                                j.state = JobState::Aborted;
+                                j.state_message = format!("Rasterize failed: {e}");
+                                return;
+                            }
+                        };
+                        tracing::info!("IPP: rasterized ImageWriter job {job_id} to {} bytes", raster.len());
+                        job.lock().await.state_message = "Waiting for printer".to_string();
+                        let _pap_guard = job_lock.lock().await;
+
+                        // The check above can be minutes stale by now if this job
+                        // queued behind another, so confirm there is still paper
+                        // before feeding it. A failed read is not fatal here; the
+                        // print itself is the better error in that case.
+                        if let Ok(s) = status.read().await
+                            && s.out_of_paper()
+                        {
+                            let msg = s.error_text().unwrap_or_else(|| "Out of paper".to_string());
+                            tracing::error!("IPP: ImageWriter job {job_id} refused at print time: {msg}");
+                            let mut j = job.lock().await;
+                            j.state = JobState::Aborted;
+                            j.state_message = msg;
+                            return;
+                        }
+
+                        job.lock().await.state_message = "Printing".to_string();
+                        match print_to_pap_imagewriter(ddp, addr, raster).await {
+                            Ok(()) => {
+                                let mut j = job.lock().await;
+                                j.impressions_completed = 1;
+                                j.state = JobState::Completed;
+                                j.state_message = "Completed".to_string();
+                            }
+                            Err(e) => {
+                                tracing::error!("IPP: job {job_id} PAP error: {e}");
+                                let mut j = job.lock().await;
+                                j.state = JobState::Aborted;
+                                j.state_message = format!("PAP error: {e}");
+                            }
+                        }
+                    });
                 }
             }
             job_created_response(job_id, &job_uri, req_id)
@@ -993,22 +1267,24 @@ fn printer_attributes(printer: &Printer, req_id: u32) -> axum::response::Respons
     let uri = format!("ipp://localhost:8631/ipp/{}", printer.key);
     let caps = &printer.caps;
 
-    // A StyleWriter with a black cartridge really is monochrome-only; the
-    // LaserWriter path always accepts color input (ghostscript converts).
+    // A StyleWriter with a black cartridge, or an ImageWriter with a black
+    // ribbon, really is monochrome-only; the LaserWriter path always accepts
+    // color input (ghostscript converts).
     let color_modes: &[&str] = match printer.kind {
-        PrinterKind::StyleWriter if !caps.color => &["monochrome"],
+        PrinterKind::StyleWriter | PrinterKind::ImageWriter if !caps.color => &["monochrome"],
         _ => &["auto", "color", "monochrome"],
     };
-    let color_mode_default = if printer.kind == PrinterKind::StyleWriter && caps.color {
-        "auto"
-    } else {
-        "monochrome"
+    let color_mode_default = match printer.kind {
+        PrinterKind::StyleWriter | PrinterKind::ImageWriter if caps.color => "auto",
+        _ => "monochrome",
     };
     // StyleWriter quality maps to the printer's own mode string (normal/best);
-    // draft has no known string, so it isn't offered there.
+    // draft has no known string, so it isn't offered there. `iwhi` doesn't
+    // distinguish quality tiers at all, so ImageWriter only offers Normal.
     let qualities: &[i32] = match printer.kind {
         PrinterKind::LaserWriter => &[3, 4, 5],
         PrinterKind::StyleWriter => &[4, 5],
+        PrinterKind::ImageWriter => &[4],
     };
 
     let mut add = |name: &str, val: IppValue| {
@@ -1055,7 +1331,11 @@ fn printer_attributes(printer: &Printer, req_id: u32) -> axum::response::Respons
         add("output-mode-supported", IppValue::Array(modes));
     }
     add("pages-per-minute", IppValue::Integer(
-        match printer.kind { PrinterKind::LaserWriter => 8, PrinterKind::StyleWriter => 1 },
+        match printer.kind {
+            PrinterKind::LaserWriter => 8,
+            PrinterKind::StyleWriter => 1,
+            PrinterKind::ImageWriter => 1,
+        },
     ));
     add("pdf-k-octets-supported", IppValue::RangeOfInteger { min: 1, max: 65535 });
     add("jpeg-k-octets-supported", IppValue::RangeOfInteger { min: 1, max: 65535 });
@@ -1234,6 +1514,58 @@ fn job_media_source(parsed: &IppRequestResponse) -> String {
     media_source.or(input_slot).unwrap_or_else(|| "main".to_string())
 }
 
+/// The page size the job asked for, in points, falling back to `default_media`.
+///
+/// Clients express this two ways and both turn up in practice: the flat `media`
+/// keyword, or a `media-col` collection carrying `media-size` dimensions. Since
+/// this bridge advertises `media-col-database`, AirPrint clients in particular
+/// tend to answer in the collection form.
+///
+/// Only the ImageWriter path needs this. The other families have a PostScript
+/// interpreter that honours the document's own page size, but the ImageWriter
+/// has to be told explicitly what geometry to force on Ghostscript.
+fn job_media_pts(parsed: &IppRequestResponse, default_media: &str) -> (f32, f32) {
+    let group = parsed.attributes().groups_of(DelimiterTag::JobAttributes).next();
+
+    let keyword = group
+        .and_then(|g| g.attributes().get("media"))
+        .and_then(|a| match a.value() {
+            IppValue::Keyword(k) => Some(k.as_str()),
+            IppValue::NameWithoutLanguage(n) => Some(n.as_str()),
+            _ => None,
+        });
+    if let Some(name) = keyword {
+        return media_to_pts(name);
+    }
+
+    // media-col → media-size → {x,y}-dimension, in hundredths of a mm.
+    let member = |coll: &IppValue, want: &str| -> Option<IppValue> {
+        match coll {
+            IppValue::Collection(members) => members
+                .iter()
+                .find(|(k, _)| k.as_str() == want)
+                .map(|(_, v)| v.clone()),
+            _ => None,
+        }
+    };
+    let dimension = |size: &IppValue, want: &str| -> Option<f32> {
+        match member(size, want) {
+            Some(IppValue::Integer(hmm)) => Some(hmm as f32 * 72.0 / 2540.0),
+            _ => None,
+        }
+    };
+    let size = group
+        .and_then(|g| g.attributes().get("media-col"))
+        .and_then(|a| member(a.value(), "media-size"));
+    if let Some(size) = size
+        && let (Some(w), Some(h)) = (dimension(&size, "x-dimension"), dimension(&size, "y-dimension"))
+    {
+        return (w.round(), h.round());
+    }
+
+    media_to_pts(default_media)
+}
+
 /// Extract the requested color mode: `print-color-mode`, falling back to the
 /// older Apple `output-mode` synonym.
 fn job_color_mode(parsed: &IppRequestResponse) -> Option<String> {
@@ -1392,17 +1724,29 @@ pub fn gs_probe() -> bool {
 
 /// Rasterize a PDF/PS/URF document with Ghostscript to a raw raster device
 /// (`pbmraw`, `ppmraw`, …) at `dpi`, returning the concatenated raw pages.
-async fn gs_raster(mut data: Vec<u8>, fmt: &str, device: &str, dpi: u32, job_token: u32) -> anyhow::Result<Vec<u8>> {
+async fn gs_raster(data: Vec<u8>, fmt: &str, device: &str, dpi: u32, job_token: u32) -> anyhow::Result<Vec<u8>> {
+    gs_device_run(data, fmt, device, &[format!("-r{dpi}")], job_token).await
+}
+
+/// Run Ghostscript over a document with `device_args` controlling how the
+/// device renders (resolution, page geometry, …), returning the device's raw
+/// output. Raw raster devices cannot write to stdout, so this goes via a temp
+/// file either way.
+async fn gs_device_run(
+    mut data: Vec<u8>,
+    fmt: &str,
+    device: &str,
+    device_args: &[String],
+    job_token: u32,
+) -> anyhow::Result<Vec<u8>> {
     // Track whether urf_to_rasterizable ran — on Linux it returns PostScript, not PDF.
     let is_urf = fmt == "image/urf" || data.starts_with(b"UNIRAST");
     if is_urf {
         data = urf_to_rasterizable(data, job_token).await?;
     }
 
-    // Raw raster devices cannot write to stdout, so use a temp file.
     let tmp = std::env::temp_dir();
     let out_path = tmp.join(format!("tailtalk-rip-{job_token}.{device}"));
-    let res_arg = format!("-r{dpi}");
     let dev_arg = format!("-sDEVICE={device}");
 
     // Use .ps extension when we know the content is PostScript (Linux ippeveps output),
@@ -1416,9 +1760,11 @@ async fn gs_raster(mut data: Vec<u8>, fmt: &str, device: &str, dpi: u32, job_tok
     tokio::fs::write(&input_path, &data).await?;
 
     let output = tokio::process::Command::new(gs_command())
+        .args(["-dNOPAUSE", "-dBATCH", "-dSAFER", &dev_arg])
+        .args(device_args)
         // Pass -sOutputFile as a separate -o arg so the OS handles path quoting,
         // avoiding issues with spaces in the temp directory path on Windows.
-        .args(["-dNOPAUSE", "-dBATCH", "-dSAFER", &dev_arg, &res_arg, "-o"])
+        .arg("-o")
         .arg(&out_path)
         .arg(&input_path)
         .stdout(std::process::Stdio::piped())
@@ -1467,6 +1813,27 @@ async fn rasterize_to_ps(data: Vec<u8>, fmt: &str, tray_source: &str, dpi: u32, 
 
     let page_count = pages.len();
     Ok((build_ps_raster(&pages, dpi, tray_source), page_count))
+}
+
+/// Rasterize directly to raw ImageWriter II command bytes via Ghostscript's
+/// `iwhi`/`iwhic` device, forcing the page to `media_pts` (clamped by
+/// `imagewriter_safe_page`). Unlike LaserWriter/StyleWriter there's no
+/// PS-passthrough shortcut: the printer has no interpreter of its own, so
+/// everything goes through `gs` whatever the incoming document format.
+async fn rasterize_for_imagewriter(
+    data: Vec<u8>,
+    fmt: &str,
+    media_pts: (f32, f32),
+    color: bool,
+    job_token: u32,
+) -> anyhow::Result<Vec<u8>> {
+    let (w, h) = imagewriter_safe_page(media_pts.0, media_pts.1);
+    let args = [
+        format!("-dDEVICEWIDTHPOINTS={w}"),
+        format!("-dDEVICEHEIGHTPOINTS={h}"),
+        "-dFIXEDMEDIA".to_string(),
+    ];
+    gs_device_run(data, fmt, imagewriter_gs_device(color), &args, job_token).await
 }
 
 /// One page of raw planar StyleWriter scanlines: rows → planes (1 for mono,
@@ -1627,6 +1994,8 @@ async fn run_stylewriter_job(
     username: String,
     job_lock: Arc<Mutex<()>>,
     job_id: u32,
+    // Held, not read: keeps the printer registered until this job is done.
+    _active_guard: PrintingGuard,
 ) {
     job.lock().await.state_message = "Rasterizing".to_string();
     let pages = match rasterize_for_stylewriter(doc, &fmt, color, job_id).await {
@@ -1890,6 +2259,19 @@ async fn print_to_pap(ddp: DdpHandle, addr: AtpAddress, doc: Vec<u8>) -> anyhow:
     Ok(output)
 }
 
+/// Like `print_to_pap`, but for ImageWriter: there's no PostScript
+/// interpreter behind it, so there's no interactive stdout to read back
+/// after the job.
+async fn print_to_pap_imagewriter(ddp: DdpHandle, addr: AtpAddress, doc: Vec<u8>) -> anyhow::Result<()> {
+    if doc.is_empty() {
+        tracing::warn!("IPP: empty ImageWriter document, skipping print");
+        return Ok(());
+    }
+    let mut printer = ImageWriter::connect(&ddp, addr).await?;
+    printer.print_bytes(&doc).await?;
+    printer.close().await
+}
+
 /// Returns the PS error string from `%%[ Error: ]%%` lines; ignores `PrinterError`/`LastError`.
 fn parse_printer_error(output: &str) -> Option<String> {
     output.lines()
@@ -1901,6 +2283,95 @@ fn parse_printer_error(output: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A printer with a job on it must survive missed lookups for the whole
+    /// job, however long that is, and for the grace period afterwards.
+    #[test]
+    fn test_active_printers_protects_for_the_life_of_a_job() {
+        let active = Arc::new(ActivePrinters::default());
+        assert!(!active.protected("iw"), "unknown printers aren't protected");
+
+        let guard = active.begin("iw".to_string());
+        assert!(active.protected("iw"));
+        // A second job queued behind the first.
+        let queued = active.begin("iw".to_string());
+        drop(guard);
+        assert!(active.protected("iw"), "the queued job still holds it");
+
+        drop(queued);
+        assert!(active.protected("iw"), "grace period runs from the last job");
+
+        // Expire the grace period rather than sleeping through it.
+        {
+            let mut map = active.0.lock().unwrap();
+            map.get_mut("iw").unwrap().idle_since = Some(Instant::now() - PRUNE_GRACE);
+        }
+        assert!(!active.protected("iw"));
+        assert!(
+            active.0.lock().unwrap().is_empty(),
+            "expired entries are swept so the map doesn't grow per job"
+        );
+    }
+
+    #[test]
+    fn test_imagewriter_safe_page_clamps_and_floors() {
+        // Width above the physical 8.5in carriage gets clamped.
+        assert_eq!(imagewriter_safe_page(700.0, 792.0), (612.0, 792.0));
+        // Height not a multiple of 24pt gets floored to one, or the `iwhi`
+        // device's band-buffer sizing crashes.
+        assert_eq!(imagewriter_safe_page(612.0, 792.0), (612.0, 792.0)); // Letter, already exact
+        assert_eq!(imagewriter_safe_page(595.0, 842.0), (595.0, 840.0)); // A4
+        assert_eq!(imagewriter_safe_page(279.0, 540.0), (279.0, 528.0)); // Monarch
+    }
+
+    /// Picking the mono device for a colour job is silent: `iwhi` prints the
+    /// page in black and looks like a printer that just ignores colour.
+    #[test]
+    fn test_imagewriter_gs_device_picks_color_twin() {
+        assert_eq!(imagewriter_gs_device(false), "iwhi");
+        assert_eq!(imagewriter_gs_device(true), "iwhic");
+    }
+
+    /// Build a PrintJob request carrying one job attribute.
+    fn job_request_with(attr: IppAttribute) -> IppRequestResponse {
+        let mut req = IppRequestResponse::new(IppVersion::v2_0(), Operation::PrintJob, None).unwrap();
+        req.attributes_mut().add(DelimiterTag::JobAttributes, attr);
+        req
+    }
+
+    /// Clients send the page size either as the flat `media` keyword or inside
+    /// a `media-col` collection; the ImageWriter path has to honour both, since
+    /// missing it silently forces the default size onto every job.
+    #[test]
+    fn test_job_media_pts_reads_keyword_and_media_col() {
+        let by_keyword = job_request_with(IppAttribute::new(
+            "media".try_into().unwrap(),
+            IppValue::Keyword("iso_a4_210x297mm".try_into().unwrap()),
+        ));
+        assert_eq!(job_media_pts(&by_keyword, "na_letter_8.5x11in"), (595.0, 842.0));
+
+        let by_collection = job_request_with(IppAttribute::new(
+            "media-col".try_into().unwrap(),
+            IppValue::Collection(BTreeMap::from([(
+                "media-size".try_into().unwrap(),
+                media_size_collection(21000, 29700).unwrap(),
+            )])),
+        ));
+        assert_eq!(job_media_pts(&by_collection, "na_letter_8.5x11in"), (595.0, 842.0));
+
+        // Neither present: the printer's own default wins, not a hardcoded size.
+        let bare = IppRequestResponse::new(IppVersion::v2_0(), Operation::PrintJob, None).unwrap();
+        assert_eq!(job_media_pts(&bare, "iso_a4_210x297mm"), (595.0, 842.0));
+        assert_eq!(job_media_pts(&bare, "na_letter_8.5x11in"), (612.0, 792.0));
+    }
+
+    #[test]
+    fn test_media_to_pts_roundtrips_known_names() {
+        assert_eq!(media_to_pts("na_letter_8.5x11in"), (612.0, 792.0));
+        assert_eq!(media_to_pts("iso_a4_210x297mm"), (595.0, 842.0));
+        // Unknown name falls back to Letter rather than panicking.
+        assert_eq!(media_to_pts("bogus_media_name"), (612.0, 792.0));
+    }
 
     #[test]
     fn all_advertised_media_have_dimensions() {

--- a/tailtalk-gui/printer_tool.rs
+++ b/tailtalk-gui/printer_tool.rs
@@ -6,6 +6,8 @@
 //!   * StyleWriter — rename, over the ADSP management socket (`sw-rename`).
 //!   * LaserWriter — rename, default paper size and power-on startup page, as
 //!     PostScript over PAP (`pap-print`).
+//!   * ImageWriter — rename, as the option card's `ESC b` command over PAP.
+//!     Status comes back from the same card as a packed status word.
 //!
 //! The server has to be running: we borrow its live `NbpHandle`/`DdpHandle`
 //! rather than building a second stack, which couldn't reopen an in-use
@@ -22,7 +24,8 @@ use tailtalk::{
     adsp::{Adsp, AdspAddress, AdspStream},
     atp::{Atp, AtpAddress},
     ddp::DdpHandle,
-    pap::PapClient,
+    imagewriter::{self, ImageWriter, ImageWriterStatus},
+    pap::{PapClient, PapStatusHandle},
     stylewriter::StyleWriterSession,
 };
 use tailtalk_packets::nbp::EntityName;
@@ -72,10 +75,29 @@ enum PrinterKind {
     /// Color StyleWriter behind an EtherTalk adapter, driven over ADSP
     /// (NBP type "ColorStyleWriter2400AT").
     StyleWriter,
+    /// Apple ImageWriter II/LQ behind a LocalTalk Option Card, queried over PAP
+    /// (NBP type "ImageWriter").
+    ImageWriter,
 }
 
 /// ADSP management socket — fixed at 129 on StyleWriter adapters (see `sw-rename`).
 const SW_MGMT_SOCKET: u8 = 129;
+
+/// Longest name each family accepts: the StyleWriter's Pascal-string rename
+/// takes 31, the LaserWriter's `PrinterName` 32. Drives both validation and the
+/// hint under the name field, so the two cannot disagree.
+const SW_MAX_NAME_LEN: usize = 31;
+const LW_MAX_NAME_LEN: usize = 32;
+
+impl PrinterKind {
+    fn max_name_len(self) -> usize {
+        match self {
+            PrinterKind::StyleWriter => SW_MAX_NAME_LEN,
+            PrinterKind::LaserWriter => LW_MAX_NAME_LEN,
+            PrinterKind::ImageWriter => imagewriter::MAX_NAME_LEN,
+        }
+    }
+}
 
 /// Attention codes used by the StyleWriter name-change protocol.
 const ATTN_GET_NAME: u16 = 0x0011;
@@ -112,7 +134,7 @@ impl Discovered {
         }
     }
 
-    /// The advertised print endpoint, as an ATP address (LaserWriter).
+    /// The advertised print endpoint, as an ATP address (LaserWriter, ImageWriter).
     fn atp_addr(&self) -> AtpAddress {
         AtpAddress {
             network_number: self.net,
@@ -127,9 +149,11 @@ impl Discovered {
             kind: match self.kind {
                 PrinterKind::LaserWriter => "LaserWriter (PostScript)".into(),
                 PrinterKind::StyleWriter => "Color StyleWriter".into(),
+                PrinterKind::ImageWriter => "ImageWriter".into(),
             },
             address: format!("{}.{} socket {}", self.net, self.node, self.socket).into(),
             is_stylewriter: self.kind == PrinterKind::StyleWriter,
+            is_imagewriter: self.kind == PrinterKind::ImageWriter,
         }
     }
 }
@@ -239,12 +263,13 @@ fn ps_escape(s: &str) -> String {
 
 // ── Async operations (reuse the existing protocol code) ───────────────────────
 
-/// Discover LaserWriters and Color StyleWriters — the same batched NBP lookup
-/// the IPP bridge performs.
+/// Discover LaserWriters, Color StyleWriters and ImageWriters, using the same
+/// batched NBP lookup the IPP bridge performs.
 async fn discover(handles: &PrinterHandles) -> anyhow::Result<Vec<Discovered>> {
-    const PATTERNS: [(PrinterKind, &str); 2] = [
+    const PATTERNS: [(PrinterKind, &str); 3] = [
         (PrinterKind::LaserWriter, "=:LaserWriter@*"),
         (PrinterKind::StyleWriter, "=:ColorStyleWriter2400AT@*"),
+        (PrinterKind::ImageWriter, "=:ImageWriter@*"),
     ];
 
     // Our own address on each transport, so registrations belonging to this
@@ -345,6 +370,62 @@ async fn query_stylewriter(ddp: &DdpHandle, addr: AdspAddress) -> anyhow::Result
     })
 }
 
+/// Query an ImageWriter's LocalTalk Option Card over PAP. No connection is
+/// opened, so this works even while the printer is mid-job. Everything the card
+/// reports is in one 16-bit word, so there is nothing further to ask it.
+async fn query_imagewriter(ddp: &DdpHandle, addr: AtpAddress) -> anyhow::Result<Queried> {
+    let s = ImageWriter::status_of(ddp, addr).await?;
+    Ok(Queried {
+        lines: imagewriter_lines(&s),
+        settings: None,
+    })
+}
+
+/// The whole info panel for one status word. Every row here bar the model comes
+/// out of that word, so the poller re-renders all of them together rather than
+/// refreshing the Condition line over a frozen copy of everything else.
+fn imagewriter_lines(s: &ImageWriterStatus) -> Vec<Line> {
+    let yes_no = |b: bool| if b { "Yes" } else { "No" };
+
+    vec![
+        Line::section("Status"),
+        Line::field("Condition", imagewriter_condition(s)),
+        Line::field("Paper", if s.paper_present() { "Loaded" } else { "Out of paper" }),
+        Line::field("Busy", yes_no(s.busy())),
+        Line::field("Printing", yes_no(s.active())),
+        Line::section("Hardware"),
+        Line::field("Model", "Apple ImageWriter II/LQ"),
+        Line::field("Ribbon", s.ribbon_text()),
+        Line::field(
+            "Colour printing",
+            if s.color_ribbon() { "Yes" } else { "No, black ribbon installed" },
+        ),
+        Line::field("Sheet feeder", yes_no(s.sheet_feeder())),
+        // The unaltered reply alongside the decode: a raw reading is what
+        // any "this status looks wrong" report needs.
+        Line::section("Raw protocol reply"),
+        Line::field("Status word", format!("0x{:04X}", s.raw)),
+        Line::field(
+            "Wire bytes",
+            s.wire_bytes().iter().map(|b| format!("{b:02X}")).collect::<Vec<_>>().join(" "),
+        ),
+    ]
+}
+
+/// One-line summary for the Condition row, matching how the other two families
+/// phrase it: errors first, then whatever the printer is doing.
+fn imagewriter_condition(s: &ImageWriterStatus) -> String {
+    if let Some(e) = s.error_text() {
+        e
+    } else if s.active() {
+        "Printing".to_string()
+    } else if s.busy() {
+        "Busy: connection open or printer not ready".to_string()
+    } else {
+        "Ready".to_string()
+    }
+}
+
 /// Send one attention command and check the printer's two-byte acknowledgement.
 async fn attention(stream: &mut AdspStream, code: u16, payload: &[u8]) -> anyhow::Result<()> {
     stream.send_attention(code, payload).await?;
@@ -364,7 +445,7 @@ async fn rename_stylewriter(
     mgmt_addr: AdspAddress,
     new_name: &str,
 ) -> anyhow::Result<String> {
-    validate_name(new_name, 31)?;
+    validate_name(new_name, PrinterKind::StyleWriter.max_name_len())?;
 
     let mut stream = timeout(Duration::from_secs(10), Adsp::connect(ddp, mgmt_addr))
         .await
@@ -379,6 +460,27 @@ async fn rename_stylewriter(
     attention(&mut stream, ATTN_SET_NAME, &pascal).await?;
     attention(&mut stream, ATTN_COMMIT, &[0x00]).await?;
     stream.close().await?;
+
+    Ok(format!(
+        "Renamed to \"{new_name}\". Click Refresh in a moment to confirm re-registration."
+    ))
+}
+
+/// Rename an ImageWriter by sending the option card's `ESC b` command over PAP.
+/// The card takes the name out of the data stream instead of passing it to the
+/// printer, so this goes over an ordinary print connection.
+async fn rename_imagewriter(
+    ddp: &DdpHandle,
+    addr: AtpAddress,
+    new_name: &str,
+) -> anyhow::Result<String> {
+    validate_name(new_name, PrinterKind::ImageWriter.max_name_len())?;
+
+    let mut printer = ImageWriter::connect(ddp, addr).await?;
+    let result = printer.set_name(new_name).await;
+    // Close either way: leaving the connection open holds the printer busy.
+    let closed = printer.close().await;
+    result.and(closed)?;
 
     Ok(format!(
         "Renamed to \"{new_name}\". Click Refresh in a moment to confirm re-registration."
@@ -520,7 +622,7 @@ async fn save_laserwriter(
     startup: bool,
     name: &str,
 ) -> anyhow::Result<String> {
-    validate_name(name, 32)?;
+    validate_name(name, PrinterKind::LaserWriter.max_name_len())?;
     let (w, h) = size.points();
     let escaped_name = ps_escape(name);
     let job = format!(
@@ -652,11 +754,22 @@ pub fn open(
                 w.set_info_rows(to_model(Vec::new()));
                 w.set_error_text("".into());
                 w.set_edit_name(printer.name.as_str().into());
+                w.set_name_max(printer.kind.max_name_len() as i32);
             }
             begin_busy(&weak, "Querying printer…");
 
-            if printer.kind == PrinterKind::LaserWriter {
-                poll_status(&rt, weak.clone(), ddp.clone(), printer.atp_addr(), &generation, my_gen);
+            // Both PAP families can be re-polled cheaply; the StyleWriter's ADSP
+            // query needs a whole session, so it is left to the manual refresh.
+            if matches!(printer.kind, PrinterKind::LaserWriter | PrinterKind::ImageWriter) {
+                poll_status(
+                    &rt,
+                    weak.clone(),
+                    ddp.clone(),
+                    printer.atp_addr(),
+                    printer.kind,
+                    &generation,
+                    my_gen,
+                );
             }
 
             let weak = weak.clone();
@@ -668,6 +781,7 @@ pub fn open(
                         query_stylewriter(&ddp, printer.adsp_print_addr()).await
                     }
                     PrinterKind::LaserWriter => query_laserwriter(&ddp, printer.atp_addr()).await,
+                    PrinterKind::ImageWriter => query_imagewriter(&ddp, printer.atp_addr()).await,
                 };
                 slint::invoke_from_event_loop(move || {
                     let Some(w) = weak.upgrade() else { return };
@@ -736,6 +850,12 @@ pub fn open(
                         finish_save(weak, result, Some(index));
                     });
                 }
+                PrinterKind::ImageWriter => {
+                    rt.spawn(async move {
+                        let result = rename_imagewriter(&ddp, printer.atp_addr(), &name).await;
+                        finish_save(weak, result, None);
+                    });
+                }
             }
         });
     }
@@ -749,19 +869,33 @@ pub fn open(
     *slot.borrow_mut() = Some(window);
 }
 
-/// Re-check a LaserWriter's PAP status every few seconds for as long as it stays
-/// selected, so the Condition line doesn't sit stale between the much slower
-/// PostScript queries.
+/// What one poll produced: either the whole info panel, or just a new Condition
+/// line for families whose other rows this poll can't refresh.
+enum PollUpdate {
+    Rows(Vec<Line>),
+    Condition(String),
+}
+
+/// Re-check a PAP printer's status every few seconds for as long as it stays
+/// selected, so the panel doesn't sit stale between the much slower full
+/// queries. A LaserWriter answers with a PostScript status string, an
+/// ImageWriter with the packed status word.
+///
+/// Both families poll over one `PapStatusHandle`, allocated once for the life of
+/// the poller rather than per tick, and needing no PAP connection to the printer.
 fn poll_status(
     rt: &tokio::runtime::Handle,
     weak: Weak<PrinterToolWindow>,
     ddp: DdpHandle,
     addr: AtpAddress,
+    kind: PrinterKind,
     generation: &Arc<AtomicU64>,
     my_gen: u64,
 ) {
     let generation = generation.clone();
     rt.spawn(async move {
+        let status_socket = PapStatusHandle::new(&ddp, addr).await;
+        let imagewriter = imagewriter::StatusHandle::from(status_socket.clone());
         let mut ticker = tokio::time::interval(Duration::from_secs(5));
         ticker.tick().await; // the initial query already left a fresh status
         loop {
@@ -769,8 +903,23 @@ fn poll_status(
             if generation.load(Ordering::SeqCst) != my_gen {
                 return;
             }
-            let (_, req, _) = Atp::spawn(&ddp, None).await;
-            let status = PapClient::get_status(req, addr).await;
+            let update = match kind {
+                // Every ImageWriter row comes from the status word, so re-render
+                // the panel instead of leaving the raw reply showing an older
+                // reading than the Condition line above it.
+                PrinterKind::ImageWriter => {
+                    imagewriter.read().await.map(|s| PollUpdate::Rows(imagewriter_lines(&s)))
+                }
+                // A LaserWriter's other rows come from PostScript queries this
+                // poll doesn't run, so only the condition is refreshed.
+                _ => status_socket.read_text().await.map(|s| {
+                    PollUpdate::Condition(if s.is_empty() {
+                        "No status string returned".to_string()
+                    } else {
+                        s
+                    })
+                }),
+            };
 
             let weak = weak.clone();
             let generation = generation.clone();
@@ -779,11 +928,11 @@ fn poll_status(
                 if generation.load(Ordering::SeqCst) != my_gen {
                     return;
                 }
-                set_condition(&w, match status {
-                    Ok(s) if !s.is_empty() => s,
-                    Ok(_) => "No status string returned".to_string(),
-                    Err(e) => format!("Unavailable: {e}"),
-                });
+                match update {
+                    Ok(PollUpdate::Rows(lines)) => w.set_info_rows(to_model(lines)),
+                    Ok(PollUpdate::Condition(s)) => set_condition(&w, s),
+                    Err(e) => set_condition(&w, format!("Unavailable: {e}")),
+                }
             });
             if posted.is_err() {
                 return; // the Slint event loop is gone — the app is shutting down

--- a/tailtalk-gui/ui/printer_tool.slint
+++ b/tailtalk-gui/ui/printer_tool.slint
@@ -5,6 +5,7 @@ export struct PrinterRow {
     kind: string,
     address: string,
     is-stylewriter: bool,
+    is-imagewriter: bool,
 }
 
 /// One line of the queried information panel. A section row renders as a
@@ -35,13 +36,16 @@ export component PrinterToolWindow inherits Window {
     in property <bool> detail-loaded: false;
 
     // Editable fields. Which apply depends on the selected printer's kind.
-    in-out property <string> edit-name;                 // StyleWriter rename
+    in-out property <string> edit-name;                 // rename (all families)
+    in property <int> name-max: 31;                     // set per family from Rust
     in-out property <int> paper-index: 0;               // LaserWriter default paper
     in-out property <bool> startup-enabled: false;      // LaserWriter power-on test page
 
     property <bool> has-selection: root.selected >= 0 && root.selected < root.printers.length;
     property <bool> sel-is-sw: root.has-selection && root.printers[root.selected].is-stylewriter;
-    property <bool> sel-is-lw: root.has-selection && !root.sel-is-sw;
+    property <bool> sel-is-iw: root.has-selection && root.printers[root.selected].is-imagewriter;
+    // LaserWriter is the default family, so it is whatever is left over.
+    property <bool> sel-is-lw: root.has-selection && !root.sel-is-sw && !root.sel-is-iw;
 
     callback refresh();
     callback query(int);
@@ -232,12 +236,14 @@ export component PrinterToolWindow inherits Window {
                 // Editable settings
                 Text { text: "Settings"; font-weight: 700; }
 
-                if root.sel-is-sw : HorizontalBox {
+                // StyleWriter and ImageWriter both expose the name and nothing
+                // else, and both cap it at 31 characters.
+                if root.sel-is-sw || root.sel-is-iw : HorizontalBox {
                     padding: 0;
                     Text { text: "Name"; min-width: 120px; vertical-alignment: center; }
                     LineEdit {
                         text <=> root.edit-name;
-                        placeholder-text: "Printer name (1–31 characters)";
+                        placeholder-text: "Printer name (1–\{root.name-max} characters)";
                         enabled: root.detail-loaded && !root.busy;
                         horizontal-stretch: 1;
                     }
@@ -251,7 +257,7 @@ export component PrinterToolWindow inherits Window {
                         Text { text: "Name"; min-width: 120px; vertical-alignment: center; }
                         LineEdit {
                             text <=> root.edit-name;
-                            placeholder-text: "Printer name (1–32 characters)";
+                            placeholder-text: "Printer name (1–\{root.name-max} characters)";
                             enabled: root.detail-loaded && !root.busy;
                             horizontal-stretch: 1;
                         }

--- a/tailtalk/src/imagewriter.rs
+++ b/tailtalk/src/imagewriter.rs
@@ -1,0 +1,691 @@
+//! Printing and status queries for the Apple ImageWriter II/LQ LocalTalk
+//! Option Card.
+//!
+//! [`ImageWriter`] is the whole interface: find a printer by NBP name, open a
+//! PAP connection to it, read its status, and stream a job.
+//!
+//! ```no_run
+//! # use tailtalk::{TalkStack, imagewriter::ImageWriter};
+//! # async fn example(stack: &TalkStack, raster: Vec<u8>) -> anyhow::Result<()> {
+//! let mut printer = ImageWriter::connect_named(&stack.ddp, &stack.nbp, "=").await?;
+//! if printer.status().await?.out_of_paper() {
+//!     anyhow::bail!("load some paper first");
+//! }
+//! printer.print_bytes(&raster).await?;
+//! printer.close().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! The card has no PostScript interpreter, so a job is raw ImageWriter command
+//! bytes (Ghostscript's `iwhi`/`iwhic` devices produce them), not PostScript.
+//!
+//! It has no query language of its own either, so everything it will tell us
+//! arrives in the reply to a single PAP `SendStatus` call. Where a LaserWriter
+//! puts a PostScript status comment, the option card puts a three-byte status
+//! buffer: a length byte (always 2) followed by the two `statusBits` bytes.
+//! Reading it therefore goes through [`PapClient::get_status_bytes`] rather than
+//! the text-oriented `get_status`.
+//!
+//! Bit assignments. The starting point was the "PAP Status Buffer from an
+//! ImageWriter II/LQ LocalTalk Option Card" figure in Apple's PAP
+//! documentation, but the hardware does not agree with it, so treat the figure
+//! as a hint rather than a specification:
+//!
+//! ```text
+//!  15  14 13 12 11 10 9 8   7    6    5    4     3    2    1    0
+//! busy |<--- unused --->| ribbon feed  ?  cover paper jam fault active
+//! ```
+//!
+//! Confirmed against a real ImageWriter II:
+//!
+//!   * Bit 3 is **paper present**, not the figure's "off line", and it is
+//!     asserted when paper is loaded. An empty printer read `0x0080`; loading
+//!     paper changed it to `0x0088` and nothing else moved. It therefore reads
+//!     the opposite way round to the error bits around it.
+//!   * Bit 7 is the colour ribbon, set in both of those readings on a printer
+//!     with a colour ribbon fitted.
+//!   * Bit 5, which the figure labels paper-out, stayed clear while the printer
+//!     was genuinely out of paper. Whatever it is, it is not that.
+//!
+//! Everything else below is still only the figure's word. Bits 6, 4, 2, 1 and 0
+//! were clear in both confirmed readings, consistent with active-high
+//! conditions that never fired, but none has been deliberately triggered and
+//! checked. [`error_text`](ImageWriterStatus::error_text) reports the
+//! unconfirmed ones, so a surprising error there is as likely to be a wrong bit
+//! as a real fault.
+//!
+//! The card sends the low byte first, so the word is assembled little-endian
+//! even though AppleTalk is otherwise big-endian. Both confirmed readings put
+//! the meaningful bits in the byte that arrives first, which is also why the
+//! card's documented glitch reply is "all ones in the low byte".
+//!
+//! That glitch is occasional and not sticky: the card sometimes answers with
+//! every bit of the low byte set, and the call simply has to be repeated.
+//! [`StatusHandle::read`] does that; [`ImageWriterStatus::parse`] rejects it.
+
+use crate::atp::{Atp, AtpAddress};
+use crate::ddp::DdpHandle;
+use crate::nbp::NbpHandle;
+use crate::pap::{IMAGEWRITER_CHUNK_SIZE, PapClient, PapStatusHandle};
+use anyhow::{Result, anyhow};
+use encoding_rs::MACINTOSH;
+use tailtalk_packets::nbp::{EntityName, NbpTuple};
+use tokio::io::AsyncRead;
+
+/// The NBP type the LocalTalk Option Card registers itself under.
+pub const NBP_TYPE: &str = "ImageWriter";
+
+/// `ESC b`, the option card's rename command. See [`rename_command`].
+const RENAME_COMMAND: [u8; 2] = [0x1B, 0x62];
+
+/// Longest name the card is given. An NBP object name is at most 32 bytes, and
+/// the StyleWriter's rename caps at 31, so this matches that until hardware
+/// says otherwise.
+pub const MAX_NAME_LEN: usize = 31;
+
+const BUSY: u16 = 1 << 15;
+const COLOR_RIBBON: u16 = 1 << 7;
+const SHEET_FEEDER: u16 = 1 << 6;
+const COVER_OPEN: u16 = 1 << 4;
+/// Set while paper is loaded, so this reads the opposite way round to the
+/// error bits. See the module note on which bits are confirmed.
+const PAPER_PRESENT: u16 = 1 << 3;
+const PAPER_JAM: u16 = 1 << 2;
+const FAULT: u16 = 1 << 1;
+const ACTIVE: u16 = 1 << 0;
+
+const LOW_BYTE: u16 = 0x00FF;
+
+/// How many PAP status calls [`StatusHandle::read`] makes before giving up on
+/// the card returning a valid word.
+pub const DEFAULT_STATUS_ATTEMPTS: usize = 3;
+
+/// A decoded `statusBits` word from an ImageWriter II/LQ LocalTalk Option Card.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ImageWriterStatus {
+    /// The raw word, kept verbatim so callers can inspect the undocumented
+    /// bits 8 to 14.
+    pub raw: u16,
+}
+
+impl ImageWriterStatus {
+    /// Decode the status buffer returned by [`PapClient::get_status_bytes`],
+    /// i.e. the two `statusBits` bytes with the leading length byte already
+    /// stripped. The low byte comes first.
+    ///
+    /// Fails when the buffer is too short, or when the card returned the
+    /// all-ones low byte that marks an invalid reply. Prefer
+    /// [`StatusHandle::read`], which retries that case for you.
+    pub fn parse(status_buffer: &[u8]) -> Result<Self> {
+        let bytes = status_buffer.get(..2).ok_or_else(|| {
+            anyhow!(
+                "ImageWriter status buffer is {} byte(s), expected 2",
+                status_buffer.len()
+            )
+        })?;
+        let raw = u16::from_le_bytes([bytes[0], bytes[1]]);
+        if !Self::is_valid(raw) {
+            return Err(anyhow!(
+                "ImageWriter returned an invalid status word (0x{raw:04X}): \
+                 all ones in the low byte means the reply must be repeated"
+            ));
+        }
+        Ok(Self { raw })
+    }
+
+    /// False for the card's glitch reply, an all-ones low byte, which makes the
+    /// whole word meaningless.
+    pub fn is_valid(raw: u16) -> bool {
+        raw & LOW_BYTE != LOW_BYTE
+    }
+
+    /// The two bytes as they arrived on the wire, low byte first, for showing
+    /// an unaltered reading next to the decode.
+    pub fn wire_bytes(&self) -> [u8; 2] {
+        self.raw.to_le_bytes()
+    }
+
+    /// The printer is busy (bit 15), i.e. it already has a PAP connection open.
+    pub fn busy(&self) -> bool {
+        self.raw & BUSY != 0
+    }
+
+    /// A colour ribbon is installed (bit 7). The only capability bit the card
+    /// exposes.
+    pub fn color_ribbon(&self) -> bool {
+        self.raw & COLOR_RIBBON != 0
+    }
+
+    /// A cut-sheet feeder is installed (bit 6). Unconfirmed, see the module
+    /// note; it only changes the wording of the jam text.
+    pub fn sheet_feeder(&self) -> bool {
+        self.raw & SHEET_FEEDER != 0
+    }
+
+    /// Paper is loaded (bit 3). Confirmed on real hardware: loading paper is
+    /// what sets this bit. Note the sense, it is asserted when all is well.
+    pub fn paper_present(&self) -> bool {
+        self.raw & PAPER_PRESENT != 0
+    }
+
+    /// Raw paper-jam bit (bit 2). Unconfirmed, see the module note.
+    pub fn paper_jam_bit(&self) -> bool {
+        self.raw & PAPER_JAM != 0
+    }
+
+    /// The cover is open (bit 4). Unconfirmed, see the module note.
+    pub fn cover_open(&self) -> bool {
+        self.raw & COVER_OPEN != 0
+    }
+
+    /// A general printer fault is asserted (bit 1). Unconfirmed, see the module
+    /// note.
+    pub fn fault(&self) -> bool {
+        self.raw & FAULT != 0
+    }
+
+    /// The printer is actively printing, i.e. the head is moving (bit 0).
+    pub fn active(&self) -> bool {
+        self.raw & ACTIVE != 0
+    }
+
+    /// Whether the printer is out of paper, i.e. [`paper_present`] is clear.
+    ///
+    /// [`paper_present`]: Self::paper_present
+    pub fn out_of_paper(&self) -> bool {
+        !self.paper_present()
+    }
+
+    /// Every error condition the card is reporting, or `None` when it reports
+    /// none. Ready-but-busy is not an error and does not appear here.
+    pub fn error_text(&self) -> Option<String> {
+        let mut errors: Vec<&str> = Vec::new();
+        if self.out_of_paper() {
+            errors.push("Out of paper");
+        }
+        if self.paper_jam_bit() {
+            errors.push(if self.sheet_feeder() {
+                "Paper jam or sheet feeder empty"
+            } else {
+                "Paper jam"
+            });
+        }
+        if self.cover_open() {
+            errors.push("Cover open");
+        }
+        if self.fault() {
+            errors.push("Printer fault");
+        }
+        (!errors.is_empty()).then(|| errors.join(", "))
+    }
+
+    /// Which ribbon is installed, in the same shape as the StyleWriter's
+    /// cartridge readout so both printer tools can present it alike.
+    pub fn ribbon_text(&self) -> &'static str {
+        if self.color_ribbon() {
+            "Color"
+        } else {
+            "Black only"
+        }
+    }
+}
+
+/// A connection to an ImageWriter II/LQ LocalTalk Option Card.
+///
+/// The card speaks PAP, so this wraps a [`PapClient`] with the pieces specific
+/// to the ImageWriter: the chunk size it needs, its packed status word, and the
+/// fact that a job is raw command bytes with no interpreter behind it and so no
+/// job output to read back.
+///
+/// Holding one of these holds the printer's single PAP connection open, which
+/// every other host sees as the busy bit, so [`close`](Self::close) as soon as
+/// the job is done. Status can be read without a connection at all, via
+/// [`ImageWriter::status_of`].
+///
+/// Two ATP sockets are allocated: one carrying the PAP connection, and one for
+/// status queries, which keeps polling entirely clear of the job's transactions.
+/// See [`StatusHandle`].
+pub struct ImageWriter {
+    pap: PapClient,
+    status: StatusHandle,
+    address: AtpAddress,
+}
+
+impl ImageWriter {
+    /// Find ImageWriters on the network. `object` is an NBP object name, `=`
+    /// for any, and the type is always [`NBP_TYPE`].
+    pub async fn lookup(nbp: &NbpHandle, object: &str) -> Result<Vec<NbpTuple>> {
+        let entity = EntityName {
+            object: object.to_string(),
+            entity_type: NBP_TYPE.to_string(),
+            zone: "*".to_string(),
+        };
+        Ok(nbp.lookup(entity).await?)
+    }
+
+    /// Open a PAP connection to the printer at `address`.
+    pub async fn connect(ddp: &DdpHandle, address: AtpAddress) -> Result<Self> {
+        let (_, req, resp) = Atp::spawn(ddp, None).await;
+        let mut pap = PapClient::new(req, resp);
+        pap.connect(address).await?;
+        pap.chunk_size = Some(IMAGEWRITER_CHUNK_SIZE);
+        let status = StatusHandle::new(ddp, address).await;
+        Ok(Self {
+            pap,
+            status,
+            address,
+        })
+    }
+
+    /// Look an ImageWriter up by NBP object name and connect to the first one
+    /// that answers. Pass `=` to take whichever ImageWriter is on the network.
+    pub async fn connect_named(ddp: &DdpHandle, nbp: &NbpHandle, object: &str) -> Result<Self> {
+        let tuples = Self::lookup(nbp, object).await?;
+        let printer = tuples.first().ok_or_else(|| {
+            anyhow!("no ImageWriter named '{object}:{NBP_TYPE}@*' on the network")
+        })?;
+        tracing::info!(
+            "ImageWriter: found {} at {}.{} socket {}",
+            printer.entity_name,
+            printer.network_number,
+            printer.node_id,
+            printer.socket_number
+        );
+        Self::connect(ddp, printer.service_address().into()).await
+    }
+
+    /// Read the printer's status word without opening a connection, so this
+    /// works against a printer that is busy or mid-job. For repeated reads,
+    /// keep a [`StatusHandle`] instead: this allocates a socket per call.
+    pub async fn status_of(ddp: &DdpHandle, address: AtpAddress) -> Result<ImageWriterStatus> {
+        StatusHandle::new(ddp, address).await.read().await
+    }
+
+    /// Read the printer's status word over this session's status socket.
+    pub async fn status(&self) -> Result<ImageWriterStatus> {
+        self.status.read().await
+    }
+
+    /// A status reader that borrows nothing from the session, so it can run
+    /// while [`print`](Self::print) holds `&mut self`. See [`StatusHandle`].
+    pub fn status_handle(&self) -> StatusHandle {
+        self.status.clone()
+    }
+
+    /// Stream a job to the printer: raw ImageWriter command bytes, as produced
+    /// by Ghostscript's `iwhi` (mono) or `iwhic` (colour ribbon) device.
+    pub async fn print<R: AsyncRead + Unpin>(&mut self, source: R) -> Result<()> {
+        self.pap.print_stream(source).await
+    }
+
+    /// [`print`](Self::print) for a job already in memory.
+    pub async fn print_bytes(&mut self, data: &[u8]) -> Result<()> {
+        self.print(std::io::Cursor::new(data)).await
+    }
+
+    /// Rename the printer, which is the one setting the option card holds.
+    ///
+    /// The new name is what the card registers with NBP, so it is what the
+    /// Chooser and [`lookup`](Self::lookup) will show. It survives a power
+    /// cycle, and the card re-registers itself, so a lookup shortly afterwards
+    /// should find the printer under the new name.
+    ///
+    /// See [`rename_command`] for the wire format and the caveats on it.
+    pub async fn set_name(&mut self, name: &str) -> Result<()> {
+        self.print_bytes(&rename_command(name)?).await
+    }
+
+    /// The address this connection was opened to.
+    pub fn address(&self) -> AtpAddress {
+        self.address
+    }
+
+    /// Close the PAP connection, releasing the printer for other hosts.
+    pub async fn close(mut self) -> Result<()> {
+        self.pap.close().await
+    }
+}
+
+/// Build the option card's rename command: `ESC b` followed by the new name as
+/// a MacRoman Pascal string (one length byte, then the bytes).
+///
+/// `ESC b` is unassigned in the ImageWriter II's own command set (it appears
+/// nowhere in the Technical Reference Manual's command summary), which is what
+/// leaves it free for the card to claim. The card intercepts it rather than
+/// passing it through to the printer, so the command is sent the same way a
+/// job is, as PAP data.
+///
+/// Names are capped at [`MAX_NAME_LEN`] and may not contain the NBP delimiters
+/// `:`, `@` or `*`. Characters MacRoman cannot represent are rejected rather
+/// than substituted, since a mangled name is one the Chooser will show and we
+/// would then have to look up.
+pub fn rename_command(name: &str) -> Result<Vec<u8>> {
+    if name.is_empty() {
+        return Err(anyhow!("printer name cannot be empty"));
+    }
+    if name.contains([':', '@', '*']) {
+        return Err(anyhow!("printer name cannot contain ':', '@', or '*'"));
+    }
+
+    let (bytes, _, unmappable) = MACINTOSH.encode(name);
+    if unmappable {
+        return Err(anyhow!(
+            "printer name contains characters MacRoman cannot represent"
+        ));
+    }
+    if bytes.len() > MAX_NAME_LEN {
+        return Err(anyhow!(
+            "printer name is {} bytes, the maximum is {MAX_NAME_LEN}",
+            bytes.len()
+        ));
+    }
+
+    let mut cmd = Vec::with_capacity(3 + bytes.len());
+    cmd.extend_from_slice(&RENAME_COMMAND);
+    cmd.push(bytes.len() as u8);
+    cmd.extend_from_slice(&bytes);
+    Ok(cmd)
+}
+
+/// Reads an ImageWriter's status independently of the [`ImageWriter`] session
+/// it came from, so a job can be watched while it prints.
+///
+/// This is [`PapStatusHandle`] (its own ATP socket, no PAP connection, safe to
+/// call mid-job) plus the ImageWriter's decode: the packed status word, and the
+/// retry that rides out the card's glitch reply.
+///
+/// Poll gently. Each read is a round trip on a bus the job is already saturating
+/// (a few seconds between reads is plenty), and expect
+/// [`busy`](ImageWriterStatus::busy) to be set throughout: that is our own
+/// connection. The bits worth watching during a job are
+/// [`active`](ImageWriterStatus::active) and the error bits.
+///
+/// ```no_run
+/// # use std::time::Duration;
+/// # use tailtalk::imagewriter::ImageWriter;
+/// # async fn example(printer: &mut ImageWriter, raster: Vec<u8>) -> anyhow::Result<()> {
+/// let status = printer.status_handle();
+/// let mut ticker = tokio::time::interval(Duration::from_secs(5));
+/// ticker.tick().await; // the first tick is immediate
+///
+/// tokio::select! {
+///     result = printer.print_bytes(&raster) => result?,
+///     // Never finishes, so the job is always what ends the select.
+///     _ = async {
+///         loop {
+///             ticker.tick().await;
+///             match status.read().await {
+///                 Ok(s) => println!("printing={} {}", s.active(), s.error_text().unwrap_or_default()),
+///                 Err(e) => tracing::warn!("status poll failed: {e}"),
+///             }
+///         }
+///     } => {}
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+/// The handle keeps its ATP socket alive for as long as it (or any clone of it)
+/// exists, so drop it once you are done watching.
+#[derive(Clone)]
+pub struct StatusHandle {
+    pap: PapStatusHandle,
+}
+
+impl From<PapStatusHandle> for StatusHandle {
+    /// Add the ImageWriter decode to a status socket that already exists, for
+    /// callers polling a printer whose family isn't known until runtime.
+    fn from(pap: PapStatusHandle) -> Self {
+        Self { pap }
+    }
+}
+
+impl StatusHandle {
+    /// Allocate a status socket for the printer at `address`. No PAP connection
+    /// is opened, so this works against a busy printer, and works with no
+    /// [`ImageWriter`] session at all.
+    pub async fn new(ddp: &DdpHandle, address: AtpAddress) -> Self {
+        Self {
+            pap: PapStatusHandle::new(ddp, address).await,
+        }
+    }
+
+    /// Read the status word, retrying the card's glitch reply
+    /// [`DEFAULT_STATUS_ATTEMPTS`] times.
+    pub async fn read(&self) -> Result<ImageWriterStatus> {
+        self.read_with_attempts(DEFAULT_STATUS_ATTEMPTS).await
+    }
+
+    /// [`read`](Self::read) with an explicit retry count.
+    pub async fn read_with_attempts(&self, attempts: usize) -> Result<ImageWriterStatus> {
+        let attempts = attempts.max(1);
+        let mut last_err = None;
+        for attempt in 1..=attempts {
+            let buf = self.pap.read_bytes().await?;
+            // Log the unaltered buffer: a raw reading is what any "this status
+            // looks wrong" report will need.
+            tracing::debug!(
+                "ImageWriter status buffer (attempt {attempt}/{attempts}): {}",
+                buf.iter()
+                    .map(|b| format!("{b:02X}"))
+                    .collect::<Vec<_>>()
+                    .join(" "),
+            );
+            match ImageWriterStatus::parse(&buf) {
+                Ok(status) => return Ok(status),
+                Err(e) => {
+                    tracing::debug!(
+                        "ImageWriter status attempt {attempt}/{attempts} rejected: {e}"
+                    );
+                    last_err = Some(e);
+                }
+            }
+        }
+        Err(last_err.unwrap_or_else(|| anyhow!("ImageWriter status query made no attempts")))
+    }
+
+    /// The printer this handle reads from.
+    pub fn address(&self) -> AtpAddress {
+        self.pap.address()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a status buffer the way the card sends it: low byte first.
+    fn wire(low: u8, high: u8) -> [u8; 2] {
+        [low, high]
+    }
+
+    #[test]
+    fn rename_command_is_esc_b_then_a_pascal_string() {
+        assert_eq!(
+            rename_command("Lobby").unwrap(),
+            b"\x1Bb\x05Lobby",
+            "ESC b, one length byte, then the name"
+        );
+        // The length byte counts encoded bytes, and MacRoman is single byte, so
+        // an accented name stays one byte per character rather than UTF-8's two.
+        let cmd = rename_command("Café").unwrap();
+        assert_eq!(cmd[..3], [0x1B, 0x62, 4]);
+        assert_eq!(cmd.len(), 7);
+    }
+
+    /// A name the Chooser will display and NBP has to carry, so reject anything
+    /// that would arrive mangled rather than silently substituting.
+    #[test]
+    fn rename_command_rejects_unusable_names() {
+        assert!(rename_command("").is_err());
+        // NBP entity-name delimiters.
+        assert!(rename_command("Front:Desk").is_err());
+        assert!(rename_command("Front@Desk").is_err());
+        assert!(rename_command("Front*Desk").is_err());
+        // Not representable in MacRoman.
+        assert!(rename_command("Printer \u{4E2D}").is_err());
+        // One over the cap, counted in encoded bytes.
+        assert!(rename_command(&"a".repeat(MAX_NAME_LEN)).is_ok());
+        assert!(rename_command(&"a".repeat(MAX_NAME_LEN + 1)).is_err());
+    }
+
+    /// Pins each bit position we decode. Bit 5 is deliberately absent: the
+    /// figure calls it paper-out, but the hardware left it clear with the
+    /// printer empty, so nothing is decoded from it.
+    #[test]
+    fn decodes_each_documented_bit() {
+        let s = ImageWriterStatus::parse(&wire(0x00, 0x80)).unwrap();
+        assert!(s.busy() && !s.color_ribbon() && !s.active());
+
+        let s = ImageWriterStatus::parse(&wire(0x80, 0x00)).unwrap();
+        assert!(s.color_ribbon() && !s.sheet_feeder());
+
+        let s = ImageWriterStatus::parse(&wire(0x40, 0x00)).unwrap();
+        assert!(s.sheet_feeder() && !s.color_ribbon());
+
+        let s = ImageWriterStatus::parse(&wire(0x20, 0x00)).unwrap();
+        assert!(
+            s.out_of_paper(),
+            "bit 5 is not decoded, bit 3 is still clear"
+        );
+
+        let s = ImageWriterStatus::parse(&wire(0x10, 0x00)).unwrap();
+        assert!(s.cover_open());
+
+        let s = ImageWriterStatus::parse(&wire(0x08, 0x00)).unwrap();
+        assert!(s.paper_present() && !s.out_of_paper());
+
+        let s = ImageWriterStatus::parse(&wire(0x04, 0x00)).unwrap();
+        assert!(s.paper_jam_bit());
+
+        let s = ImageWriterStatus::parse(&wire(0x02, 0x00)).unwrap();
+        assert!(s.fault());
+
+        let s = ImageWriterStatus::parse(&wire(0x01, 0x00)).unwrap();
+        assert!(s.active());
+    }
+
+    /// The pair of readings that pin bit 3, taken from a real ImageWriter II
+    /// with a colour ribbon and no sheet feeder. Only one thing changed between
+    /// them: paper was loaded. Only one bit moved with it.
+    #[test]
+    fn matches_observed_hardware_readings() {
+        // Empty printer.
+        let empty = ImageWriterStatus::parse(&[0x80, 0x00]).unwrap();
+        assert_eq!(empty.raw, 0x0080);
+        assert!(empty.out_of_paper(), "printer had no paper in it");
+        assert_eq!(empty.error_text().as_deref(), Some("Out of paper"));
+
+        // Same printer, paper loaded.
+        let loaded = ImageWriterStatus::parse(&[0x88, 0x00]).unwrap();
+        assert_eq!(loaded.raw, 0x0088);
+        assert!(loaded.paper_present(), "printer had paper in it");
+        assert_eq!(loaded.error_text(), None, "a ready printer has no errors");
+
+        // Loading paper moved bit 3 and nothing else.
+        assert_eq!(empty.raw ^ loaded.raw, PAPER_PRESENT);
+
+        // Both readings agree on the rest of the printer's state.
+        for s in [empty, loaded] {
+            assert!(s.color_ribbon(), "printer had a colour ribbon fitted");
+            assert!(!s.sheet_feeder(), "printer had no sheet feeder");
+            assert!(!s.busy(), "printer was idle");
+            // Nothing lands in the unused 8..=14 range.
+            assert_eq!(s.raw & 0x7F00, 0);
+        }
+    }
+
+    /// Capability bits come out of the first byte, the busy bit out of the second.
+    #[test]
+    fn word_is_little_endian_on_the_wire() {
+        let s = ImageWriterStatus::parse(&[0x80, 0x80]).unwrap();
+        assert_eq!(s.raw, 0x8080);
+        assert!(s.busy() && s.color_ribbon());
+        // Round-trips back to the bytes the card sent.
+        assert_eq!(s.wire_bytes(), [0x80, 0x80]);
+
+        let s = ImageWriterStatus::parse(&[0x01, 0x80]).unwrap();
+        assert_eq!(s.wire_bytes(), [0x01, 0x80]);
+        assert!(s.busy() && s.active());
+    }
+
+    /// A black ribbon must not be mistaken for a colour one: that bit decides
+    /// the IPP colour advertisement and the Ghostscript device.
+    #[test]
+    fn black_ribbon_is_not_color() {
+        // Idle, black ribbon, nothing else asserted.
+        assert!(
+            !ImageWriterStatus::parse(&wire(0x00, 0x00))
+                .unwrap()
+                .color_ribbon()
+        );
+        // Busy with a black ribbon: the busy bit must not leak into the ribbon read.
+        assert!(
+            !ImageWriterStatus::parse(&wire(0x00, 0x80))
+                .unwrap()
+                .color_ribbon()
+        );
+    }
+
+    /// The jam bit's wording depends on whether a feeder is fitted, since with
+    /// one an empty tray is said to raise it too. Both the bit and that
+    /// distinction come from the figure and neither is confirmed; paper is
+    /// present in each case here so the confirmed bit stays out of the way.
+    #[test]
+    fn sheet_feeder_changes_the_jam_wording() {
+        let paper = PAPER_PRESENT as u8;
+
+        let feeder =
+            ImageWriterStatus::parse(&wire(paper | SHEET_FEEDER as u8 | PAPER_JAM as u8, 0x00))
+                .unwrap();
+        assert_eq!(
+            feeder.error_text().as_deref(),
+            Some("Paper jam or sheet feeder empty")
+        );
+
+        let no_feeder = ImageWriterStatus::parse(&wire(paper | PAPER_JAM as u8, 0x00)).unwrap();
+        assert_eq!(no_feeder.error_text().as_deref(), Some("Paper jam"));
+    }
+
+    /// The glitch reply must be rejected rather than decoded as "every error at
+    /// once".
+    #[test]
+    fn rejects_all_ones_low_byte() {
+        assert!(ImageWriterStatus::parse(&[0xFF, 0x00]).is_err());
+        assert!(ImageWriterStatus::parse(&[0xFF, 0x80]).is_err());
+        assert!(!ImageWriterStatus::is_valid(0x00FF));
+        // A high byte of ones is not the documented glitch, so it stays valid.
+        assert!(ImageWriterStatus::is_valid(0xFF00));
+    }
+
+    #[test]
+    fn rejects_short_buffer() {
+        assert!(ImageWriterStatus::parse(&[]).is_err());
+        assert!(ImageWriterStatus::parse(&[0x00]).is_err());
+    }
+
+    /// Extra trailing bytes are ignored rather than rejected: only the first
+    /// two are the status word.
+    #[test]
+    fn ignores_trailing_bytes() {
+        let s = ImageWriterStatus::parse(&[0x80, 0x00, 0xAA]).unwrap();
+        assert_eq!(s.raw, 0x0080);
+    }
+
+    /// A ready printer has paper, so bit 3 is part of every no-error reading.
+    #[test]
+    fn idle_printer_reports_no_error() {
+        let paper = PAPER_PRESENT as u8;
+
+        let s = ImageWriterStatus::parse(&wire(paper | 0x80, 0x00)).unwrap();
+        assert_eq!(s.error_text(), None);
+        assert_eq!(s.ribbon_text(), "Color");
+
+        // Busy and actively printing is a state, not an error.
+        let s = ImageWriterStatus::parse(&wire(paper | 0x01, 0x80)).unwrap();
+        assert_eq!(s.error_text(), None);
+        assert!(s.busy() && s.active());
+        assert_eq!(s.ribbon_text(), "Black only");
+    }
+}

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -22,6 +22,7 @@ pub mod atp;
 
 pub mod ddp;
 pub mod echo;
+pub mod imagewriter;
 pub mod nbp;
 pub mod pap;
 pub mod remote;
@@ -764,9 +765,43 @@ impl TalkStack {
     }
 
     /// Query the status string of a PAP printer without opening a full connection.
+    /// For repeated reads, keep a [`pap_status_handle`](Self::pap_status_handle):
+    /// this allocates a socket per call.
     pub async fn pap_status(&self, address: atp::AtpAddress) -> anyhow::Result<String> {
-        let (_, atp_requestor, _) = atp::Atp::spawn(&self.ddp, None).await;
-        pap::PapClient::get_status(atp_requestor, address).await
+        self.pap_status_handle(address).await.read_text().await
+    }
+
+    /// A reusable status socket for the PAP printer at `address`, independent of
+    /// any print connection, so it can be polled while a job streams.
+    pub async fn pap_status_handle(&self, address: atp::AtpAddress) -> pap::PapStatusHandle {
+        pap::PapStatusHandle::new(&self.ddp, address).await
+    }
+
+    /// Query an ImageWriter II/LQ LocalTalk Option Card's packed status word,
+    /// which is what that card returns instead of a PAP status string. No
+    /// connection is opened.
+    pub async fn imagewriter_status(
+        &self,
+        address: atp::AtpAddress,
+    ) -> anyhow::Result<imagewriter::ImageWriterStatus> {
+        imagewriter::ImageWriter::status_of(&self.ddp, address).await
+    }
+
+    /// Connect to the ImageWriter at `address`.
+    pub async fn imagewriter(
+        &self,
+        address: atp::AtpAddress,
+    ) -> anyhow::Result<imagewriter::ImageWriter> {
+        imagewriter::ImageWriter::connect(&self.ddp, address).await
+    }
+
+    /// Look an ImageWriter up by NBP object name (`=` for any) and connect to
+    /// the first one that answers.
+    pub async fn imagewriter_named(
+        &self,
+        object: &str,
+    ) -> anyhow::Result<imagewriter::ImageWriter> {
+        imagewriter::ImageWriter::connect_named(&self.ddp, &self.nbp, object).await
     }
 
     /// Create a PAP printer emulator.

--- a/tailtalk/src/pap.rs
+++ b/tailtalk/src/pap.rs
@@ -52,6 +52,12 @@ fn remember_reply(
     cache.push_back((seq, user_bytes, data));
 }
 
+/// [`PapClient::chunk_size`] for the ImageWriter II/LQ LocalTalk Option Card:
+/// one ATP packet's worth per SendData cycle. The card handles the full
+/// bitmap-derived capacity poorly, and this is the size verified against real
+/// hardware.
+pub const IMAGEWRITER_CHUNK_SIZE: usize = 512;
+
 #[derive(Debug)]
 pub struct PapClient {
     atp_requestor: AtpRequestor,
@@ -404,6 +410,18 @@ impl PapClient {
     }
 
     pub async fn get_status(atp: AtpRequestor, address: AtpAddress) -> Result<String> {
+        let buf = Self::get_status_bytes(atp, address).await?;
+        Ok(String::from_utf8_lossy(&buf).to_string())
+    }
+
+    /// The raw contents of the PAP status buffer, with the length byte already
+    /// consumed but no assumption that the payload is text.
+    ///
+    /// LaserWriters put a PostScript status comment here, which is what
+    /// [`get_status`](Self::get_status) returns. An ImageWriter II/LQ LocalTalk
+    /// Option Card instead answers with a two-byte packed `statusBits` word
+    /// that a lossy UTF-8 conversion would mangle (see [`crate::imagewriter`]).
+    pub async fn get_status_bytes(atp: AtpRequestor, address: AtpAddress) -> Result<Vec<u8>> {
         let pkt = PapPacket {
             connection_id: 0,
             function: PapFunction::SendStatus,
@@ -431,7 +449,52 @@ impl PapClient {
             ));
         };
         let end = (5 + len as usize).min(reply.data.len());
-        Ok(String::from_utf8_lossy(&reply.data[5..end]).to_string())
+        Ok(reply.data[5..end].to_vec())
+    }
+}
+
+/// A dedicated ATP socket for PAP `SendStatus` calls.
+///
+/// `SendStatus` is connectionless: it carries connection ID 0 to the printer's
+/// NBP-advertised socket rather than the per-connection socket a job streams
+/// over, so it needs no PAP connection and is answered even mid-job.
+///
+/// Giving it a socket of its own is what makes polling during a print safe. The
+/// poll shares no transaction state with the job, cannot interleave with the
+/// printer's `SendData` traffic, and the handle can outlive the session that
+/// created it. Reusing one handle also beats a socket per poll.
+///
+/// The reply's meaning is printer-specific: a LaserWriter puts a PostScript
+/// status comment here, so use [`read_text`](Self::read_text); an ImageWriter
+/// option card puts a packed status word, which [`crate::imagewriter`] decodes
+/// on top of [`read_bytes`](Self::read_bytes).
+#[derive(Clone)]
+pub struct PapStatusHandle {
+    atp: AtpRequestor,
+    address: AtpAddress,
+}
+
+impl PapStatusHandle {
+    /// Allocate a status socket for the printer at `address`. Opens no PAP
+    /// connection, so this works against a printer that is busy or printing.
+    pub async fn new(ddp: &DdpHandle, address: AtpAddress) -> Self {
+        let (_, atp, _) = Atp::spawn(ddp, None).await;
+        Self { atp, address }
+    }
+
+    /// The printer this handle reads from.
+    pub fn address(&self) -> AtpAddress {
+        self.address
+    }
+
+    /// The raw status buffer, for printers whose reply is not text.
+    pub async fn read_bytes(&self) -> Result<Vec<u8>> {
+        PapClient::get_status_bytes(self.atp.clone(), self.address).await
+    }
+
+    /// The status buffer as text, for PostScript printers.
+    pub async fn read_text(&self) -> Result<String> {
+        PapClient::get_status(self.atp.clone(), self.address).await
     }
 }
 


### PR DESCRIPTION
Discover printers advertising the NBP type "ImageWriter" and expose them as AirPrint queues, alongside the LaserWriter/PAP and StyleWriter/ADSP paths. These are ImageWriter II or LQ printers with the LocalTalk Option Card, which speaks PAP but has no PostScript interpreter, so jobs are rasterized with Ghostscript's iwhi/iwhic devices and the raw command bytes streamed over. The installed ribbon picks the device and decides whether the queue advertises colour.

New tailtalk::imagewriter module is the API for it: look a printer up by NBP name, connect, read its status, rename it, stream a job. Renaming is the one setting the card holds. Status comes back as a packed statusBits word rather than a text string, and reads through PapStatusHandle, a new type in pap.rs that holds an ATP socket of its own so status can be polled while a job is streaming. LaserWriter status reads through the same handle.

The Printer Tool lists ImageWriters alongside the other two families and offers the same Name field. The IPP bridge keeps a printer registered while it has a job on it, since a job can run for minutes and the printer may not answer NBP for any of it.

Also adds the iw-print example and a retry flag for nbp-lookup.