### PR TITLE
ImageWriter: Fix large page rendering and status bits

### DIFF
--- a/examples/iw-print/main.rs
+++ b/examples/iw-print/main.rs
@@ -171,6 +171,18 @@ async fn main() -> anyhow::Result<()> {
             "not installed"
         }
     );
+    println!(
+        "  Paper:        {}",
+        if status.paper_present() {
+            "loaded"
+        } else {
+            "out of paper"
+        }
+    );
+    println!(
+        "  Select:       {}",
+        if status.off_line() { "off line" } else { "on line" }
+    );
     println!("  Busy:         {}", status.busy());
     println!("  Printing:     {}", status.active());
     match status.error_text() {
@@ -181,8 +193,11 @@ async fn main() -> anyhow::Result<()> {
     if args.status_only {
         return Ok(());
     }
-    if status.out_of_paper() {
-        anyhow::bail!("printer reports no paper loaded, refusing to print");
+    if !status.ready_to_print() {
+        anyhow::bail!(
+            "printer is not ready ({}), refusing to print",
+            status.error_text().unwrap_or_default()
+        );
     }
 
     let color = status.color_ribbon() && !args.mono;

--- a/tailtalk-gui/ipp_bridge.rs
+++ b/tailtalk-gui/ipp_bridge.rs
@@ -203,6 +203,28 @@ const IW_MAX_WIDTH_PT: f32 = 612.0;
 /// 144dpi). Anything else makes gdevadmp's internal band-buffer sizing return a
 /// negative "unexpected value" and abort the whole job.
 const IW_HEIGHT_GRANULARITY_PT: f32 = 24.0;
+/// Ceiling in bytes on the full-page bitmap Ghostscript keeps for the
+/// ImageWriter devices.
+///
+/// `iwhi`/`iwhic` render an entirely blank page whenever Ghostscript takes its
+/// banded (clist) path. That is specific to this device: `pbmraw`, `ppmraw` and
+/// `bitcmyk` all produce byte-identical output banded or not, while `iwhi` goes
+/// blank under `-dMaxBitmap=0` even for a page with no transparency on it.
+/// Ghostscript switches to banding the moment the page buffer would exceed
+/// `MaxBitmap`, which defaults to 10MB, so the device works until a document
+/// needs more than that and then silently prints nothing.
+///
+/// A transparent object is all it takes: the page then renders through the
+/// compositor at ~20 bytes per device pixel, measured as 43MB for Letter and
+/// 54MB for a 14in page at 160x144dpi. This is a threshold rather than an
+/// allocation, so the number only has to clear that with room to spare;
+/// Ghostscript still takes what the page needs and no more, which for the
+/// worst case here is a peak RSS of 48MB. A job somehow needing more than this
+/// bands, comes out blank, and is caught by `imagewriter_raster_has_ink`.
+///
+/// There is no switch for "never band": `-dBandingNever`, `-dNOBAND` and
+/// `-dBandingType=2` are all silently swallowed as user params and do nothing.
+const IW_MAX_BITMAP: u64 = 128 * 1024 * 1024;
 
 #[derive(Clone)]
 struct PrinterCaps {
@@ -859,6 +881,19 @@ fn imagewriter_safe_page(w: f32, h: f32) -> (f32, f32) {
     (w, h)
 }
 
+/// Whether an ImageWriter raster carries any dots at all.
+///
+/// `iwhi`/`iwhic` introduce every run of graphics with `ESC G`, and emit
+/// nothing but carriage returns and line feeds for a row with no ink, so a job
+/// without a single `ESC G` is a page the printer will feed through and eject
+/// without ever moving the head. Ghostscript reaches that state without
+/// failing: given a damaged PDF it repairs what it can, renders whatever
+/// survived and exits 0, so the empty page is otherwise indistinguishable from
+/// a successful job until the paper comes out.
+fn imagewriter_raster_has_ink(raster: &[u8]) -> bool {
+    raster.windows(2).any(|w| w == [0x1B, b'G'])
+}
+
 /// `iwhic` is the colour twin of `iwhi`, driving the four-band colour ribbon.
 /// Mono jobs stay on `iwhi` even with a colour ribbon fitted, where they strike
 /// the ribbon's black band directly instead of laying down a composite.
@@ -1125,8 +1160,12 @@ async fn handle_ipp(
                         // the status call needs no connection, so ask again rather
                         // than rasterize for a ribbon that has since changed.
                         let color = match status.read().await {
-                            Ok(s) if s.out_of_paper() => {
-                                let msg = s.error_text().unwrap_or_else(|| "Out of paper".to_string());
+                            // Off line counts as well as out of paper. A
+                            // deselected printer will not print, so the job
+                            // would sit on the PAP connection blocking the
+                            // queue behind it with nothing said.
+                            Ok(s) if !s.ready_to_print() => {
+                                let msg = s.error_text().unwrap_or_else(|| "Printer not ready".to_string());
                                 tracing::error!("IPP: ImageWriter job {job_id} refused: {msg}");
                                 let mut j = job.lock().await;
                                 j.state = JobState::Aborted;
@@ -1153,17 +1192,31 @@ async fn handle_ipp(
                             }
                         };
                         tracing::info!("IPP: rasterized ImageWriter job {job_id} to {} bytes", raster.len());
+                        if !imagewriter_raster_has_ink(&raster) {
+                            let msg = format!(
+                                "Ghostscript rendered a blank page ({} bytes, no dot data)",
+                                raster.len()
+                            );
+                            tracing::error!(
+                                "IPP: ImageWriter job {job_id} refused: {msg}. \
+                                 Check the log for what gs made of the document."
+                            );
+                            let mut j = job.lock().await;
+                            j.state = JobState::Aborted;
+                            j.state_message = msg;
+                            return;
+                        }
                         job.lock().await.state_message = "Waiting for printer".to_string();
                         let _pap_guard = job_lock.lock().await;
 
                         // The check above can be minutes stale by now if this job
-                        // queued behind another, so confirm there is still paper
-                        // before feeding it. A failed read is not fatal here; the
-                        // print itself is the better error in that case.
+                        // queued behind another, so confirm the printer is still
+                        // ready before feeding it. A failed read is not fatal
+                        // here; the print itself is the better error in that case.
                         if let Ok(s) = status.read().await
-                            && s.out_of_paper()
+                            && !s.ready_to_print()
                         {
-                            let msg = s.error_text().unwrap_or_else(|| "Out of paper".to_string());
+                            let msg = s.error_text().unwrap_or_else(|| "Printer not ready".to_string());
                             tracing::error!("IPP: ImageWriter job {job_id} refused at print time: {msg}");
                             let mut j = job.lock().await;
                             j.state = JobState::Aborted;
@@ -1785,7 +1838,22 @@ async fn gs_device_run(
             stdout.trim(),
         );
     }
-    let _ = tokio::fs::remove_file(&input_path).await;
+
+    // A damaged document is not a failed run: gs repairs what it can, renders
+    // whatever survived (often nothing at all) and still exits 0. Its progress
+    // chatter goes to stdout, so anything on stderr is a genuine complaint and
+    // is the only account we get of why a page came out empty. Keep the input
+    // alongside it so the document itself can be examined.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.trim().is_empty() {
+        let _ = tokio::fs::remove_file(&input_path).await;
+    } else {
+        tracing::warn!(
+            "gs {device} exited 0 but reported problems with the document (input kept at {}): {}",
+            input_path.display(),
+            stderr.trim(),
+        );
+    }
 
     let raster = tokio::fs::read(&out_path).await;
     let _ = tokio::fs::remove_file(&out_path).await;
@@ -1827,13 +1895,21 @@ async fn rasterize_for_imagewriter(
     color: bool,
     job_token: u32,
 ) -> anyhow::Result<Vec<u8>> {
+    let args = imagewriter_gs_args(media_pts);
+    gs_device_run(data, fmt, imagewriter_gs_device(color), &args, job_token).await
+}
+
+/// Ghostscript switches for an ImageWriter job: the page geometry the printer
+/// has to be told about, and the `MaxBitmap` ceiling that keeps the render out
+/// of the banded path (see [`IW_MAX_BITMAP`]).
+fn imagewriter_gs_args(media_pts: (f32, f32)) -> Vec<String> {
     let (w, h) = imagewriter_safe_page(media_pts.0, media_pts.1);
-    let args = [
+    vec![
         format!("-dDEVICEWIDTHPOINTS={w}"),
         format!("-dDEVICEHEIGHTPOINTS={h}"),
         "-dFIXEDMEDIA".to_string(),
-    ];
-    gs_device_run(data, fmt, imagewriter_gs_device(color), &args, job_token).await
+        format!("-dMaxBitmap={IW_MAX_BITMAP}"),
+    ]
 }
 
 /// One page of raw planar StyleWriter scanlines: rows → planes (1 for mono,
@@ -2330,6 +2406,39 @@ mod tests {
     fn test_imagewriter_gs_device_picks_color_twin() {
         assert_eq!(imagewriter_gs_device(false), "iwhi");
         assert_eq!(imagewriter_gs_device(true), "iwhic");
+    }
+
+    /// Losing the `MaxBitmap` ceiling costs nothing visible until someone
+    /// prints a page with transparency on it, which then comes out blank.
+    #[test]
+    fn test_imagewriter_gs_args_force_page_and_lift_max_bitmap() {
+        let args = imagewriter_gs_args((595.0, 842.0));
+        assert!(args.contains(&"-dDEVICEWIDTHPOINTS=595".to_string()));
+        assert!(args.contains(&"-dDEVICEHEIGHTPOINTS=840".to_string())); // floored to 24pt
+        assert!(args.contains(&"-dFIXEDMEDIA".to_string()));
+
+        let max_bitmap = args
+            .iter()
+            .find_map(|a| a.strip_prefix("-dMaxBitmap="))
+            .and_then(|v| v.parse::<u64>().ok())
+            .expect("MaxBitmap is set");
+        // A Letter page at 160x144dpi needs ~45MB to stay out of banded mode,
+        // and legal is half again as tall.
+        assert!(max_bitmap >= 64 * 1024 * 1024, "{max_bitmap} leaves no headroom");
+    }
+
+    /// A page gs rendered blank is otherwise a successful job: it streams,
+    /// completes, and ejects paper the head never touched.
+    #[test]
+    fn test_imagewriter_raster_has_ink_spots_a_blank_page() {
+        // Line spacing and feeds only, as `iwhi` emits for a page with no ink.
+        let blank = b"\x1b<\x1bT16\x1bP\x1bT01\n\x1bT15\r\n\x1bT01\n\x0c";
+        assert!(!imagewriter_raster_has_ink(blank));
+
+        // The same, with one row of dots: `ESC G`, a four-digit byte count,
+        // then the column data.
+        let inked = b"\x1b<\x1bT16\x1bP\x1bT01\n\x1bG0003\xff\xff\xff\r\n\x0c";
+        assert!(imagewriter_raster_has_ink(inked));
     }
 
     /// Build a PrintJob request carrying one job attribute.

--- a/tailtalk-gui/printer_tool.rs
+++ b/tailtalk-gui/printer_tool.rs
@@ -391,6 +391,7 @@ fn imagewriter_lines(s: &ImageWriterStatus) -> Vec<Line> {
         Line::section("Status"),
         Line::field("Condition", imagewriter_condition(s)),
         Line::field("Paper", if s.paper_present() { "Loaded" } else { "Out of paper" }),
+        Line::field("Select", if s.off_line() { "Off line" } else { "On line" }),
         Line::field("Busy", yes_no(s.busy())),
         Line::field("Printing", yes_no(s.active())),
         Line::section("Hardware"),

--- a/tailtalk/src/imagewriter.rs
+++ b/tailtalk/src/imagewriter.rs
@@ -8,8 +8,9 @@
 //! # use tailtalk::{TalkStack, imagewriter::ImageWriter};
 //! # async fn example(stack: &TalkStack, raster: Vec<u8>) -> anyhow::Result<()> {
 //! let mut printer = ImageWriter::connect_named(&stack.ddp, &stack.nbp, "=").await?;
-//! if printer.status().await?.out_of_paper() {
-//!     anyhow::bail!("load some paper first");
+//! let status = printer.status().await?;
+//! if !status.ready_to_print() {
+//!     anyhow::bail!("{}", status.error_text().unwrap_or_default());
 //! }
 //! printer.print_bytes(&raster).await?;
 //! printer.close().await?;
@@ -27,37 +28,40 @@
 //! Reading it therefore goes through [`PapClient::get_status_bytes`] rather than
 //! the text-oriented `get_status`.
 //!
-//! Bit assignments. The starting point was the "PAP Status Buffer from an
-//! ImageWriter II/LQ LocalTalk Option Card" figure in Apple's PAP
-//! documentation, but the hardware does not agree with it, so treat the figure
-//! as a hint rather than a specification:
+//! Bit assignments, from the "PAP Status Buffer from an ImageWriter II/LQ
+//! LocalTalk Option Card" figure in Apple's PAP documentation:
 //!
 //! ```text
-//!  15  14 13 12 11 10 9 8   7    6    5    4     3    2    1    0
-//! busy |<--- unused --->| ribbon feed  ?  cover paper jam fault active
+//!  15  14 13 12 11 10 9 8   7    6     5     4     3    2    1    0
+//! busy |<--- unused --->| ribbon feed paper cover  off  jam fault active
+//!                                      out         line
 //! ```
 //!
-//! Confirmed against a real ImageWriter II:
+//! Three readings from a real ImageWriter II, all with a colour ribbon fitted
+//! and no sheet feeder:
 //!
-//!   * Bit 3 is **paper present**, not the figure's "off line", and it is
-//!     asserted when paper is loaded. An empty printer read `0x0080`; loading
-//!     paper changed it to `0x0088` and nothing else moved. It therefore reads
-//!     the opposite way round to the error bits around it.
-//!   * Bit 7 is the colour ribbon, set in both of those readings on a printer
-//!     with a colour ribbon fitted.
-//!   * Bit 5, which the figure labels paper-out, stayed clear while the printer
-//!     was genuinely out of paper. Whatever it is, it is not that.
+//! | Paper  | Select light | Word     |
+//! |--------|--------------|----------|
+//! | loaded | on           | `0x0080` |
+//! | loaded | off          | `0x0088` |
+//! | empty  | off          | `0x00AA` |
 //!
-//! Everything else below is still only the figure's word. Bits 6, 4, 2, 1 and 0
-//! were clear in both confirmed readings, consistent with active-high
-//! conditions that never fired, but none has been deliberately triggered and
-//! checked. [`error_text`](ImageWriterStatus::error_text) reports the
-//! unconfirmed ones, so a surprising error there is as likely to be a wrong bit
-//! as a real fault.
+//! The first two differ only in the Select light, and only in bit 3, so bit 3
+//! is **off line** as the figure says. Emptying the printer then raised bit 5,
+//! **paper out**, and bit 1, the general fault, with it: those two move
+//! together. The printer was already off line for that third reading, so
+//! whether running out deselects it on its own is untested. Bit 7, the colour
+//! ribbon, is set throughout.
+//!
+//! Every bit confirmed that way is active-high, so a ready printer reads
+//! all-clear below bit 7. Bits 6, 4, 2 and 0 are still the figure's word alone,
+//! never having been deliberately triggered and checked, so a surprising error
+//! from [`error_text`](ImageWriterStatus::error_text) naming one of those is as
+//! likely to be a wrong bit as a real fault.
 //!
 //! The card sends the low byte first, so the word is assembled little-endian
-//! even though AppleTalk is otherwise big-endian. Both confirmed readings put
-//! the meaningful bits in the byte that arrives first, which is also why the
+//! even though AppleTalk is otherwise big-endian. All three readings put the
+//! meaningful bits in the byte that arrives first, which is also why the
 //! card's documented glitch reply is "all ones in the low byte".
 //!
 //! That glitch is occasional and not sticky: the card sometimes answers with
@@ -87,10 +91,11 @@ pub const MAX_NAME_LEN: usize = 31;
 const BUSY: u16 = 1 << 15;
 const COLOR_RIBBON: u16 = 1 << 7;
 const SHEET_FEEDER: u16 = 1 << 6;
+const PAPER_OUT: u16 = 1 << 5;
 const COVER_OPEN: u16 = 1 << 4;
-/// Set while paper is loaded, so this reads the opposite way round to the
-/// error bits. See the module note on which bits are confirmed.
-const PAPER_PRESENT: u16 = 1 << 3;
+/// Set while the Select light is off. See the module note on which bits are
+/// confirmed.
+const OFF_LINE: u16 = 1 << 3;
 const PAPER_JAM: u16 = 1 << 2;
 const FAULT: u16 = 1 << 1;
 const ACTIVE: u16 = 1 << 0;
@@ -163,10 +168,17 @@ impl ImageWriterStatus {
         self.raw & SHEET_FEEDER != 0
     }
 
-    /// Paper is loaded (bit 3). Confirmed on real hardware: loading paper is
-    /// what sets this bit. Note the sense, it is asserted when all is well.
-    pub fn paper_present(&self) -> bool {
-        self.raw & PAPER_PRESENT != 0
+    /// The printer is out of paper (bit 5). Confirmed on real hardware:
+    /// emptying the printer is what sets this bit, and it brings
+    /// [`fault`](Self::fault) up with it.
+    pub fn out_of_paper(&self) -> bool {
+        self.raw & PAPER_OUT != 0
+    }
+
+    /// The printer is off line (bit 3), i.e. its Select light is off, so it
+    /// will not print until someone presses Select. Confirmed on real hardware.
+    pub fn off_line(&self) -> bool {
+        self.raw & OFF_LINE != 0
     }
 
     /// Raw paper-jam bit (bit 2). Unconfirmed, see the module note.
@@ -179,8 +191,9 @@ impl ImageWriterStatus {
         self.raw & COVER_OPEN != 0
     }
 
-    /// A general printer fault is asserted (bit 1). Unconfirmed, see the module
-    /// note.
+    /// A general printer fault is asserted (bit 1). Seen on real hardware only
+    /// alongside [`out_of_paper`](Self::out_of_paper), so what else raises it
+    /// is unconfirmed.
     pub fn fault(&self) -> bool {
         self.raw & FAULT != 0
     }
@@ -190,11 +203,19 @@ impl ImageWriterStatus {
         self.raw & ACTIVE != 0
     }
 
-    /// Whether the printer is out of paper, i.e. [`paper_present`] is clear.
-    ///
-    /// [`paper_present`]: Self::paper_present
-    pub fn out_of_paper(&self) -> bool {
-        !self.paper_present()
+    /// The inverse of [`out_of_paper`](Self::out_of_paper), for readouts that
+    /// phrase it the positive way round. The card has no paper-present bit.
+    pub fn paper_present(&self) -> bool {
+        !self.out_of_paper()
+    }
+
+    /// Whether the printer will take a job: it needs paper, and it has to be on
+    /// line. The remaining error bits are deliberately left out, since none of
+    /// them is confirmed and one we have misread would refuse jobs a working
+    /// printer would have taken. [`error_text`](Self::error_text) still reports
+    /// them.
+    pub fn ready_to_print(&self) -> bool {
+        !self.out_of_paper() && !self.off_line()
     }
 
     /// Every error condition the card is reporting, or `None` when it reports
@@ -214,7 +235,11 @@ impl ImageWriterStatus {
         if self.cover_open() {
             errors.push("Cover open");
         }
-        if self.fault() {
+        if self.off_line() {
+            errors.push("Off line, press Select");
+        }
+        // Paper-out raises the fault bit too, and has already named the cause.
+        if self.fault() && !self.out_of_paper() {
             errors.push("Printer fault");
         }
         (!errors.is_empty()).then(|| errors.join(", "))
@@ -530,9 +555,7 @@ mod tests {
         assert!(rename_command(&"a".repeat(MAX_NAME_LEN + 1)).is_err());
     }
 
-    /// Pins each bit position we decode. Bit 5 is deliberately absent: the
-    /// figure calls it paper-out, but the hardware left it clear with the
-    /// printer empty, so nothing is decoded from it.
+    /// Pins each bit position we decode.
     #[test]
     fn decodes_each_documented_bit() {
         let s = ImageWriterStatus::parse(&wire(0x00, 0x80)).unwrap();
@@ -545,16 +568,13 @@ mod tests {
         assert!(s.sheet_feeder() && !s.color_ribbon());
 
         let s = ImageWriterStatus::parse(&wire(0x20, 0x00)).unwrap();
-        assert!(
-            s.out_of_paper(),
-            "bit 5 is not decoded, bit 3 is still clear"
-        );
+        assert!(s.out_of_paper());
 
         let s = ImageWriterStatus::parse(&wire(0x10, 0x00)).unwrap();
         assert!(s.cover_open());
 
         let s = ImageWriterStatus::parse(&wire(0x08, 0x00)).unwrap();
-        assert!(s.paper_present() && !s.out_of_paper());
+        assert!(s.off_line() && s.paper_present(), "bit 3 is not about paper");
 
         let s = ImageWriterStatus::parse(&wire(0x04, 0x00)).unwrap();
         assert!(s.paper_jam_bit());
@@ -566,31 +586,48 @@ mod tests {
         assert!(s.active());
     }
 
-    /// The pair of readings that pin bit 3, taken from a real ImageWriter II
-    /// with a colour ribbon and no sheet feeder. Only one thing changed between
-    /// them: paper was loaded. Only one bit moved with it.
+    /// The three readings that pin bits 5, 3 and 1, taken from a real
+    /// ImageWriter II with a colour ribbon and no sheet feeder. Between the
+    /// first two only the Select light changed, and only one bit moved with it.
     #[test]
     fn matches_observed_hardware_readings() {
-        // Empty printer.
-        let empty = ImageWriterStatus::parse(&[0x80, 0x00]).unwrap();
-        assert_eq!(empty.raw, 0x0080);
-        assert!(empty.out_of_paper(), "printer had no paper in it");
-        assert_eq!(empty.error_text().as_deref(), Some("Out of paper"));
+        // Paper loaded, Select light on: the fully ready printer.
+        let ready = ImageWriterStatus::parse(&[0x80, 0x00]).unwrap();
+        assert_eq!(ready.raw, 0x0080);
+        assert!(ready.ready_to_print());
+        assert_eq!(ready.error_text(), None, "a ready printer has no errors");
 
-        // Same printer, paper loaded.
-        let loaded = ImageWriterStatus::parse(&[0x88, 0x00]).unwrap();
-        assert_eq!(loaded.raw, 0x0088);
-        assert!(loaded.paper_present(), "printer had paper in it");
-        assert_eq!(loaded.error_text(), None, "a ready printer has no errors");
+        // Same printer, Select light off.
+        let deselected = ImageWriterStatus::parse(&[0x88, 0x00]).unwrap();
+        assert_eq!(deselected.raw, 0x0088);
+        assert!(deselected.paper_present(), "printer still had paper in it");
+        assert!(deselected.off_line() && !deselected.ready_to_print());
+        assert_eq!(
+            deselected.error_text().as_deref(),
+            Some("Off line, press Select")
+        );
 
-        // Loading paper moved bit 3 and nothing else.
-        assert_eq!(empty.raw ^ loaded.raw, PAPER_PRESENT);
+        // Pressing Select moved bit 3 and nothing else.
+        assert_eq!(ready.raw ^ deselected.raw, OFF_LINE);
 
-        // Both readings agree on the rest of the printer's state.
-        for s in [empty, loaded] {
+        // Paper removed, Select light still off. Paper-out brings the general
+        // fault up with it, so two bits move.
+        let empty = ImageWriterStatus::parse(&[0xAA, 0x00]).unwrap();
+        assert_eq!(empty.raw, 0x00AA);
+        assert!(empty.out_of_paper() && empty.off_line() && empty.fault());
+        assert_eq!(deselected.raw ^ empty.raw, PAPER_OUT | FAULT);
+        // The fault bit adds nothing once paper-out has named the cause.
+        assert_eq!(
+            empty.error_text().as_deref(),
+            Some("Out of paper, Off line, press Select")
+        );
+
+        // All three readings agree on the rest of the printer's state.
+        for s in [ready, deselected, empty] {
             assert!(s.color_ribbon(), "printer had a colour ribbon fitted");
             assert!(!s.sheet_feeder(), "printer had no sheet feeder");
             assert!(!s.busy(), "printer was idle");
+            assert!(!s.cover_open() && !s.paper_jam_bit() && !s.active());
             // Nothing lands in the unused 8..=14 range.
             assert_eq!(s.raw & 0x7F00, 0);
         }
@@ -630,22 +667,27 @@ mod tests {
 
     /// The jam bit's wording depends on whether a feeder is fitted, since with
     /// one an empty tray is said to raise it too. Both the bit and that
-    /// distinction come from the figure and neither is confirmed; paper is
-    /// present in each case here so the confirmed bit stays out of the way.
+    /// distinction come from the figure and neither is confirmed. Every other
+    /// bit is left clear so only the wording is under test.
     #[test]
     fn sheet_feeder_changes_the_jam_wording() {
-        let paper = PAPER_PRESENT as u8;
-
         let feeder =
-            ImageWriterStatus::parse(&wire(paper | SHEET_FEEDER as u8 | PAPER_JAM as u8, 0x00))
-                .unwrap();
+            ImageWriterStatus::parse(&wire(SHEET_FEEDER as u8 | PAPER_JAM as u8, 0x00)).unwrap();
         assert_eq!(
             feeder.error_text().as_deref(),
             Some("Paper jam or sheet feeder empty")
         );
 
-        let no_feeder = ImageWriterStatus::parse(&wire(paper | PAPER_JAM as u8, 0x00)).unwrap();
+        let no_feeder = ImageWriterStatus::parse(&wire(PAPER_JAM as u8, 0x00)).unwrap();
         assert_eq!(no_feeder.error_text().as_deref(), Some("Paper jam"));
+    }
+
+    /// Suppressing the fault bit is specific to the paper-out that raises it.
+    /// On its own it is still worth saying.
+    #[test]
+    fn fault_alone_is_still_reported() {
+        let s = ImageWriterStatus::parse(&wire(FAULT as u8, 0x00)).unwrap();
+        assert_eq!(s.error_text().as_deref(), Some("Printer fault"));
     }
 
     /// The glitch reply must be rejected rather than decoded as "every error at
@@ -673,19 +715,19 @@ mod tests {
         assert_eq!(s.raw, 0x0080);
     }
 
-    /// A ready printer has paper, so bit 3 is part of every no-error reading.
+    /// Every error bit is active-high, so a ready printer reads all-clear below
+    /// the ribbon bit.
     #[test]
     fn idle_printer_reports_no_error() {
-        let paper = PAPER_PRESENT as u8;
-
-        let s = ImageWriterStatus::parse(&wire(paper | 0x80, 0x00)).unwrap();
+        let s = ImageWriterStatus::parse(&wire(0x80, 0x00)).unwrap();
         assert_eq!(s.error_text(), None);
+        assert!(s.ready_to_print());
         assert_eq!(s.ribbon_text(), "Color");
 
         // Busy and actively printing is a state, not an error.
-        let s = ImageWriterStatus::parse(&wire(paper | 0x01, 0x80)).unwrap();
+        let s = ImageWriterStatus::parse(&wire(0x01, 0x80)).unwrap();
         assert_eq!(s.error_text(), None);
-        assert!(s.busy() && s.active());
+        assert!(s.busy() && s.active() && s.ready_to_print());
         assert_eq!(s.ribbon_text(), "Black only");
     }
 }


### PR DESCRIPTION
The iwhi/iwhic devices render an entirely blank page whenever Ghostscript takes its banded (clist) path, which it does the moment the page buffer would exceed MaxBitmap, default 10MB. Any transparency on the page pushes it through the compositor at ~20 bytes per device pixel, measured at 43MB for Letter and 54MB for a 14in page at 160x144dpi, so such a document silently ejected paper the head never touched. Raise MaxBitmap to 128MB, a threshold rather than an allocation, since there is no "never band" switchi.

Additionally fixes the status bit readings - the fact that the "Select" button changes multiple bits at a time was throwing me and I ended up mislabeling a number of them. This caused us to refuse to print when paper was loaded even though it was ready to go.