### PR TITLE
ATP/DDP: Release dynamic sockets when their handles drop

### DIFF
--- a/tailtalk-gui/lw_bridge.rs
+++ b/tailtalk-gui/lw_bridge.rs
@@ -227,7 +227,7 @@ pub async fn run(
                                 counter: std::sync::atomic::AtomicU32::new(0),
                             };
 
-                            let (socket_num, _requestor, responder) = Atp::spawn(&ddp, None).await;
+                            let (socket_num, _, responder) = Atp::spawn(&ddp, None).await;
                             let mut server = PapServer::new(
                                 responder,
                                 ddp,

--- a/tailtalk/Cargo.toml
+++ b/tailtalk/Cargo.toml
@@ -45,3 +45,6 @@ ethertalk = ["dep:pcap", "dep:mac_address"]
 
 [dev-dependencies]
 tempfile = "3.13"
+# `test-util` is not part of tokio's `full`, and gives tests `start_paused` so
+# they can wait on timers without spending real wall clock.
+tokio = { workspace = true, features = ["test-util"] }

--- a/tailtalk/src/atp.rs
+++ b/tailtalk/src/atp.rs
@@ -108,10 +108,13 @@ pub struct AtpSendResponse {
     pub packets: Vec<AtpResponse>,
 }
 
+/// Internal only. A TRelease closes out one of our own XO transactions, which
+/// the actor decides on its own in `complete_transaction`, so this never
+/// crosses the command channel.
 #[derive(Debug)]
-pub struct AtpSendRelease {
-    pub destination: AtpAddress,
-    pub tid: u16,
+struct AtpSendRelease {
+    destination: AtpAddress,
+    tid: u16,
 }
 
 /// A fire-and-forget ALO (at-least-once) packet — no pending transaction is registered
@@ -126,7 +129,6 @@ pub struct AtpSendAlo {
 pub enum AtpCommand {
     SendRequest(AtpSendRequest),
     SendResponse(AtpSendResponse),
-    SendRelease(AtpSendRelease),
     SendAlo(AtpSendAlo),
 }
 
@@ -295,12 +297,23 @@ impl AtpRequestor {
 
 #[derive(Debug)]
 pub struct AtpResponder {
-    pub incoming_rx: mpsc::Receiver<AtpReceivedRequest>,
+    incoming_rx: mpsc::Receiver<AtpReceivedRequest>,
+    /// The requesting half of the same socket. ATP sockets are symmetric: ASP
+    /// serves commands on its socket while sending tickles from it. Bundling it
+    /// here also means a server handed only a responder still owns the socket,
+    /// which is what keeps `PapServer` alive.
+    requestor: AtpRequestor,
 }
 
 impl AtpResponder {
     pub async fn next(&mut self) -> Option<AtpReceivedRequest> {
         self.incoming_rx.recv().await
+    }
+
+    /// The requesting half of this socket, for sending requests from the same
+    /// socket number that serves them.
+    pub fn requestor(&self) -> &AtpRequestor {
+        &self.requestor
     }
 }
 
@@ -308,7 +321,16 @@ pub struct Atp {
     sock: DdpSocket,
     request_recv: mpsc::Receiver<AtpCommand>,
     incoming_req_tx: mpsc::Sender<AtpReceivedRequest>,
-    cmd_tx: mpsc::Sender<AtpCommand>,
+    /// Weak on purpose: a strong clone here would keep the command channel's
+    /// sender count above zero forever, so `run` could never return and the
+    /// [`DdpSocket`] it owns would never be dropped, leaking its socket number.
+    /// Liveness comes from the [`AtpRequestor`]s held outside the actor,
+    /// including the one inside [`AtpResponder`].
+    ///
+    /// Upgraded only to stamp a reply channel onto an inbound request. That
+    /// gives the resulting [`AtpReceivedRequest`] a strong sender, so a socket
+    /// cannot be recycled while a reply on it is still owed.
+    cmd_tx: mpsc::WeakSender<AtpCommand>,
     // Map Transaction ID to pending request channel and XO status
     pending_transactions: AtpTransactionMap,
     next_tid: u16,
@@ -333,7 +355,7 @@ impl Atp {
             sock,
             request_recv,
             incoming_req_tx,
-            cmd_tx: request_send.clone(),
+            cmd_tx: request_send.downgrade(),
             pending_transactions: HashMap::new(),
             next_tid: 1, // Start TID at 1
         };
@@ -344,14 +366,17 @@ impl Atp {
             tracing::debug!("ATP actor stopped");
         });
 
+        let requestor = AtpRequestor {
+            cmd_tx: request_send,
+            socket_number: actual_socket,
+        };
+
         (
             actual_socket,
-            AtpRequestor {
-                cmd_tx: request_send,
-                socket_number: actual_socket,
-            },
+            requestor.clone(),
             AtpResponder {
                 incoming_rx: incoming_req_rx,
+                requestor,
             },
         )
     }
@@ -382,11 +407,12 @@ impl Atp {
                         match command {
                             AtpCommand::SendRequest(req) => self.handle_send_request(req).await,
                             AtpCommand::SendResponse(resp) => self.handle_send_response(resp).await,
-                            AtpCommand::SendRelease(rel) => self.handle_send_release(rel).await,
                             AtpCommand::SendAlo(alo) => self.handle_send_alo(alo).await,
                         }
                     } else {
-                        tracing::info!("ATP command channel closed");
+                        // Returning drops `self.sock`, which deregisters the
+                        // socket number for reuse.
+                        tracing::debug!("ATP: all handles dropped, releasing socket");
                         break;
                     }
                 }
@@ -684,12 +710,19 @@ impl Atp {
                     Vec::new()
                 };
 
+                // Fails only once every handle is gone, i.e. nothing is left
+                // to answer with.
+                let Some(response_sender) = self.cmd_tx.upgrade() else {
+                    tracing::debug!("Dropping incoming ATP request, ATP actor is shutting down");
+                    return;
+                };
+
                 let req = AtpReceivedRequest {
                     transaction_id: packet.tid,
                     source: AtpAddress::from_ddp_source(&ddp),
                     user_bytes: packet.user_bytes,
                     data: request_data,
-                    response_sender: self.cmd_tx.clone(),
+                    response_sender,
                     bitmap: packet.bitmap_seq_num,
                 };
 

--- a/tailtalk/src/ddp.rs
+++ b/tailtalk/src/ddp.rs
@@ -233,6 +233,10 @@ impl DdpSocket {
 
 type SockNum = u8;
 
+/// Socket numbers available for dynamic assignment, 191 of them. Below 64 is
+/// reserved for statically assigned sockets, and 255 is the broadcast socket.
+pub const DYNAMIC_SOCKETS: std::ops::RangeInclusive<SockNum> = 64..=254;
+
 pub struct DdpProcessor {
     sockets: HashMap<SockNum, mpsc::Sender<Packet>>,
     command_rx: mpsc::Receiver<DdpCommand>,
@@ -308,9 +312,21 @@ impl DdpProcessor {
                     self.handle_outbound(pkt).await;
                 }
                 DdpCommand::Deregister(sock_num) => {
-                    self.sockets.remove(&sock_num);
+                    self.deregister(sock_num);
                 }
             }
+        }
+    }
+
+    /// Release a socket number on behalf of a dropped [`DdpSocket`].
+    ///
+    /// Ignored unless the registration is actually dead. Since `new_sock` reaps
+    /// closed sockets itself, the number may already have been reissued by the
+    /// time this is drained, and evicting that new owner would silently stop
+    /// delivering their traffic. A `Sender` still open belongs to someone else.
+    fn deregister(&mut self, sock_num: SockNum) {
+        if self.sockets.get(&sock_num).is_some_and(|tx| tx.is_closed()) {
+            self.sockets.remove(&sock_num);
         }
     }
 
@@ -319,6 +335,12 @@ impl DdpProcessor {
         protocol: DdpProtocolType,
         sock_num: Option<SockNum>,
     ) -> Result<DdpSocket, io::Error> {
+        // A socket whose owner is gone still holds its number until this runs:
+        // `DdpSocket::drop` publishes `Deregister` with `try_send`, which is
+        // dropped outright if the command channel is full. A closed `Sender`
+        // here means the `DdpSocket` holding the matching `Receiver` is gone.
+        self.sockets.retain(|_, tx| !tx.is_closed());
+
         let sock_num = if let Some(n) = sock_num {
             if self.sockets.contains_key(&n) {
                 return Err(io::Error::from(io::ErrorKind::AddrInUse));
@@ -326,18 +348,10 @@ impl DdpProcessor {
             n
         } else {
             let mut rng = rand::rng();
-            // 255 is the reserved broadcast socket, never dynamically assignable.
-            let mut candidate = rng.random_range(64u8..=254);
-            for _ in 0..192u16 {
-                if !self.sockets.contains_key(&candidate) {
-                    break;
-                }
-                candidate = rng.random_range(64..=254);
-            }
-            if self.sockets.contains_key(&candidate) {
-                return Err(io::Error::from(io::ErrorKind::AddrInUse));
-            }
-            candidate
+            (0..DYNAMIC_SOCKETS.count())
+                .map(|_| rng.random_range(DYNAMIC_SOCKETS))
+                .find(|n| !self.sockets.contains_key(n))
+                .ok_or_else(|| io::Error::from(io::ErrorKind::AddrInUse))?
         };
 
         let (tx, rx) = mpsc::channel(100);
@@ -814,5 +828,76 @@ impl DdpHandle {
                 source_mac,
             }));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::route_table::LearningMode;
+
+    /// A processor driven directly, so socket bookkeeping can be exercised
+    /// without a runtime or any interfaces.
+    fn processor() -> (DdpProcessor, mpsc::Receiver<DataLinkPacket>) {
+        let (out_tx, out_rx) = mpsc::channel(16);
+        let (command_tx, command_rx) = mpsc::channel(16);
+        let processor = DdpProcessor {
+            sockets: HashMap::new(),
+            command_rx,
+            command_tx,
+            ethertalk: OutboundHandle::new(out_tx),
+            et_addressing: None,
+            lt_addressing: None,
+            route_table: RouteTable::new(LearningMode::Static),
+        };
+        (processor, out_rx)
+    }
+
+    /// A dropped socket's number must come back even if its `Deregister` never
+    /// arrives, since `DdpSocket::drop` publishes that with `try_send` and the
+    /// command channel is shared with all packet traffic.
+    #[test]
+    fn a_dropped_socket_is_reaped_without_its_deregister() {
+        let (mut p, _out_rx) = processor();
+
+        let sock = p.new_sock(DdpProtocolType::Atp, Some(70)).unwrap();
+        assert!(p.new_sock(DdpProtocolType::Atp, Some(70)).is_err());
+
+        // Drop the socket but never deliver the Deregister it queued.
+        drop(sock);
+
+        assert!(
+            p.new_sock(DdpProtocolType::Atp, Some(70)).is_ok(),
+            "socket 70 was not reaped after its owner dropped"
+        );
+    }
+
+    /// The reaping above means a `Deregister` can arrive after its number has
+    /// already been reissued. Honouring it then would deregister an innocent
+    /// socket, which on a live stack means a printer or server silently
+    /// receiving nothing.
+    #[test]
+    fn a_stale_deregister_does_not_evict_the_new_owner() {
+        let (mut p, _out_rx) = processor();
+
+        let first = p.new_sock(DdpProtocolType::Atp, Some(70)).unwrap();
+        drop(first);
+
+        // Reissued to a new owner before the first owner's Deregister is drained.
+        let second = p.new_sock(DdpProtocolType::Atp, Some(70)).unwrap();
+
+        p.deregister(70);
+
+        assert!(
+            p.sockets.contains_key(&70),
+            "a stale Deregister evicted the socket's new owner"
+        );
+        // Still wired to the live socket, not a leftover entry.
+        assert!(!p.sockets.get(&70).unwrap().is_closed());
+        drop(second);
+
+        // And once that owner really is gone, the number is releasable again.
+        p.deregister(70);
+        assert!(!p.sockets.contains_key(&70));
     }
 }

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -815,7 +815,8 @@ impl TalkStack {
         attributes: pap::PrinterAttributes,
         sink: impl pap::PrintSink + 'static,
     ) -> pap::PapServer {
-        let (socket_num, _requestor, responder) = atp::Atp::spawn(&self.ddp, None).await;
+        // The responder owns the socket, so dropping the requestor is free.
+        let (socket_num, _, responder) = atp::Atp::spawn(&self.ddp, None).await;
         pap::PapServer::new(responder, self.ddp.clone(), socket_num, attributes, Box::new(sink))
     }
 

--- a/tailtalk/tests/atp_socket_release.rs
+++ b/tailtalk/tests/atp_socket_release.rs
@@ -1,0 +1,108 @@
+//! Dynamic DDP socket numbers are a finite resource. Every short-lived ATP user
+//! (a PAP status poll, an ImageWriter job, a Printer Tool query) takes one and
+//! must give it back, or a long-running stack runs out and `Atp::spawn` panics.
+
+use std::time::Duration;
+use tailtalk::{
+    OutboundHandle,
+    atp::{Atp, AtpRequestor, AtpResponder},
+    ddp::{DYNAMIC_SOCKETS, DdpHandle, DdpProcessor},
+    route_table::{LearningMode, RouteTable},
+};
+use tailtalk_packets::ddp::DdpProtocolType;
+use tokio::sync::mpsc;
+
+/// Give the actor a chance to notice its handles are gone and release the socket.
+///
+/// A bare `yield_now` is not enough: the actor opens by skipping the first tick
+/// of its retransmit `interval`, and that tick is not ready on its first poll.
+/// A current-thread runtime only advances its timer when it parks, which
+/// yielding never does. Under `start_paused` this costs no wall clock.
+async fn settle() {
+    tokio::time::sleep(Duration::from_millis(20)).await;
+}
+
+/// A DDP layer with no interfaces. Enough to allocate and release socket
+/// numbers, which is all these tests exercise.
+fn ddp_only() -> (DdpHandle, mpsc::Receiver<tailtalk::DataLinkPacket>) {
+    let (out_tx, out_rx) = mpsc::channel(100);
+    let ddp = DdpProcessor::spawn(
+        None,
+        None,
+        OutboundHandle::new(out_tx),
+        RouteTable::new(LearningMode::Static),
+    );
+    // Hand the receiver back so the outbound channel stays open for the
+    // processor's lifetime rather than closing under it.
+    (ddp, out_rx)
+}
+
+/// Whether `sock` is claimable again, i.e. its previous owner released it.
+/// Claims and immediately releases it when it is.
+async fn can_claim(ddp: &DdpHandle, sock: u8) -> bool {
+    ddp.new_sock(DdpProtocolType::Atp, Some(sock)).await.is_ok()
+}
+
+/// Assert that whichever half `keep` returns holds the socket open on its own,
+/// and that dropping it frees the number. Both halves are handles to one
+/// socket, so either must suffice.
+async fn outlives_its_sibling<T>(keep: impl FnOnce(AtpRequestor, AtpResponder) -> T) {
+    let (ddp, _out_rx) = ddp_only();
+    let (sock, requestor, responder) = Atp::spawn(&ddp, None).await;
+
+    // The half the closure does not return is dropped as it goes out of scope.
+    let kept = keep(requestor, responder);
+    settle().await;
+    assert!(
+        !can_claim(&ddp, sock).await,
+        "socket {sock} released too early"
+    );
+
+    drop(kept);
+    settle().await;
+    assert!(
+        can_claim(&ddp, sock).await,
+        "socket {sock} was never released"
+    );
+}
+
+/// Servers are handed only a responder: `TalkStack::pap_server` drops the
+/// requestor outright.
+#[tokio::test(start_paused = true)]
+async fn responder_alone_keeps_the_socket_open() {
+    outlives_its_sibling(|_, responder| responder).await;
+}
+
+/// Clients keep only a requestor, as `PapStatusHandle` does.
+#[tokio::test(start_paused = true)]
+async fn requestor_alone_keeps_the_socket_open() {
+    outlives_its_sibling(|requestor, _| requestor).await;
+}
+
+/// The responder holds the socket by owning the requesting half of it, not an
+/// inert token, so a server can send from the number it serves on.
+#[tokio::test(start_paused = true)]
+async fn responder_lends_out_its_requestor() {
+    let (ddp, _out_rx) = ddp_only();
+    let (sock, _requestor, responder) = Atp::spawn(&ddp, None).await;
+
+    assert_eq!(responder.requestor().socket_number, sock);
+}
+
+/// Cycling far more sockets than exist at once, which only completes if each
+/// one's number returns to the pool.
+#[tokio::test(start_paused = true)]
+async fn the_socket_pool_does_not_run_out() {
+    let (ddp, _out_rx) = ddp_only();
+
+    for i in 0..DYNAMIC_SOCKETS.count() * 2 {
+        let (sock, requestor, responder) = Atp::spawn(&ddp, None).await;
+        assert!(
+            DYNAMIC_SOCKETS.contains(&sock),
+            "iteration {i}: socket {sock} outside the dynamic range"
+        );
+        drop(requestor);
+        drop(responder);
+        settle().await;
+    }
+}

--- a/tailtalk/tests/pap_test.rs
+++ b/tailtalk/tests/pap_test.rs
@@ -435,3 +435,123 @@ async fn test_pap_server_query_session() {
 
     hub_task.abort();
 }
+
+/// A printer emulator built the way the real callers build it: handed only a
+/// responder, with the requesting half dropped.
+///
+/// `TalkStack::pap_server` and the GUI's LaserWriter bridge both do that, so
+/// the responder alone has to hold the ATP socket open. Not covered by the test
+/// above, which only partially moves its `TestClient` and so keeps `atp_req`
+/// alive throughout. The failure guarded against is silent: the socket is
+/// released as the server is built, leaving a printer that answers NBP lookups
+/// but never a PAP packet.
+#[tokio::test]
+async fn test_pap_server_survives_requestor_drop() {
+    let _ = tracing_subscriber::fmt().try_init();
+
+    let hub = TestHub::new();
+    let (hub_in_tx, hub_in_rx) = mpsc::channel(100);
+    let hub_ref = Arc::new(hub);
+    let hub_runner = hub_ref.clone();
+    let hub_task = tokio::spawn(async move {
+        hub_runner.run(hub_in_rx).await;
+    });
+
+    let workstation = TestClient::new(
+        [0x00, 0x01, 0x02, 0x03, 0x04, 0xDD],
+        hub_in_tx.clone(),
+        hub_ref.subscribe(),
+        None,
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    const PRINTER_SOCKET: u8 = 132;
+    let printer = TestClient::new(
+        [0x00, 0x01, 0x02, 0x03, 0x04, 0xCC],
+        hub_in_tx.clone(),
+        hub_ref.subscribe(),
+        Some(PRINTER_SOCKET),
+    )
+    .await;
+    printer
+        .nbp
+        .register(RegisteredName {
+            name: "DropPrinter:LaserWriter@*".try_into().unwrap(),
+            sock_num: PRINTER_SOCKET,
+        })
+        .await
+        .expect("Printer registration failed");
+
+    // Underscore bindings still own their values to the end of the test, so
+    // every other handle stays up exactly as a real stack would keep it.
+    let TestClient {
+        mac: _mac,
+        addressing: _addressing,
+        ddp,
+        nbp: _nbp,
+        echo: _echo,
+        atp_req,
+        atp_resp,
+    } = printer;
+
+    // The point of the test: the responder is now the only thing holding the
+    // socket. Wait out the actor's 250 ms retransmit tick so one that was going
+    // to shut down has had the chance.
+    drop(atp_req);
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let jobs = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let mut server = tailtalk::pap::PapServer::new(
+        atp_resp,
+        ddp.clone(),
+        PRINTER_SOCKET,
+        tailtalk::pap::PrinterAttributes::default(),
+        Box::new(CollectSink(jobs.clone())),
+    );
+    tokio::spawn(async move {
+        let _ = server.run().await;
+    });
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // NBP lives on its own socket, so discovery still works even with the ATP
+    // socket gone. It is the PAP exchange below that actually proves anything.
+    let results = workstation
+        .nbp
+        .lookup("DropPrinter:LaserWriter@*".try_into().unwrap())
+        .await
+        .expect("Lookup failed");
+    assert!(!results.is_empty(), "printer did not answer NBP");
+    let target = &results[0];
+    let printer_addr = tailtalk::atp::AtpAddress {
+        network_number: target.network_number,
+        node_number: target.node_id,
+        socket_number: target.socket_number,
+    };
+
+    let mut pap = workstation.into_pap_client();
+    // A released socket means DDP drops OpenConn with nothing to answer it, so
+    // this burns the ATP retry budget rather than failing fast. Bound it.
+    pap.connect_with_timeout(printer_addr, Duration::from_secs(10))
+        .await
+        .expect("PAP connect failed: the server's socket was released when its requestor dropped");
+
+    let ps_job = b"%!PS-Adobe-3.0\rshowpage\r%%EOF\r".to_vec();
+    pap.print(&ps_job).await.expect("Print job failed");
+    let stdout = pap.read_response().await.expect("Job stdout read failed");
+    assert!(stdout.is_empty(), "print job should produce no stdout");
+
+    tokio::time::timeout(Duration::from_secs(10), pap.close())
+        .await
+        .expect("Close timed out")
+        .expect("Close failed");
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let jobs = jobs.lock().await;
+    assert_eq!(jobs.len(), 1, "sink must receive the print job");
+    assert_eq!(jobs[0], ps_job);
+
+    println!("✓ PAP server survived its requestor being dropped!");
+
+    hub_task.abort();
+}


### PR DESCRIPTION
The ATP actor held a clone of its own command sender, so the command channel never closed, run() never returned, and the DdpSocket it owns was never dropped to deregister its number. Every Atp::spawn leaked one of the 191 dynamic sockets, panicking with "failed to create ATP sock" after roughly 60 ImageWriter jobs. The actor now holds a WeakSender, and AtpResponder owns an AtpRequestor for its own socket, since TalkStack::pap_server hands PapServer only a responder and a weak reference alone would shut it down at construction. New tests cover reuse past the pool size, and a PAP server completing a job with its requestor dropped.

On the DDP side, Deregister is published from Drop with try_send and lost if the command channel is full, so new_sock reaps closed registrations and deregister() ignores a stale request rather than evicting a number's new owner. Also drops the never-sent AtpCommand::SendRelease.