### PR TITLE
GUI: Fix title bar being transparent on macOS 27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6723,6 +6723,7 @@ dependencies = [
  "binhex-rs",
  "dirs",
  "hfs-reader",
+ "i-slint-backend-winit",
  "if-addrs",
  "ipp",
  "keepawake",

--- a/tailtalk-gui/Cargo.toml
+++ b/tailtalk-gui/Cargo.toml
@@ -44,6 +44,11 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [target.'cfg(target_os = "macos")'.dependencies]
 tailtalk = { workspace = true, features = ["ethertalk"] }
 libc = "0.2"
+# Only to reach `Backend::builder()` and turn off the transparent window Slint
+# asks winit for by default. `default-features = false` so the renderer choice
+# stays whatever the `slint` dependency selects; Cargo unifies the two. Version
+# must track `slint` exactly, these crates ship in lockstep.
+i-slint-backend-winit = { version = "=1.17.1", default-features = false }
 
 [build-dependencies]
 slint-build = "1"

--- a/tailtalk-gui/main.rs
+++ b/tailtalk-gui/main.rs
@@ -264,7 +264,29 @@ fn open_in_file_manager(path: &Path) {
 
 // ── Entry point ───────────────────────────────────────────────────────────────
 
+/// Slint asks winit for a transparent window unconditionally (it only backs that
+/// out on Windows), and winit turns `transparent` into `NSWindow.setOpaque(false)`
+/// plus a clear background colour. Through macOS 26 AppKit drew the title bar
+/// material regardless; on macOS 27 the bar follows the window background, so it
+/// disappears and the traffic lights are left floating over our content. Nothing
+/// here wants a see-through window, so ask for an opaque one.
+#[cfg(target_os = "macos")]
+fn install_opaque_backend() -> anyhow::Result<()> {
+    let backend = i_slint_backend_winit::Backend::builder()
+        .with_window_attributes_hook(|attributes| attributes.with_transparent(false))
+        .build()
+        .map_err(|e| anyhow::anyhow!("winit backend: {e}"))?;
+    slint::platform::set_platform(Box::new(backend))
+        .map_err(|e| anyhow::anyhow!("setting the Slint platform: {e}"))?;
+    Ok(())
+}
+
 fn main() -> anyhow::Result<()> {
+    // Before any window exists, or the platform is already fixed.
+    #[cfg(target_os = "macos")]
+    install_opaque_backend()?;
+
+
     let (cmd_tx, cmd_rx) = tokio::sync::mpsc::channel::<ServerCommand>(4);
     // Shared handle used to shut the stack down when the window closes.
     let active_handle: Arc<tokio::sync::Mutex<Option<ShutdownHandle>>> =


### PR DESCRIPTION
Fixes the menu bar from being totally transparent and look like its floating on top of the window in macOS 27 / Golden Gate.