### PR TITLE
AFP: Fix timestamps using wrong epoch

### DIFF
--- a/tailtalk-packets/src/afp/bitmap.rs
+++ b/tailtalk-packets/src/afp/bitmap.rs
@@ -15,11 +15,11 @@ bitflags! {
         const ATTRIBUTES = 0x0001;
         /// Request for volume signature, i.e a flat without directories, fixed directory ID, or variable directory IDs.
         const SIGNATURE = 0x0002;
-        /// Request for creation date of this volume (In 32-bit Macintosh time)
+        /// Request for creation date of this volume (32-bit AFP date-time: signed seconds from Jan 1, 2000)
         const CREATION_DATE = 0x0004;
-        /// Request for last modified date of this volume (In 32-bit Macintosh time)
+        /// Request for last modified date of this volume (32-bit AFP date-time: signed seconds from Jan 1, 2000)
         const MODIFICATION_DATE = 0x0008;
-        /// Request for the last time this volume was backed up (In 32-bit Macintosh time)
+        /// Request for the last time this volume was backed up (32-bit AFP date-time: signed seconds from Jan 1, 2000)
         const BACKUP_DATE = 0x0010;
         /// Request for the volume's 16-bit ID assigned by the server.
         const VOLUME_ID = 0x0020;
@@ -59,13 +59,13 @@ bitflags! {
         /// Response: 32-bit directory ID
         const PARENT_DIR_ID = 1 << 1;
         /// Request for the creation date of this directory.
-        /// Response: 32-bit Macintosh time
+        /// Response: 32-bit AFP date-time (signed seconds from Jan 1, 2000)
         const CREATE_DATE = 1 << 2;
         /// Request for the last modification date of ths directory.
-        /// Response: 32-bit Macintosh time
+        /// Response: 32-bit AFP date-time (signed seconds from Jan 1, 2000)
         const MODIFICATION_DATE = 1 << 3;
         /// Request for the last backup date of this directory.
-        /// Response: 32-bit Macintosh time
+        /// Response: 32-bit AFP date-time (signed seconds from Jan 1, 2000)
         const BACKUP_DATE = 1 << 4;
         /// Request for the Finder information of this directory.
         /// Response: 32-byte Finder information

--- a/tailtalk/src/afp/server.rs
+++ b/tailtalk/src/afp/server.rs
@@ -233,7 +233,7 @@ impl AspSession {
                 tailtalk_packets::afp::AFP_CMD_GET_SRVR_PARMS => {
                     debug!("AFP FPGetSrvrParms req: (no params)");
                     let vol_response = FPGetSrvrParms {
-                        server_time: crate::time_to_afp_v1(std::time::SystemTime::now()),
+                        server_time: crate::time_to_afp(std::time::SystemTime::now()),
                         volumes: vec![our_volume.get_fp_volume()],
                     };
                     debug!(

--- a/tailtalk/src/afp/volume.rs
+++ b/tailtalk/src/afp/volume.rs
@@ -10,7 +10,7 @@ use tailtalk_packets::afp::{
 };
 use encoding_rs::MACINTOSH;
 
-use crate::time_to_afp_v1;
+use crate::time_to_afp;
 use tracing::{error, info};
 #[cfg(unix)]
 use xattr;
@@ -298,20 +298,20 @@ impl Node {
         }
 
         if bitmap.contains(FPFileBitmap::CREATE_DATE) {
-            let created_at_bytes = time_to_afp_v1(creation_time(&metadata)).to_be_bytes();
+            let created_at_bytes = time_to_afp(creation_time(&metadata)).to_be_bytes();
             output[offset..offset + 4].copy_from_slice(&created_at_bytes);
             offset += 4;
         }
 
         if bitmap.contains(FPFileBitmap::MODIFICATION_DATE) {
             let modified = metadata.modified().unwrap_or_else(|_| creation_time(&metadata));
-            let modified_at_bytes = time_to_afp_v1(modified).to_be_bytes();
+            let modified_at_bytes = time_to_afp(modified).to_be_bytes();
             output[offset..offset + 4].copy_from_slice(&modified_at_bytes);
             offset += 4;
         }
 
         if bitmap.contains(FPFileBitmap::BACKUP_DATE) {
-            output[offset..offset + 4].copy_from_slice(&0u32.to_be_bytes());
+            output[offset..offset + 4].copy_from_slice(&crate::AFP_DATE_NEVER.to_be_bytes());
             offset += 4;
         }
 
@@ -602,7 +602,7 @@ fn afp_path_is_empty(path: &Path) -> bool {
 
 impl Volume {
     pub async fn new(name: String, path: PathBuf, volume_id: u16, db: sled::Db) -> Self {
-        let created_at = time_to_afp_v1(SystemTime::now());
+        let created_at = time_to_afp(SystemTime::now());
         let desktop_database = crate::afp::DesktopDatabase::from_db(db, 1)
             .expect("failed to open AFP desktop database");
         let mangle_tree = desktop_database.mangle_names.clone();
@@ -1161,22 +1161,24 @@ impl Volume {
         0
     }
 
-    /// Returns the creation time of the volume as a u32 in Macintosh time format.
+    /// Returns the creation time of the volume as a 32-bit AFP date-time.
     pub fn get_created_at(&self) -> u32 {
         self.created_at
     }
 
-    /// Returns the last modified time of the volume as a u32 in Macintosh time format.
+    /// Returns the last modified time of the volume as a 32-bit AFP date-time.
     pub async fn get_modified_at(&self) -> u32 {
         tokio::fs::metadata(&self.path)
             .await
             .and_then(|m| m.modified())
-            .map(time_to_afp_v1)
+            .map(time_to_afp)
             .unwrap_or(self.created_at)
     }
 
+    /// Returns the backup time of the volume as a 32-bit AFP date-time. We never
+    /// back anything up, so this is always the "never backed up" sentinel.
     pub fn get_backup_at(&self) -> u32 {
-        0
+        crate::AFP_DATE_NEVER
     }
 
     /// Returns the assigned volume ID. This ID is used for all AFP requests to identify this volume.
@@ -3460,7 +3462,11 @@ mod tests {
         assert!(!is_dir);
         assert_eq!(bytes_written, 4);
         let backup_date = u32::from_be_bytes(output[0..4].try_into().unwrap());
-        assert_eq!(backup_date, 0, "backup date should be zero (never backed up)");
+        assert_eq!(
+            backup_date,
+            crate::AFP_DATE_NEVER,
+            "backup date should be the earliest representable time (never backed up)"
+        );
     }
 
     #[tokio::test]

--- a/tailtalk/src/lib.rs
+++ b/tailtalk/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Error;
 use std::path::PathBuf;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 use tailtalk_packets::aarp;
 use tailtalk_packets::ddp::DdpPacket;
 use tailtalk_packets::llap::{LlapPacket, LlapType};
@@ -1196,34 +1196,72 @@ impl TalkStackBuilder {
 
 // ── AFP time helpers ──────────────────────────────────────────────────────────
 
-/// Converts a SystemTime to a 32-bit AFP date for **AFP 2.x** (seconds since Jan 1, 2000).
+/// The AFP date-time meaning "never", used for the backup date of a file or
+/// directory that has never been backed up. It is the earliest representable
+/// time, i.e. the most negative signed 32-bit value.
+pub const AFP_DATE_NEVER: u32 = 0x8000_0000;
+
+/// Seconds from the Unix epoch (Jan 1, 1970) to the AFP epoch (Jan 1, 2000).
+const AFP_EPOCH_OFFSET: i64 = 946_684_800;
+
+/// Converts a SystemTime to a 32-bit AFP date-time.
 ///
-/// AFP 2.0 and later use midnight, January 1, 2000 as the epoch. Times before the
-/// epoch are clamped to 0.
+/// AFP date-times are signed 4-byte counts of seconds from 12:00 A.M. on
+/// January 1, 2000, so anything before then is negative (Inside AppleTalk,
+/// 2nd ed., chapter 13, "Date-time values"). Note this is *not* the classic
+/// Mac OS 1904 epoch, which AFP does not use at any version.
 pub fn time_to_afp(time: SystemTime) -> u32 {
-    // Seconds from Unix epoch (Jan 1, 1970) to AFP 2.x epoch (Jan 1, 2000)
-    const AFP2_EPOCH_OFFSET: u64 = 946_684_800;
+    let unix_secs = match time.duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(after) => after.as_secs() as i64,
+        Err(before) => -(before.duration().as_secs() as i64),
+    };
 
-    let unix_secs = time
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-
-    unix_secs.saturating_sub(AFP2_EPOCH_OFFSET) as u32
+    unix_secs
+        .saturating_sub(AFP_EPOCH_OFFSET)
+        .clamp(i32::MIN as i64, i32::MAX as i64) as i32 as u32
 }
 
-/// Converts a SystemTime to a 32-bit AFP date for **AFP 1.x** (seconds since Jan 1, 1904).
-///
-/// AFP 1.x (and classic Mac OS) use midnight, January 1, 1904 as the epoch —
-/// 2,082,844,800 seconds before the Unix epoch.
-pub fn time_to_afp_v1(time: SystemTime) -> u32 {
-    // Seconds from Jan 1, 1904 (Mac OS classic epoch) to Jan 1, 1970 (Unix epoch)
-    const MAC_TO_UNIX_EPOCH_OFFSET: u64 = 2_082_844_800;
+/// Converts a 32-bit AFP date-time back to a SystemTime. See [`time_to_afp`].
+pub fn afp_to_time(date: u32) -> SystemTime {
+    let unix_secs = date as i32 as i64 + AFP_EPOCH_OFFSET;
+    if unix_secs >= 0 {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(unix_secs as u64)
+    } else {
+        SystemTime::UNIX_EPOCH - Duration::from_secs(unix_secs.unsigned_abs())
+    }
+}
 
-    let unix_secs = time
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+#[cfg(test)]
+mod afp_time_tests {
+    use super::*;
 
-    (unix_secs + MAC_TO_UNIX_EPOCH_OFFSET) as u32
+    /// Midnight, Jan 1 2000 UTC as a Unix timestamp.
+    const AFP_EPOCH_UNIX: u64 = AFP_EPOCH_OFFSET as u64;
+
+    #[test]
+    fn epoch_is_january_1_2000() {
+        let epoch = SystemTime::UNIX_EPOCH + Duration::from_secs(AFP_EPOCH_UNIX);
+        assert_eq!(time_to_afp(epoch), 0);
+    }
+
+    #[test]
+    fn times_before_the_epoch_are_negative() {
+        // Jan 1 1999, one non-leap year before the epoch.
+        let before = SystemTime::UNIX_EPOCH + Duration::from_secs(AFP_EPOCH_UNIX - 365 * 86_400);
+        assert_eq!(time_to_afp(before) as i32, -365 * 86_400);
+    }
+
+    #[test]
+    fn round_trips_either_side_of_the_epoch() {
+        // Well before the epoch (1936), just before, the epoch itself, and after.
+        for offset in [-2_000_000_000i64, -86_400, 0, 86_400, 2_000_000_000] {
+            let time = if offset.is_negative() {
+                SystemTime::UNIX_EPOCH + Duration::from_secs(AFP_EPOCH_UNIX)
+                    - Duration::from_secs(offset.unsigned_abs())
+            } else {
+                SystemTime::UNIX_EPOCH + Duration::from_secs(AFP_EPOCH_UNIX + offset as u64)
+            };
+            assert_eq!(afp_to_time(time_to_afp(time)), time, "offset {offset}");
+        }
+    }
 }


### PR DESCRIPTION
In _The Great Before Times_ (i.e when I started) I did not realise that classic Mac OS clients will calculate the offset between the server reported time and the local time. If the Mac client had a really wrong system time (i.e on virtually all of mine as I did not have working PRAM) this would lead it to starting up set to 1904 or something silly. When it then connected to our server this offset would cause the time to wrap around and report a really really wrong time.

I mistakenly worked around this by calculating based on _that_ offset as the epoch which made it appear to work, even though it was completely wrong. Now that I know this (Thanks @NJRoadfan!) I've stripped out the wrong code and replaced it with the right one based on 1st Jan 2000 as the epoch. We should likely adopt the same offset from UTC that Netatalk does to make this better but that is a change for another day.