### PR TITLE
Printer Bridge: Add support for LaserWriter drivers 5 through 7

### DIFF
--- a/examples/pap-capture/main.rs
+++ b/examples/pap-capture/main.rs
@@ -58,6 +58,7 @@ async fn main() -> Result<()> {
         color: true,
         resolutions_dpi: vec![600],
         paper_sizes: vec![PaperSize::Letter, PaperSize::A4],
+        ..PrinterAttributes::default()
     };
 
     let mut server = stack

--- a/tailtalk-gui/lw_bridge.rs
+++ b/tailtalk-gui/lw_bridge.rs
@@ -28,7 +28,7 @@ use tailtalk::{
     atp::Atp,
     ddp::DdpHandle,
     nbp::{NbpHandle, RegisteredName},
-    pap::{PapServer, PaperSize, PrintJob, PrintSink, PrinterAttributes},
+    pap::{ConnectionId, PapServer, PaperSize, PrintJob, PrintSink, PrinterAttributes},
 };
 use tailtalk_packets::nbp::EntityName;
 use tokio::sync::Mutex;
@@ -214,6 +214,7 @@ pub async fn run(
                                 color: caps.color,
                                 resolutions_dpi: vec![caps.dpi],
                                 paper_sizes: caps.paper_sizes.clone(),
+                                resident_fonts: resident_fonts().await,
                                 ..PrinterAttributes::default()
                             };
 
@@ -225,6 +226,7 @@ pub async fn run(
                                 printer: nbp_name.clone(),
                                 serial: Arc::new(tokio::sync::Mutex::new(())),
                                 counter: std::sync::atomic::AtomicU32::new(0),
+                                laser_prep: LaserPrep::new(),
                             };
 
                             let (socket_num, _, responder) = Atp::spawn(&ddp, None).await;
@@ -492,6 +494,7 @@ struct IppForwardSink {
     /// Serialises forwarded jobs so two quick prints can't arrive out of order.
     serial: Arc<Mutex<()>>,
     counter: AtomicU32,
+    laser_prep: LaserPrep,
 }
 
 impl PrintSink for IppForwardSink {
@@ -505,6 +508,15 @@ impl PrintSink for IppForwardSink {
         let color = self.color;
         let printer = self.printer.clone();
         let serial = self.serial.clone();
+        // A prologue download is not a document; keep it for the jobs that reference
+        // it instead of sending a blank page to the printer. Checked before the
+        // counter moves so job numbers still count documents.
+        if self.laser_prep.capture(job.connection, &job.data) {
+            return Box::pin(std::future::ready(Ok(())));
+        }
+        // Resolved here, while the connection that downloaded it is still the one
+        // being served: the forward runs detached and may outlive it.
+        let prep = self.laser_prep.for_job(job.connection, &job.data);
         let n = self.counter.fetch_add(1, Ordering::Relaxed) + 1;
         Box::pin(async move {
             // Forward in the background so the PAP session keeps answering the Mac's
@@ -512,7 +524,7 @@ impl PrintSink for IppForwardSink {
             // failure here can only be logged.
             tokio::spawn(async move {
                 let _guard = serial.lock().await;
-                match forward_job(&uri, format, dpi, color, job.data, n).await {
+                match forward_job(&uri, format, dpi, color, job.data, prep, n).await {
                     Ok(job_id) => tracing::info!(
                         "LW bridge: job {n} for '{printer}' submitted (IPP job {job_id})"
                     ),
@@ -545,19 +557,27 @@ async fn forward_job(
     dpi: u32,
     color: bool,
     ps: Vec<u8>,
+    prep: Option<Vec<u8>>,
     n: u32,
 ) -> anyhow::Result<i32> {
     let title = ps_title(&ps).unwrap_or_else(|| format!("TailTalk job {n}"));
 
     let doc = match format {
+        // A document from a 5.x/6.x driver is not self-contained PostScript: it
+        // leans on the prologue we swallowed, and forwarding it alone gets
+        // `/undefined in md` at the printer. Ghostscript puts the two back together
+        // and writes out PostScript that stands on its own.
+        ForwardFormat::Postscript if prep.is_some() => {
+            gs_convert(&ps, prep.as_deref(), "ps2write", &[]).await?
+        }
         ForwardFormat::Postscript => ps,
-        ForwardFormat::Pdf => gs_convert(&ps, "pdfwrite", &[]).await?,
+        ForwardFormat::Pdf => gs_convert(&ps, prep.as_deref(), "pdfwrite", &[]).await?,
         ForwardFormat::Urf => {
             let device = if color { "urfrgb" } else { "urfgray" };
-            gs_convert(&ps, device, &[format!("-r{dpi}")]).await?
+            gs_convert(&ps, prep.as_deref(), device, &[format!("-r{dpi}")]).await?
         }
         ForwardFormat::PwgRaster => {
-            gs_convert(&ps, "pwgraster", &[format!("-r{dpi}")]).await?
+            gs_convert(&ps, prep.as_deref(), "pwgraster", &[format!("-r{dpi}")]).await?
         }
     };
 
@@ -589,9 +609,187 @@ async fn forward_job(
     Ok(job_id)
 }
 
+/// Fonts we may tell the Mac are already in the printer, worked out once per run.
+static RESIDENT_FONTS: tokio::sync::OnceCell<Vec<String>> = tokio::sync::OnceCell::const_new();
+
+/// The subset of the standard 35 that our renderer can actually produce.
+///
+/// Claiming a font makes the driver reference it by name instead of downloading the
+/// font program, which is the difference between a job that crawls over LocalTalk
+/// and one that doesn't. Claiming one we cannot render, though, means the page comes
+/// out in a substitute face, so every name is checked against Ghostscript's own
+/// font resources before we promise it. No Ghostscript, no promises: the driver
+/// embeds everything, which is slower but always right.
+async fn resident_fonts() -> Vec<String> {
+    RESIDENT_FONTS
+        .get_or_init(|| async {
+            let available = match gs_font_names().await {
+                Ok(names) => names,
+                Err(e) => {
+                    tracing::info!(
+                        "LW bridge: could not list Ghostscript's fonts ({e}), so the Mac \
+                         will be told the printer has none and will embed them all"
+                    );
+                    return Vec::new();
+                }
+            };
+            let (have, missing): (Vec<&str>, Vec<&str>) = tailtalk::pap::LASERWRITER_35
+                .iter()
+                .copied()
+                .partition(|font| available.contains(*font));
+            if !missing.is_empty() {
+                tracing::info!(
+                    "LW bridge: Ghostscript is missing {} of the standard 35 ({}), \
+                     so those stay embedded",
+                    missing.len(),
+                    missing.join(", ")
+                );
+            }
+            have.into_iter().map(str::to_string).collect()
+        })
+        .await
+        .clone()
+}
+
+/// Ask Ghostscript for every font it can resolve, Fontmap aliases included.
+async fn gs_font_names() -> anyhow::Result<HashSet<String>> {
+    let output = tokio::process::Command::new(crate::ipp_bridge::gs_command())
+        .args(["-q", "-dNODISPLAY", "-dBATCH", "-dNOPAUSE", "-dSAFER"])
+        // resourceforall walks the /Font category, so this covers the URW faces
+        // aliased to the standard names rather than just what is already loaded.
+        .args(["-c", "(*) {cvn ==} 256 string /Font resourceforall quit"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("gs exited with {}: {}", output.status, stderr.trim());
+    }
+
+    // `==` prints each name in syntactic form, so one `/Name` per line.
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix('/'))
+        .map(|name| name.to_string())
+        .collect())
+}
+
+// ── LaserPrep, the Apple `md` dictionary ──────────────────────────────────────
+
+/// Offset of `needle` in `haystack`.
+///
+/// On the bytes, not on a decoded string: a PostScript prologue carries eexec
+/// binary, and an offset counted in a lossy decode of it does not point where it
+/// says it does once a byte has been replaced by a three-byte U+FFFD.
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// The LaserPrep prologue downloaded on the PAP connection currently being served.
+///
+/// The LaserWriter 5.x/6.x/7.x drivers do not put their PostScript dictionary in the
+/// document. They send it as its own PAP job, an ExitServer job that on a real
+/// printer survives in VM until power-off, then print documents that merely say
+/// `%%IncludeProcSet: "(AppleDict md)"` and `md begin`. Each of those documents is
+/// meaningless on its own: Ghostscript stops at `/undefined in md`.
+///
+/// Scoped to the connection that sent it, which is all the scope it needs: we answer
+/// every `%%?BeginProcSetQuery` with "0" (not resident), so a driver re-downloads
+/// the prologue on every connection where it intends to use one, and a capture shows
+/// query, prologue and document arriving as three jobs of a single conversation.
+/// One slot is enough because [`PapServer`] serves one connection at a time and
+/// refuses the rest as busy; a prologue from a conversation that has ended can never
+/// be handed to the next one, because the [`ConnectionId`] will not match.
+pub(crate) struct LaserPrep {
+    held: StdMutex<Option<(ConnectionId, Vec<u8>)>>,
+}
+
+impl LaserPrep {
+    pub(crate) const fn new() -> Self {
+        Self { held: StdMutex::new(None) }
+    }
+
+    /// Remember a job if it is a prologue download, and report whether it was one.
+    ///
+    /// A prologue prints nothing, so a caller that gets `true` should drop the job
+    /// rather than save or forward it.
+    pub(crate) fn capture(&self, connection: ConnectionId, data: &[u8]) -> bool {
+        if !Self::is_prologue(data) {
+            return false;
+        }
+        let stripped = Self::strip_exit_server(data);
+        tracing::info!(
+            "LaserWriter: stored LaserPrep prologue ({} bytes) for this connection, \
+             will replay it ahead of each job that needs it",
+            stripped.len()
+        );
+        *self.held.lock().unwrap() = Some((connection, stripped));
+        true
+    }
+
+    /// The prologue to run ahead of this job: one it asks for, downloaded by the
+    /// conversation it belongs to.
+    pub(crate) fn for_job(&self, connection: ConnectionId, data: &[u8]) -> Option<Vec<u8>> {
+        if !Self::needs_prologue(data) {
+            return None;
+        }
+        let held = self.held.lock().unwrap();
+        let (from, prologue) = held.as_ref()?;
+        (*from == connection).then(|| prologue.clone())
+    }
+
+    /// Is this job a prologue download rather than something to print?
+    ///
+    /// An ExitServer job says so on its `%!PS-Adobe` line. A few driver versions
+    /// leave the header plain, so the `serverdict begin exitserver` call counts too.
+    fn is_prologue(data: &[u8]) -> bool {
+        let head = &data[..data.len().min(4096)];
+        let first = head.split(|&b| b == b'\r' || b == b'\n').next().unwrap_or_default();
+        (first.starts_with(b"%!") && find_bytes(first, b"ExitServer").is_some())
+            || find_bytes(head, b"serverdict begin exitserver").is_some()
+    }
+
+    /// Does this job depend on a prologue it does not carry itself?
+    fn needs_prologue(data: &[u8]) -> bool {
+        let head = &data[..data.len().min(8192)];
+        find_bytes(head, b"%%IncludeProcSet:").is_some()
+            || find_bytes(head, b"(AppleDict md)").is_some()
+    }
+
+    /// Strip the `%%BeginExitServer`/`%%EndExitServer` block from a prologue.
+    ///
+    /// The block is just the password and the `serverdict begin exitserver` call
+    /// that moves the definitions into the printer's permanent VM. Ghostscript
+    /// refuses that call with `/invalidaccess in exitserver`, and we do not need it:
+    /// replaying the prologue ahead of each job gives the same definitions for the
+    /// job's lifetime.
+    fn strip_exit_server(data: &[u8]) -> Vec<u8> {
+        const END: &[u8] = b"%%EndExitServer";
+        let Some(start) = find_bytes(data, b"%%BeginExitServer") else {
+            return data.to_vec();
+        };
+        let Some(end) = find_bytes(&data[start..], END) else {
+            return data.to_vec();
+        };
+        // Take the line terminator after the End comment with it, so the two halves
+        // do not run together into one token.
+        let mut after = start + end + END.len();
+        while data.get(after).is_some_and(|b| *b == b'\r' || *b == b'\n') {
+            after += 1;
+        }
+        let mut out = Vec::with_capacity(data.len());
+        out.extend_from_slice(&data[..start]);
+        out.extend_from_slice(&data[after..]);
+        out
+    }
+}
+
 /// Run Ghostscript over a PostScript job with the given output device.
 pub(crate) async fn gs_convert(
     ps: &[u8],
+    prep: Option<&[u8]>,
     device: &str,
     extra_args: &[String],
 ) -> anyhow::Result<Vec<u8>> {
@@ -601,12 +799,33 @@ pub(crate) async fn gs_convert(
     let out_path = tmp.join(format!("tailtalk-gs-{id}.out"));
     tokio::fs::write(&in_path, ps).await?;
 
-    let output = tokio::process::Command::new(crate::ipp_bridge::gs_command())
-        .args(["-dNOPAUSE", "-dBATCH", "-dSAFER"])
+    // A job that includes a ProcSet we have seen downloaded gets that prologue put
+    // back in front of it, as a *separate* input file rather than concatenated.
+    // LaserPrep decides twice whether it is talking to a genuine LaserWriter, and
+    // when it decides it is not it runs `currentfile … flushfile`, which on one
+    // combined stream would swallow the document along with the rest of itself.
+    // Ghostscript runs each file on the command line in turn in the same
+    // interpreter, so the definitions carry over but the flush stops at the
+    // prologue's own end.
+    let prep_path = match prep {
+        Some(prep) => {
+            let path = tmp.join(format!("tailtalk-gs-{id}-prep.ps"));
+            tokio::fs::write(&path, prep).await?;
+            Some(path)
+        }
+        None => None,
+    };
+
+    let mut cmd = tokio::process::Command::new(crate::ipp_bridge::gs_command());
+    cmd.args(["-dNOPAUSE", "-dBATCH", "-dSAFER"])
         .arg(format!("-sDEVICE={device}"))
         .args(extra_args)
         .arg("-o")
-        .arg(&out_path)
+        .arg(&out_path);
+    if let Some(path) = &prep_path {
+        cmd.arg(path);
+    }
+    let output = cmd
         .arg(&in_path)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -614,6 +833,9 @@ pub(crate) async fn gs_convert(
         .await?;
 
     let _ = tokio::fs::remove_file(&in_path).await;
+    if let Some(path) = &prep_path {
+        let _ = tokio::fs::remove_file(path).await;
+    }
 
     if !output.status.success() {
         let _ = tokio::fs::remove_file(&out_path).await;
@@ -629,6 +851,110 @@ pub(crate) async fn gs_convert(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The header of a real System 6 LaserPrep job, CR-terminated like the wire.
+    const PREP: &[u8] = b"%!PS-Adobe-2.0 ExitServer\r\
+        %%BeginExitServer: 0000000000\r\
+        0000000000\r\
+        serverdict begin exitserver\r\
+        %%EndExitServer\r\
+        %%Title: \"Laser Prep\"\r\
+        /md 200 dict def\r";
+
+    /// The header of the document that follows it.
+    const DOC: &[u8] = b"%!PS-Adobe-2.0\r\
+        %%Creator: TeachText\r\
+        %%IncludeProcSet: \"(AppleDict md)\" 68 0\r\
+        md begin\r";
+
+    #[test]
+    fn laser_prep_recognised() {
+        assert!(LaserPrep::is_prologue(PREP));
+        assert!(!LaserPrep::is_prologue(DOC));
+        // Header without the ExitServer keyword, recognised by the call itself.
+        assert!(LaserPrep::is_prologue(b"%!PS-Adobe-2.0\rserverdict begin exitserver\r"));
+    }
+
+    #[test]
+    fn exit_server_block_stripped() {
+        let out = LaserPrep::strip_exit_server(PREP);
+        let text = String::from_utf8(out).unwrap();
+        // The password and the exitserver call go, everything else stays.
+        assert!(!text.contains("exitserver"));
+        assert!(!text.contains("0000000000"));
+        assert!(text.starts_with("%!PS-Adobe-2.0 ExitServer\r"));
+        assert!(text.contains("/md 200 dict def"));
+        // The two halves must not have run together into one token.
+        assert!(text.contains("ExitServer\r%%Title:"));
+    }
+
+    #[test]
+    fn strip_exit_server_leaves_other_jobs_alone() {
+        assert_eq!(LaserPrep::strip_exit_server(DOC), DOC);
+    }
+
+    #[test]
+    fn exit_server_offsets_are_counted_on_the_bytes() {
+        // A prologue is not text: the definitions it carries are eexec-encrypted, so
+        // an offset taken from a lossy decode would land in the wrong place and cut
+        // the job apart mid-token.
+        let mut prep = PREP.to_vec();
+        prep.extend_from_slice(b"\rdup(\x18\xae\xda\xe1\xa9\xf9)eexec\r");
+        assert!(String::from_utf8(prep.clone()).is_err(), "fixture must not be text");
+
+        let out = LaserPrep::strip_exit_server(&prep);
+        assert!(find_bytes(&out, b"serverdict begin exitserver").is_none());
+        assert!(out.starts_with(b"%!PS-Adobe-2.0 ExitServer\r%%Title:"));
+        assert!(out.ends_with(b"eexec\r"), "the binary tail must survive intact");
+    }
+
+    #[test]
+    fn procset_users_ask_for_the_prologue() {
+        assert!(LaserPrep::needs_prologue(DOC));
+        assert!(!LaserPrep::needs_prologue(
+            b"%!PS-Adobe-3.0\r100 100 moveto\rshowpage\r"
+        ));
+    }
+
+    #[test]
+    fn capturing_a_prologue_consumes_it() {
+        let conn = ConnectionId(1);
+        let store = LaserPrep::new();
+        assert!(store.capture(conn, PREP));
+        assert!(!store.capture(conn, DOC));
+        let held = store
+            .for_job(conn, DOC)
+            .expect("a document asking for it gets it");
+        assert!(!String::from_utf8_lossy(&held).contains("exitserver"));
+        assert_eq!(
+            store.for_job(conn, b"%!PS-Adobe-3.0\rshowpage\r"),
+            None,
+            "a self-contained job is left alone"
+        );
+    }
+
+    #[test]
+    fn a_prologue_belongs_to_the_connection_that_sent_it() {
+        // A driver downloads the prologue on the connection it is about to print
+        // on, so one left over from a conversation that has ended says nothing
+        // about this one: the next driver may be a different version of the
+        // dictionary, or may not use one at all.
+        let store = LaserPrep::new();
+        assert!(store.capture(ConnectionId(1), PREP));
+        assert_eq!(
+            store.for_job(ConnectionId(2), DOC),
+            None,
+            "the next connection must not inherit it"
+        );
+        assert!(store.for_job(ConnectionId(1), DOC).is_some());
+
+        // And the next connection's download replaces it.
+        let mut newer = PREP.to_vec();
+        newer.extend_from_slice(b"/newer true def\r");
+        assert!(store.capture(ConnectionId(2), &newer));
+        assert!(store.for_job(ConnectionId(2), DOC).is_some());
+        assert_eq!(store.for_job(ConnectionId(1), DOC), None);
+    }
 
     #[test]
     fn nbp_names_sanitized() {
@@ -661,6 +987,24 @@ mod tests {
         println!("caps: {caps:?}");
     }
 
+    /// Skipped where Ghostscript isn't installed, since there is nothing to ask.
+    #[tokio::test]
+    async fn gs_reports_the_standard_35() {
+        if !crate::ipp_bridge::gs_probe() {
+            eprintln!("skipping: no Ghostscript on this machine");
+            return;
+        }
+        let names = gs_font_names().await.expect("gs font query failed");
+        // Ghostscript ships URW equivalents of all 35 under the standard names, so
+        // anything missing here means the query itself broke, not the font set.
+        let missing: Vec<_> = tailtalk::pap::LASERWRITER_35
+            .iter()
+            .filter(|f| !names.contains(**f))
+            .collect();
+        assert!(missing.is_empty(), "gs is missing {missing:?} of {} names", names.len());
+        assert_eq!(resident_fonts().await.len(), 35);
+    }
+
     #[test]
     fn ps_title_extracted() {
         let ps = b"%!PS-Adobe-3.0\r%%Title: (My Document)\r%%EndComments\r";
@@ -668,3 +1012,4 @@ mod tests {
         assert_eq!(ps_title(b"%!PS-Adobe-3.0\n"), None);
     }
 }
+

--- a/tailtalk-gui/main.rs
+++ b/tailtalk-gui/main.rs
@@ -1895,6 +1895,7 @@ struct LaserWriterSink {
     dir: PathBuf,
     convert_to_pdf: bool,
     counter: std::sync::atomic::AtomicU32,
+    laser_prep: lw_bridge::LaserPrep,
 }
 
 impl LaserWriterSink {
@@ -1903,6 +1904,7 @@ impl LaserWriterSink {
             dir: dir.into(),
             convert_to_pdf,
             counter: std::sync::atomic::AtomicU32::new(0),
+            laser_prep: lw_bridge::LaserPrep::new(),
         }
     }
 }
@@ -1913,6 +1915,14 @@ impl tailtalk::pap::PrintSink for LaserWriterSink {
         job: tailtalk::pap::PrintJob,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + '_>> {
         let dir = self.dir.clone();
+        // These drivers download their PostScript dictionary as a job of its own
+        // ahead of the document. It prints nothing, so stash it for the documents
+        // that reference it rather than saving it as a job. Checked before the
+        // counter moves so job numbers still count documents.
+        if self.laser_prep.capture(job.connection, &job.data) {
+            return Box::pin(std::future::ready(Ok(())));
+        }
+        let prep = self.laser_prep.for_job(job.connection, &job.data);
         let n = self.counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
         let convert_to_pdf = self.convert_to_pdf;
         Box::pin(async move {
@@ -1924,7 +1934,7 @@ impl tailtalk::pap::PrintSink for LaserWriterSink {
             tokio::fs::create_dir_all(&dir).await?;
 
             if convert_to_pdf {
-                match lw_bridge::gs_convert(&job.data, "pdfwrite", &[]).await {
+                match lw_bridge::gs_convert(&job.data, prep.as_deref(), "pdfwrite", &[]).await {
                     Ok(pdf) => {
                         let path = dir.join(format!("job_{n:04}_{ts}.pdf"));
                         tokio::fs::write(&path, &pdf).await?;
@@ -1950,6 +1960,23 @@ impl tailtalk::pap::PrintSink for LaserWriterSink {
                 job.data.len(),
                 path.display()
             );
+
+            // The document does not carry the dictionary it uses, so on its own this
+            // file renders as `/undefined in md`. Save the prologue beside it,
+            // as its own file rather than glued in front: the prologue ends by
+            // flushing the rest of its input when it decides it is not talking to a
+            // real LaserWriter, which on one combined file takes the document with it.
+            if let Some(prep) = &prep {
+                let prep_path = dir.join(format!("job_{n:04}_{ts}.prolog.ps"));
+                tokio::fs::write(&prep_path, prep).await?;
+                tracing::info!(
+                    "LaserWriter: job {n} needs its LaserPrep prologue, saved → {} \
+                     (render with: gs {} {})",
+                    prep_path.display(),
+                    prep_path.display(),
+                    path.display()
+                );
+            }
             Ok(())
         })
     }

--- a/tailtalk/src/pap.rs
+++ b/tailtalk/src/pap.rs
@@ -538,6 +538,15 @@ pub struct PrinterAttributes {
     pub product_name: String,
     /// PostScript language level (1 or 2). Returned for `*LanguageLevel` queries.
     pub language_level: u8,
+    /// statusdict `version`, the interpreter's ROM version, e.g. `"47.0"` on a
+    /// LaserWriter Plus. Reported for `%%?BeginPrinterQuery` and `*PSVersion`.
+    pub ps_version: String,
+    /// statusdict `revision`, paired with [`ps_version`](Self::ps_version).
+    pub ps_revision: u32,
+    /// Fonts resident in the printer, listed for `%%?BeginFontListQuery`. Empty by
+    /// default: we have no interpreter, and claiming a font we cannot render would
+    /// stop the driver from embedding it.
+    pub resident_fonts: Vec<String>,
     /// Whether the printer supports color output.
     pub color: bool,
     /// Supported output resolutions in DPI (e.g. `vec![600]`).
@@ -552,6 +561,10 @@ impl Default for PrinterAttributes {
             status: "%%[ status: idle; source: EtherTalk ]%%".to_string(),
             product_name: "TailTalk LaserWriter".to_string(),
             language_level: 2,
+            // A common PostScript Level 2 build, matching what we report for *PSVersion.
+            ps_version: "2010.020".to_string(),
+            ps_revision: 0,
+            resident_fonts: Vec::new(),
             color: false,
             resolutions_dpi: vec![300],
             paper_sizes: vec![PaperSize::Letter],
@@ -559,10 +572,24 @@ impl Default for PrinterAttributes {
     }
 }
 
+/// Identifies the PAP connection a job arrived on, for the life of the server.
+///
+/// The PAP connection ID on the wire is only a byte and gets reused, so this is a
+/// counter of our own. A sink that has to carry something from one job to the next
+/// (a downloaded prologue, say) can key it on this and know it will never mistake
+/// the next driver's conversation for the one it was talking to.
+///
+/// Numbering starts at 1, so a fabricated `ConnectionId(0)` matches no real
+/// connection.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct ConnectionId(pub u64);
+
 /// A received print job ready for processing by a [`PrintSink`].
 pub struct PrintJob {
     /// Source AppleTalk address (network/node of the client).
     pub client_addr: AtpAddress,
+    /// The connection this job and its siblings arrived on.
+    pub connection: ConnectionId,
     /// Raw PostScript data received from the client.
     pub data: Vec<u8>,
 }
@@ -634,6 +661,8 @@ pub struct PapServer {
     pub socket_number: u8,
     attributes: Arc<tokio::sync::RwLock<PrinterAttributes>>,
     sink: Box<dyn PrintSink + Send + Sync>,
+    /// Hands out a fresh [`ConnectionId`] to each connection accepted.
+    connections: u64,
 }
 
 impl PapServer {
@@ -650,6 +679,7 @@ impl PapServer {
             socket_number,
             attributes: Arc::new(tokio::sync::RwLock::new(attributes)),
             sink,
+            connections: 0,
         }
     }
 
@@ -737,6 +767,8 @@ impl PapServer {
         };
 
         // ── Phase 2: allocate per-connection socket, send OpenConnReply ────────
+        self.connections += 1;
+        let connection = ConnectionId(self.connections);
         let (conn_socket_num, conn_requestor, mut conn_responder) =
             Atp::spawn(&self.ddp, None).await;
 
@@ -790,10 +822,10 @@ impl PapServer {
         let mut seq: u16 = 1;
         let mut pull = Box::pin(make_pull(seq));
 
-        let mut job_data: Vec<u8> = Vec::new();
-        // Printer stdout queued for the client's reads: the query answer, or empty for a print job.
-        let mut stdout: Vec<u8> = Vec::new();
-        let mut stdout_pos: usize = 0;
+        let mut job = JobBuffer::default();
+        let mut stdout = PrinterStdout::default();
+        // Whether this job's output may be handed to a waiting read. False while a
+        // job is still arriving, since a driver that reads early has to wait.
         let mut response_ready = false;
         // A client read waiting for job output, with its sequence number.
         let mut pending_read: Option<(crate::atp::AtpReceivedRequest, u16)> = None;
@@ -831,39 +863,71 @@ impl PapServer {
                                 data_pkt.data.len(),
                                 data_pkt.eof
                             );
-                            job_data.extend_from_slice(&data_pkt.data);
+                            job.push(&data_pkt.data);
 
-                            if data_pkt.eof && job_data.is_empty() {
+                            if data_pkt.eof && job.is_empty() {
                                 // A zero-byte job (PapClient's post-EOF drain sends one)
                                 // would otherwise clobber a still-unread query answer.
                                 tracing::debug!("PAP: ignoring empty job");
                             } else if data_pkt.eof {
-                                let job = std::mem::take(&mut job_data);
-                                let is_pqp = job.starts_with(b"%!PS-Adobe-3.0 Query");
-                                if is_pqp {
+                                let (data, answered) = job.take();
+                                if pqp_query_style(&data).is_some() {
                                     let attrs = self.attributes.read().await;
-                                    stdout = pqp_stdout(&attrs, &job);
+                                    let writes = pqp_writes(&attrs, &data[answered..]);
                                     tracing::info!(
-                                        "PAP: PQP query from {:?}, answering with {} bytes",
+                                        "PAP: PQP query from {:?}, answering with {} writes",
                                         client_data_addr,
-                                        stdout.len()
+                                        writes.len()
                                     );
+                                    // Behind whatever is still unread, never in place of it: a
+                                    // block answered earlier may not have been collected yet, and
+                                    // dropping it leaves the driver waiting on an answer that has
+                                    // been thrown away.
+                                    stdout.queue(writes);
                                 } else {
-                                    stdout = Vec::new();
-                                    tracing::info!("PAP: job complete, {} bytes received", job.len());
+                                    tracing::info!("PAP: job complete, {} bytes received", data.len());
                                     if let Err(e) = self
                                         .sink
                                         .receive_job(PrintJob {
                                             client_addr: client_data_addr,
-                                            data: job,
+                                            connection,
+                                            data,
                                         })
                                         .await
                                     {
                                         tracing::error!("PAP: sink error: {e}");
                                     }
                                 }
-                                stdout_pos = 0;
                                 response_ready = true;
+                            } else if pqp_query_style(job.as_slice()).is_some()
+                                && let Some(end) = pqp_answerable_prefix(job.unanswered())
+                            {
+                                // Pre-3.0 drivers never set eof on a query job: they write it and
+                                // block on the read, waiting for the printer to speak first. So
+                                // answer as soon as the text is answerable, the way a real
+                                // interpreter's `flush` would, rather than waiting for an eof
+                                // that is never coming.
+                                let block = &job.unanswered()[..end];
+                                let writes = {
+                                    let attrs = self.attributes.read().await;
+                                    pqp_writes(&attrs, block)
+                                };
+                                tracing::info!(
+                                    "PAP: PQP query from {:?} (no eof), answering with {} writes",
+                                    client_data_addr,
+                                    writes.len()
+                                );
+                                let job_over = job_ends_at_eof(block);
+                                stdout.queue(writes);
+                                response_ready = true;
+                                job.mark_answered(end);
+                                if job_over {
+                                    // %%EOF closes the query job outright, so let the buffer go
+                                    // now rather than waiting for the next job's header to say
+                                    // so. Matters for a print job that opens with raw
+                                    // PostScript, which `pqp_resync` has no header to sync on.
+                                    job.clear();
+                                }
                             }
 
                             seq = next_pap_seq(seq);
@@ -929,11 +993,37 @@ impl PapServer {
                             };
                             let (ub, d) = reply.to_atp_parts();
                             let _ = req.send_response(d, ub).await;
-                            if !job_data.is_empty() {
-                                tracing::warn!(
-                                    "PAP: client closed mid-job, discarding {} partial bytes",
-                                    job_data.len()
-                                );
+                            // A query we already answered in full is not an unfinished job,
+                            // so only what is still unanswered counts as one.
+                            if !job.unanswered().is_empty() {
+                                let (data, answered) = job.take();
+                                // A PostScript job is self-delimiting, so a buffer ending in
+                                // %%EOF is a whole job whose driver simply closed instead of
+                                // setting the PAP eof flag, the same omission the pre-3.0
+                                // drivers make on queries. Anything else really is a job cut
+                                // short, and printing half of it helps nobody.
+                                if pqp_query_style(&data).is_none() && job_ends_at_eof(&data) {
+                                    tracing::info!(
+                                        "PAP: client closed without eof, printing the complete {} byte job",
+                                        data.len()
+                                    );
+                                    if let Err(e) = self
+                                        .sink
+                                        .receive_job(PrintJob {
+                                            client_addr: client_data_addr,
+                                            connection,
+                                            data,
+                                        })
+                                        .await
+                                    {
+                                        tracing::error!("PAP: sink error: {e}");
+                                    }
+                                } else {
+                                    tracing::warn!(
+                                        "PAP: client closed mid-job, discarding {} partial bytes",
+                                        data.len() - answered
+                                    );
+                                }
                             }
                             tracing::info!("PAP: connection closed by client");
                             return Ok(());
@@ -1001,14 +1091,12 @@ impl PapServer {
                 }
             }
 
-            // Answer a waiting client read once this job's output is ready; eof on the
-            // final chunk tells the driver we're done, then we reset for the next job.
+            // Answer a waiting client read once this job's output is ready. One printer
+            // write per response, so a font list arrives one name at a time; eof on the
+            // last one tells the driver we're done, then we reset for the next job.
             if response_ready && let Some((req, this_seq)) = pending_read.take() {
-                let remaining = stdout.len().saturating_sub(stdout_pos);
-                let take = remaining.min(req.max_packets() * PAP_MAX_DATA_PER_PACKET);
-                let chunk = stdout[stdout_pos..stdout_pos + take].to_vec();
-                let eof = stdout_pos + take >= stdout.len();
-                stdout_pos += take;
+                let (chunk, eof) =
+                    stdout.next_chunk(req.max_packets() * PAP_MAX_DATA_PER_PACKET);
                 let reply = PapPacket {
                     connection_id: conn_id,
                     function: PapFunction::Data,
@@ -1027,8 +1115,6 @@ impl PapServer {
                 if eof {
                     // This job's output is fully served; ready for the next job.
                     response_ready = false;
-                    stdout = Vec::new();
-                    stdout_pos = 0;
                 }
             }
         }
@@ -1048,59 +1134,375 @@ impl PapServer {
     }
 }
 
-// ── PQP helpers ───────────────────────────────────────────────────────────────
+// ── Session buffers ───────────────────────────────────────────────────────────
 
-/// Build the printer stdout payload for a PQP query job.
+/// The job arriving from the driver, and how much of it has been answered.
 ///
-/// Handles three DSC comment forms, any number of blocks per job:
-/// - `%%?BeginFeatureQuery:` / `%%?EndFeatureQuery:` — PPD feature lookups (`*LanguageLevel`, etc.)
-/// - `%%?BeginQuery:` / `%%?EndQuery:` — general/vendor queries (`ADOSpooler`, `RBIUAMListQuery`, etc.)
-/// - `%%?BeginFontQuery:` / `%%?EndFontQuery:` — font availability queries
-///
-/// Each block's answer is emitted followed by `\r`; no end-of-output marker —
-/// the driver detects completion via the PAP eof flag, like papd.
-fn pqp_stdout(attrs: &PrinterAttributes, job_data: &[u8]) -> Vec<u8> {
-    let text = std::str::from_utf8(job_data).unwrap_or("");
+/// Answered text stays in the buffer rather than being consumed, so the
+/// `%!PS-Adobe-…` header keeps saying what the job is after some of its blocks have
+/// been replied to. Only [`Self::push`] drops anything, and only what
+/// [`pqp_resync`] calls finished business.
+#[derive(Default)]
+struct JobBuffer {
+    data: Vec<u8>,
+    answered: usize,
+}
 
-    enum Block {
-        Query(String),
-        Font(String),
-    }
-
-    let mut out = String::new();
-    let mut current: Option<Block> = None;
-
-    for line in text.split(['\r', '\n']) {
-        if let Some(rest) = line
-            .strip_prefix("%%?BeginFeatureQuery:")
-            .or_else(|| line.strip_prefix("%%?BeginQuery:"))
-        {
-            // The Mac driver sometimes appends inline PS code on the same line:
-            //   "RBIUAMListQuery(*)= flush"  →  we want just "RBIUAMListQuery"
-            // Strip everything from the first `(` or whitespace onward.
-            let rest = rest.trim();
-            let name = rest.split(['(', ' ', '\t']).next().unwrap_or(rest);
-            current = Some(Block::Query(name.to_string()));
-        } else if let Some(rest) = line.strip_prefix("%%?BeginFontQuery:") {
-            current = Some(Block::Font(rest.trim().to_string()));
-        } else if let Some(rest) = line
-            .strip_prefix("%%?EndFeatureQuery")
-            .or_else(|| line.strip_prefix("%%?EndFontQuery"))
-            .or_else(|| line.strip_prefix("%%?EndQuery"))
-        {
-            // The End comment carries the driver's fallback answer: "%%?EndQuery: *"
-            let default_val = rest.trim_start_matches(':').trim();
-            let answer = match current.take() {
-                Some(Block::Font(fonts)) => pqp_font_answer(&fonts),
-                Some(Block::Query(name)) => pqp_answer(attrs, &name, default_val),
-                None => default_val.to_string(),
-            };
-            out.push_str(&answer);
-            out.push('\r');
+impl JobBuffer {
+    /// Append what a Data packet carried, dropping whatever is now spent.
+    fn push(&mut self, bytes: &[u8]) {
+        self.data.extend_from_slice(bytes);
+        let spent = pqp_resync(&self.data, self.answered);
+        if spent > 0 {
+            tracing::debug!("PAP: dropping {spent} bytes ahead of the job header");
+            self.data.drain(..spent);
+            self.answered = self.answered.saturating_sub(spent);
         }
     }
 
-    out.into_bytes()
+    fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// What no answer has covered yet.
+    fn unanswered(&self) -> &[u8] {
+        &self.data[self.answered.min(self.data.len())..]
+    }
+
+    /// Note that `len` more bytes, counted from the front of [`Self::unanswered`],
+    /// have been answered.
+    fn mark_answered(&mut self, len: usize) {
+        self.answered += len;
+    }
+
+    /// Empty the buffer, returning everything in it and where its unanswered part
+    /// begins.
+    fn take(&mut self) -> (Vec<u8>, usize) {
+        let answered = self.answered.min(self.data.len());
+        self.answered = 0;
+        (std::mem::take(&mut self.data), answered)
+    }
+
+    fn clear(&mut self) {
+        self.data.clear();
+        self.answered = 0;
+    }
+}
+
+/// The printer's stdout: the writes a real interpreter would have flushed, waiting
+/// for the driver to read them.
+///
+/// One write per PAP Data response and never two in one, because a font list has to
+/// arrive one name per packet and the drivers that ask for one notice if it does
+/// not. A write too big for a single response is spread over as many as it needs.
+#[derive(Default)]
+struct PrinterStdout {
+    writes: std::collections::VecDeque<Vec<u8>>,
+    /// How far into `writes.front()` the last response got.
+    pos: usize,
+}
+
+impl PrinterStdout {
+    fn queue(&mut self, writes: impl IntoIterator<Item = Vec<u8>>) {
+        self.writes.extend(writes);
+    }
+
+    /// The next response body, and whether it is the last for this job.
+    ///
+    /// Empty and final when nothing is queued, which is the answer a print job gets:
+    /// it produced no output, and the eof says so.
+    fn next_chunk(&mut self, max: usize) -> (Vec<u8>, bool) {
+        let mut chunk = Vec::new();
+        if let Some(write) = self.writes.front() {
+            let take = (write.len() - self.pos).min(max);
+            chunk.extend_from_slice(&write[self.pos..self.pos + take]);
+            self.pos += take;
+            if self.pos >= write.len() {
+                self.writes.pop_front();
+                self.pos = 0;
+            }
+        }
+        (chunk, self.writes.is_empty())
+    }
+}
+
+/// The 35 fonts every PostScript printer has carried since the LaserWriter Plus,
+/// in the names a driver asks for them by.
+///
+/// Worth claiming rather than leaving [`PrinterAttributes::resident_fonts`] empty:
+/// a driver told the printer has none embeds every one it uses, and over LocalTalk
+/// a few hundred KB of font program is minutes of transfer per job. Only claim
+/// these once the renderer is known to have them, which is what
+/// `lw_bridge::resident_fonts` checks. Ghostscript ships URW equivalents of all 35
+/// under exactly these names, and any real PostScript printer has them too.
+pub const LASERWRITER_35: [&str; 35] = [
+    "AvantGarde-Book",
+    "AvantGarde-BookOblique",
+    "AvantGarde-Demi",
+    "AvantGarde-DemiOblique",
+    "Bookman-Demi",
+    "Bookman-DemiItalic",
+    "Bookman-Light",
+    "Bookman-LightItalic",
+    "Courier",
+    "Courier-Bold",
+    "Courier-BoldOblique",
+    "Courier-Oblique",
+    "Helvetica",
+    "Helvetica-Bold",
+    "Helvetica-BoldOblique",
+    "Helvetica-Narrow",
+    "Helvetica-Narrow-Bold",
+    "Helvetica-Narrow-BoldOblique",
+    "Helvetica-Narrow-Oblique",
+    "Helvetica-Oblique",
+    "NewCenturySchlbk-Bold",
+    "NewCenturySchlbk-BoldItalic",
+    "NewCenturySchlbk-Italic",
+    "NewCenturySchlbk-Roman",
+    "Palatino-Bold",
+    "Palatino-BoldItalic",
+    "Palatino-Italic",
+    "Palatino-Roman",
+    "Symbol",
+    "Times-Bold",
+    "Times-BoldItalic",
+    "Times-Italic",
+    "Times-Roman",
+    "ZapfChancery-MediumItalic",
+    "ZapfDingbats",
+];
+
+/// The 13 fonts of the original 1985 LaserWriter, for emulating one of those.
+/// A subset of [`LASERWRITER_35`].
+pub const LASERWRITER_13: [&str; 13] = [
+    "Courier",
+    "Courier-Bold",
+    "Courier-BoldOblique",
+    "Courier-Oblique",
+    "Helvetica",
+    "Helvetica-Bold",
+    "Helvetica-BoldOblique",
+    "Helvetica-Oblique",
+    "Symbol",
+    "Times-Bold",
+    "Times-BoldItalic",
+    "Times-Italic",
+    "Times-Roman",
+];
+
+// ── PQP helpers ───────────────────────────────────────────────────────────────
+//
+// All of these work on the bytes rather than on a decoded string, and split lines
+// themselves rather than borrowing `str::lines`. A query is not necessarily text:
+// the LaserWriter 7.x PatchPrep query wraps an eexec-encrypted ProcSet in its
+// PostScript, so anything that starts by decoding the whole job reads it as no
+// query at all, and any offset taken from a lossy decode of it points somewhere
+// else. The DSC comments are ASCII whatever sits between them, so a line at a time
+// is decoded, lossily, purely to compare it against a prefix.
+
+/// Split a `%%?Begin<kind>Query` line into its kind and any argument after it.
+///
+/// `%%?BeginFeatureQuery: *Product` → `("Feature", "*Product")`, the plain
+/// `%%?BeginQuery:` form yields an empty kind, and the argument-less kinds
+/// (`%%?BeginPrinterQuery`, `%%?BeginFontListQuery`) an empty argument. The colon
+/// is optional precisely because those two never carry one. `None` for other lines.
+fn pqp_begin_line(line: &str) -> Option<(&str, &str)> {
+    let rest = line.strip_prefix("%%?Begin")?;
+    let (kind, rest) = rest.split_once("Query")?;
+    Some((kind, rest.trim_start_matches(':').trim()))
+}
+
+/// Split a `%%?End<kind>Query` line into its kind and the driver's fallback answer.
+///
+/// The End comment carries the answer to use when the printer says nothing:
+/// `%%?EndQuery: *` → `("", "*")`.
+fn pqp_end_line(line: &str) -> Option<(&str, &str)> {
+    let rest = line.strip_prefix("%%?End")?;
+    let (kind, rest) = rest.split_once("Query")?;
+    Some((kind, rest.trim_start_matches(':').trim()))
+}
+
+/// Whether a buffered job ends at its own `%%EOF` trailer, ignoring trailing
+/// whitespace and the `^D` some drivers append.
+fn job_ends_at_eof(job_data: &[u8]) -> bool {
+    let tail = job_data
+        .iter()
+        .rposition(|b| !b.is_ascii_whitespace() && *b != 0x04)
+        .map_or(&[][..], |end| &job_data[..=end]);
+    tail.ends_with(b"%%EOF")
+}
+
+/// How a driver marks a job as a PostScript query.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum QueryStyle {
+    /// `%!PS-Adobe-3.0 Query`: LaserWriter 8, which sets the PAP eof flag.
+    Dsc3,
+    /// Pre-3.0 (LaserWriter 7.x, Color LaserWriter): never sets eof.
+    Legacy,
+}
+
+/// Offset of the `%!` job header in a buffer, or `None` if there isn't one yet.
+fn pqp_magic_offset(job_data: &[u8]) -> Option<usize> {
+    job_data.windows(2).position(|w| w == b"%!")
+}
+
+/// How many leading bytes of the job buffer are finished business and can go.
+///
+/// The buffer holds one job, but drivers do not hand over one job at a time:
+/// - they preface a job with loose PostScript belonging to no job at all, a
+///   `statusdict/jobname(…)put` naming the document being the one we have seen.
+///   Left in place it hides the `%!PS-Adobe` header behind it, and passed to the
+///   interpreter it is stray code either way.
+/// - and having had a query answered in full, the next `%!` they send is the next
+///   job, not more of the one just finished. Pre-3.0 drivers close a query job with
+///   neither a PAP eof nor a `%%EOF`, so this is the only thing that separates the
+///   query from the print job that follows it on the same connection.
+///
+/// Both are text sitting in front of a header that starts no job of its own, so
+/// both are the same rule. Text belonging to a job still being received is never
+/// touched, which is what stops an EPS `%!` embedded in a print job truncating it.
+fn pqp_resync(job_data: &[u8], answered: usize) -> usize {
+    let answered = answered.min(job_data.len());
+    if answered == 0 && job_data.starts_with(b"%!") {
+        return 0; // Mid-job with the header already at the front.
+    }
+    match pqp_magic_offset(&job_data[answered..]) {
+        Some(magic) => answered + magic,
+        // No header in what is left. Either a job is still arriving and its header
+        // is yet to turn up, or a query has been answered to the last byte and what
+        // is buffered is spent.
+        None if answered == job_data.len() => answered,
+        None => 0,
+    }
+}
+
+/// Classify a job from its `%!PS-Adobe-…` header line, or `None` if it is not a query.
+///
+/// Version-agnostic on purpose: LaserWriter 8 sends `%!PS-Adobe-3.0 Query`, the
+/// LaserWriter 7.x-era drivers send `%!PS-Adobe-2.0 Query`, and a few send a bare
+/// `%!PS-Adobe Query`.
+fn pqp_query_style(job_data: &[u8]) -> Option<QueryStyle> {
+    let first = job_data.split(|&b| b == b'\r' || b == b'\n').next().unwrap_or(&[]);
+    let first = String::from_utf8_lossy(first);
+    let rest = first.trim_end().strip_prefix("%!PS-Adobe")?;
+    let rest = rest.strip_suffix("Query")?.trim();
+
+    // "-3.0" → 3.0; a bare "%!PS-Adobe Query" has no version and is pre-3.0.
+    let version: f32 = rest.trim_start_matches('-').parse().unwrap_or(0.0);
+    Some(if version >= 3.0 { QueryStyle::Dsc3 } else { QueryStyle::Legacy })
+}
+
+/// Length of the prefix of a still-open query job that can already be answered,
+/// or `None` if there is nothing complete to answer yet.
+///
+/// A block becomes answerable at its `%%?End…Query` line, and the job's `%%EOF` is
+/// swallowed with it so nothing is left dangling. Answering as soon as we can is
+/// what a real interpreter does, and it is the only thing that works for the
+/// pre-3.0 drivers, which write a query and then block on the read without ever
+/// setting the PAP eof flag we would otherwise wait for.
+fn pqp_answerable_prefix(job_data: &[u8]) -> Option<usize> {
+    // Byte offset just past the newest line that closes a block, or ends the job.
+    let mut end = None;
+    let mut depth = 0usize;
+    let mut pos = 0usize;
+    for line in job_data.split_inclusive(|&b| b == b'\r' || b == b'\n') {
+        pos += line.len();
+        let line = String::from_utf8_lossy(line);
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if pqp_begin_line(trimmed).is_some() {
+            depth += 1;
+        } else if pqp_end_line(trimmed).is_some() {
+            depth = depth.saturating_sub(1);
+            if depth == 0 {
+                end = Some(pos);
+            }
+        } else if depth == 0 && end.is_some() && trimmed.trim() == "%%EOF" {
+            end = Some(pos);
+        }
+    }
+    end
+}
+
+/// Build the printer's stdout for a PQP query job, as the sequence of writes a real
+/// interpreter would have flushed. Each one goes back in its own PAP Data response.
+///
+/// Handles any `%%?Begin<kind>Query` / `%%?End<kind>Query` pair, any number of
+/// blocks per job. Drivers do put several in a single PAP packet, and while that is
+/// off-spec, Netatalk and Apple's own spoolers accept it, so we do too. The kinds
+/// we answer specially are:
+/// - `Feature`: PPD feature lookups (`*LanguageLevel`, `*Product`, …)
+/// - *(empty)*: general/vendor queries (`ADOSpooler`, `RBIUAMListQuery`, …)
+/// - `Printer`: the pre-3.0 identity query, `revision`/`version`/`product`
+/// - `FontList`: everything resident, one write per name
+/// - `Font`: font availability queries
+/// - `ProcSet`: "is this ProcSet already downloaded?", always no for a spooler
+///
+/// Anything else falls back to the answer the driver put in its own End comment.
+fn pqp_writes(attrs: &PrinterAttributes, job_data: &[u8]) -> Vec<Vec<u8>> {
+    let mut out: Vec<Vec<u8>> = Vec::new();
+    let mut current: Option<(String, String)> = None;
+
+    for line in job_data.split(|&b| b == b'\r' || b == b'\n') {
+        let line = String::from_utf8_lossy(line);
+        let line = line.as_ref();
+        if let Some((kind, rest)) = pqp_begin_line(line) {
+            // The Mac driver sometimes appends inline PS code on the same line:
+            //   "RBIUAMListQuery(*)= flush"  →  we want just "RBIUAMListQuery"
+            // Strip everything from the first `(` or whitespace onward.
+            let name = match kind {
+                "Font" | "ProcSet" => rest,
+                _ => rest.split(['(', ' ', '\t']).next().unwrap_or(rest),
+            };
+            current = Some((kind.to_string(), name.to_string()));
+        } else if let Some((_, default_val)) = pqp_end_line(line) {
+            // The `\r` on most answers and the `\n` on two of them are not a slip:
+            // `=` and `==` end their output with a newline, and the queries that go
+            // through them are exactly the two below.
+            let block = current.take();
+            match block.as_ref().map(|(kind, name)| (kind.as_str(), name.as_str())) {
+                // `statusdict begin revision == version == product == end flush` is
+                // one flush after three `==`, so one write of three lines. The space
+                // after the revision is what a real LaserWriter emits; keep it.
+                Some(("Printer", _)) => out.push(
+                    format!(
+                        "{} \n({})\n({})\n",
+                        attrs.ps_revision, attrs.ps_version, attrs.product_name
+                    )
+                    .into_bytes(),
+                ),
+                // `FontDirectory{pop = flush}forall/* = flush` flushes inside the
+                // loop, so every name is its own write and `*` terminates the list.
+                // `=` prints a name without its slash, which is why the terminator
+                // comes out as `*` and not `/*`; the font names match that.
+                Some(("FontList", _)) => {
+                    for font in &attrs.resident_fonts {
+                        out.push(format!("{}\n", font.trim_start_matches('/')).into_bytes());
+                    }
+                    out.push(b"*\n".to_vec());
+                }
+                Some(("Font", fonts)) => {
+                    out.push(format!("{}\r", pqp_font_answer(fonts)).into_bytes())
+                }
+                // 0 = not resident. We have no interpreter and keep no state between
+                // jobs, so the driver must download the ProcSet itself. Its End
+                // comment says "unknown", which is not a usable answer.
+                Some(("ProcSet", _)) => out.push(b"0\r".to_vec()),
+                Some((_, name)) => {
+                    out.push(format!("{}\r", pqp_answer(attrs, name, default_val)).into_bytes())
+                }
+                // An End with no Begin in front of it: the driver's own fallback is
+                // the only answer there is.
+                None => out.push(format!("{default_val}\r").into_bytes()),
+            }
+        }
+    }
+
+    out
 }
 
 /// Return the answer to a named PQP query, falling back to `default` for
@@ -1123,15 +1525,17 @@ fn pqp_answer(attrs: &PrinterAttributes, query: &str, default: &str) -> String {
         // PostScript language level: "1" or "2".
         "*LanguageLevel" => attrs.language_level.to_string(),
 
-        // PS interpreter version: "(versnum) revnum" format.
-        // We emulate a LaserWriter running PS 2010 (a common PS Level 2 build).
-        "*PSVersion" => "(2010.020) 0".to_string(),
+        // PS interpreter version: "(versnum) revnum" format, the same pair the
+        // pre-3.0 %%?BeginPrinterQuery reports.
+        "*PSVersion" => format!("({}) {}", attrs.ps_version, attrs.ps_revision),
 
         // Product name in PS string literal form: "(name)".
         "*Product" => format!("({})", attrs.product_name),
 
-        // Current resolution; same source as RBResolution but different query key.
-        "*?Resolution" => attrs
+        // Current resolution. A driver asks by the PPD's main keyword, `*Resolution`;
+        // `*?Resolution` is what the PPD calls the query entry that answers it, and
+        // some drivers do send that instead, so take either.
+        "*Resolution" | "*?Resolution" => attrs
             .resolutions_dpi
             .first()
             .map(|dpi| format!("{dpi}dpi"))
@@ -1255,11 +1659,273 @@ mod tests {
     }
 
     #[test]
-    fn pqp_stdout_answers_each_block_with_trailing_cr() {
+    fn pqp_writes_answer_each_block_with_trailing_cr() {
         let attrs = PrinterAttributes::default();
         let job = b"%!PS-Adobe-3.0 Query\r\
                     %%?BeginQuery: RBIUAMListQuery\r(*)= flush\r%%?EndQuery: *\r\
                     %%?BeginFeatureQuery: *LanguageLevel\r%%?EndFeatureQuery: 1\r";
-        assert_eq!(pqp_stdout(&attrs, job), b"*\r2\r".to_vec());
+        assert_eq!(pqp_writes(&attrs, job), vec![b"*\r".to_vec(), b"2\r".to_vec()]);
+    }
+
+    /// Verbatim from a System 7 Mac printing to us through the Color LaserWriter
+    /// 12/600 driver. It never sets the PAP eof flag on this, so recognising the
+    /// 2.0 header and the ProcSet block is what keeps the session from deadlocking.
+    const LW7_PROCSET_QUERY: &[u8] = b"%!PS-Adobe-2.0 Query\r\
+        %%Title: Query for PatchPrep\r\
+        %%?BeginProcSetQuery: \"(AppleDict md)\" 71 0\r\
+        userdict/PV known{userdict begin PV 1 ge{(1)}{(2)}ifelse end}\
+        {/md where{pop(2)}{(0)}ifelse}ifelse = flush\r\
+        %%?EndProcSetQuery: unknown\r";
+
+    /// The LaserWriter 7.1.2 PatchPrep query, from a LocalTalk capture (the eexec
+    /// string is shortened, nothing else). Its `{eexec}` branch carries an encrypted
+    /// ProcSet, so the job is binary and decoding the whole buffer as UTF-8 fails.
+    /// Everything here has to work on the bytes: read as "not a query", the driver is
+    /// left blocked on a read that never comes and the print never starts.
+    const LW7_BINARY_PROCSET_QUERY: &[u8] = b"%!PS-Adobe-2.0 Query\r\
+        %%Title: Query for PatchPrep\r\
+        %%?BeginProcSetQuery: \"(AppleDict md)\" 71 0\r\
+        /L{load def}def/I/ifelse L/D/dup L/P/pop L\r\
+        D 0 eq{P vmstatus exch sub exch P 1.8e5\r\
+        gt{save false(\x18\x61\xae\xda\xe1\x18\xa9\xf9\x5f\x16\x5c\x29\xc0\x13\
+        \x7f\x8f\xe6\x56\x81\x1d\xd9\x3d\xfb\xea)\
+        {eexec}stopped{D type/stringtype eq{P}if}if\r\
+        exch restore{20}{0}I}{0}I}if\r\
+        = flush\r\
+        %%?EndProcSetQuery: unknown\r";
+
+    /// The other pre-3.0 shape, from a IIgs-era driver over EtherTalk: two blocks in
+    /// one PAP packet, argument-less Begin comments, and a `%%EOF` in place of the
+    /// PAP eof flag the driver never sets.
+    const LW7_PRINTER_QUERY: &[u8] = b"%!PS-Adobe-2.0 Query\r\
+        %%?BeginPrinterQuery\r\
+        statusdict begin revision == version == product == end flush\r\
+        %%?EndPrinterQuery: Unknown\r\
+        %%?BeginFontListQuery\r\
+        FontDirectory{pop = flush}forall/* = flush\r\
+        %%?EndFontListQuery: /*\r\
+        %%EOF\r";
+
+    #[test]
+    fn pqp_recognises_query_jobs_of_every_dsc_vintage() {
+        use QueryStyle::*;
+        assert_eq!(pqp_query_style(b"%!PS-Adobe-3.0 Query\r"), Some(Dsc3));
+        assert_eq!(pqp_query_style(LW7_PROCSET_QUERY), Some(Legacy));
+        assert_eq!(pqp_query_style(LW7_PRINTER_QUERY), Some(Legacy));
+        assert_eq!(pqp_query_style(b"%!PS-Adobe Query\r"), Some(Legacy));
+        // Real print jobs and partial first lines must never be taken for queries.
+        assert_eq!(pqp_query_style(b"%!PS-Adobe-3.0\rshowpage\r"), None);
+        assert_eq!(pqp_query_style(b"%!PS-Adobe-2.0 Q"), None);
+        assert_eq!(pqp_query_style(b""), None);
+    }
+
+    #[test]
+    fn pqp_answers_procset_query_as_not_resident() {
+        let attrs = PrinterAttributes::default();
+        // The driver's own fallback is the useless word "unknown"; 0 means "not in
+        // the printer", which makes it download the ProcSet as part of the job.
+        assert_eq!(pqp_writes(&attrs, LW7_PROCSET_QUERY), vec![b"0\r".to_vec()]);
+    }
+
+    #[test]
+    fn pqp_answers_a_query_carrying_binary() {
+        assert!(
+            String::from_utf8(LW7_BINARY_PROCSET_QUERY.to_vec()).is_err(),
+            "the point of this fixture is that it is not text"
+        );
+
+        let attrs = PrinterAttributes::default();
+        assert_eq!(pqp_query_style(LW7_BINARY_PROCSET_QUERY), Some(QueryStyle::Legacy));
+
+        // No eof is coming, so the End comment is the only thing that says the block
+        // can be answered; the offset it reports has to be a byte offset into the
+        // original job, not into some re-encoded copy of it.
+        let end = pqp_answerable_prefix(LW7_BINARY_PROCSET_QUERY)
+            .expect("the block ends at its %%?EndProcSetQuery");
+        assert_eq!(end, LW7_BINARY_PROCSET_QUERY.len());
+        assert_eq!(
+            pqp_writes(&attrs, &LW7_BINARY_PROCSET_QUERY[..end]),
+            vec![b"0\r".to_vec()]
+        );
+    }
+
+    #[test]
+    fn pqp_answers_printer_and_font_list_queries() {
+        let attrs = PrinterAttributes {
+            product_name: "LaserWriter Plus".to_string(),
+            ps_version: "47.0".to_string(),
+            ps_revision: 1,
+            ..PrinterAttributes::default()
+        };
+        // Two writes: one flush after the three `==`, then one for the `*` that
+        // terminates an empty font list. The space after the revision is deliberate.
+        assert_eq!(
+            pqp_writes(&attrs, LW7_PRINTER_QUERY),
+            vec![b"1 \n(47.0)\n(LaserWriter Plus)\n".to_vec(), b"*\n".to_vec()],
+        );
+    }
+
+    #[test]
+    fn pqp_font_list_sends_one_unslashed_write_per_name() {
+        // `FontDirectory{pop = flush}forall` flushes inside the loop, so the driver
+        // expects each name in its own PAP packet, then `*` in one of its own. The
+        // names carry no slash: `=` prints a name without one, which is exactly why
+        // the driver's own `/* = flush` terminator comes back as plain `*`.
+        let attrs = PrinterAttributes {
+            resident_fonts: vec!["Times-Roman".to_string(), "/Helvetica".to_string()],
+            ..PrinterAttributes::default()
+        };
+        let writes = pqp_writes(&attrs, LW7_PRINTER_QUERY);
+        assert_eq!(
+            &writes[1..],
+            &[b"Times-Roman\n".to_vec(), b"Helvetica\n".to_vec(), b"*\n".to_vec()],
+        );
+    }
+
+    #[test]
+    fn laserwriter_font_sets_are_the_documented_ones() {
+        // The 13 of the 1985 LaserWriter are a strict subset of the Plus's 35.
+        for font in LASERWRITER_13 {
+            assert!(LASERWRITER_35.contains(&font), "{font} missing from the 35");
+        }
+        // No duplicates, and no stray slashes: these go on the wire as written.
+        let mut sorted = LASERWRITER_35;
+        sorted.sort_unstable();
+        let mut deduped = sorted.to_vec();
+        deduped.dedup();
+        assert_eq!(deduped.len(), LASERWRITER_35.len(), "duplicate font name");
+        assert!(LASERWRITER_35.iter().all(|f| !f.starts_with('/')));
+    }
+
+    #[test]
+    fn pqp_resync_drops_the_prologue_before_a_job_header() {
+        // The jobname prologue arrives in its own PAP packet ahead of the query and
+        // has to go, or the header never lands at the front of the buffer.
+        let prologue = b"statusdict/jobname(User - Byte Knight)put\r";
+        let mut buf = prologue.to_vec();
+        buf.extend_from_slice(LW7_PRINTER_QUERY);
+        assert_eq!(pqp_resync(&buf, 0), prologue.len());
+        assert_eq!(pqp_query_style(&buf[prologue.len()..]), Some(QueryStyle::Legacy));
+
+        // Until the header turns up there is nothing to sync to, so keep buffering.
+        assert_eq!(pqp_resync(prologue, 0), 0);
+        // And a job already sitting at its header is left alone, embedded EPS and all.
+        assert_eq!(pqp_resync(LW7_PRINTER_QUERY, 0), 0);
+        let with_eps = b"%!PS-Adobe-3.0\r%%BeginDocument\r%!PS-Adobe-3.0 EPSF-3.0\r".to_vec();
+        assert_eq!(pqp_resync(&with_eps, 0), 0, "an embedded EPS must not truncate a job");
+    }
+
+    #[test]
+    fn pqp_resync_separates_an_answered_query_from_the_next_job() {
+        // Pre-3.0 drivers close a query with neither a PAP eof nor a %%EOF, so once
+        // the print job's header arrives everything before it is spent. Without this
+        // the buffer still reads as a query and the print job is silently dropped.
+        let answered = LW7_PROCSET_QUERY.len();
+        let mut buf = LW7_PROCSET_QUERY.to_vec();
+        buf.extend_from_slice(b"%!PS-Adobe-3.0\rshowpage\r%%EOF\r");
+        assert_eq!(pqp_resync(&buf, answered), answered);
+        assert_eq!(pqp_query_style(&buf[answered..]), None, "what is left is a print job");
+
+        // A header-less continuation of the same query is not a new job: keep it, and
+        // keep the header in front of it that says what it is.
+        let mut more = LW7_PROCSET_QUERY.to_vec();
+        more.extend_from_slice(b"%%?BeginFeatureQuery: *LanguageLevel\r%%?EndFeatureQuery: 1\r");
+        assert_eq!(pqp_resync(&more, answered), 0);
+        assert_eq!(pqp_query_style(&more), Some(QueryStyle::Legacy));
+
+        // Answered to the last byte with nothing new behind it: the buffer is spent.
+        assert_eq!(pqp_resync(LW7_PROCSET_QUERY, answered), answered);
+    }
+
+    #[test]
+    fn pqp_answerable_prefix_waits_for_a_closed_block() {
+        // Nothing to answer until the End comment lands.
+        let open = &LW7_PROCSET_QUERY[..LW7_PROCSET_QUERY.len() - 30];
+        assert_eq!(pqp_answerable_prefix(open), None);
+
+        // Once it does, the whole block is consumable and nothing is left over.
+        assert_eq!(pqp_answerable_prefix(LW7_PROCSET_QUERY), Some(LW7_PROCSET_QUERY.len()));
+
+        // A second block half-arrived: answer the first, keep the rest buffered.
+        let mut two = LW7_PROCSET_QUERY.to_vec();
+        two.extend_from_slice(b"%%?BeginFeatureQuery: *LanguageLevel\r");
+        assert_eq!(pqp_answerable_prefix(&two), Some(LW7_PROCSET_QUERY.len()));
+
+        // Both blocks and the trailing %%EOF go in one pass, so no scrap of the job
+        // is left behind to be mistaken for the start of the next one.
+        assert_eq!(pqp_answerable_prefix(LW7_PRINTER_QUERY), Some(LW7_PRINTER_QUERY.len()));
+        assert!(job_ends_at_eof(LW7_PRINTER_QUERY), "the %%EOF goes with the block");
+        assert!(!job_ends_at_eof(LW7_PROCSET_QUERY));
+    }
+
+    #[test]
+    fn stdout_serves_one_write_per_response() {
+        let mut stdout = PrinterStdout::default();
+        stdout.queue(vec![b"Times-Roman\n".to_vec(), b"*\n".to_vec()]);
+
+        // Two writes, two responses, however much room the reader offers: a driver
+        // reading a font list counts packets, not bytes.
+        assert_eq!(stdout.next_chunk(512), (b"Times-Roman\n".to_vec(), false));
+        assert_eq!(stdout.next_chunk(512), (b"*\n".to_vec(), true));
+        // Drained, and an extra read is answered with a final empty response rather
+        // than anything left over.
+        assert_eq!(stdout.next_chunk(512), (Vec::new(), true));
+    }
+
+    #[test]
+    fn stdout_splits_a_write_too_big_for_one_response() {
+        let mut stdout = PrinterStdout::default();
+        stdout.queue(vec![vec![b'x'; 5], b"tail".to_vec()]);
+
+        // Not the last response: the rest of the write is still to come.
+        assert_eq!(stdout.next_chunk(2), (vec![b'x'; 2], false));
+        assert_eq!(stdout.next_chunk(2), (vec![b'x'; 2], false));
+        assert_eq!(stdout.next_chunk(2), (vec![b'x'; 1], false));
+        assert_eq!(stdout.next_chunk(2), (b"ta".to_vec(), false));
+        assert_eq!(stdout.next_chunk(2), (b"il".to_vec(), true));
+    }
+
+    #[test]
+    fn stdout_with_nothing_queued_answers_a_print_job() {
+        // A print job produces no output, and the driver still gets one response
+        // with eof to say the job is done.
+        assert_eq!(PrinterStdout::default().next_chunk(512), (Vec::new(), true));
+    }
+
+    #[test]
+    fn job_buffer_keeps_answered_text_and_drops_spent_text() {
+        let mut job = JobBuffer::default();
+        job.push(b"statusdict/jobname(Doc)put\r");
+        job.push(LW7_PROCSET_QUERY);
+        // The prologue went, so the header is at the front where it identifies the job.
+        assert_eq!(job.as_slice(), LW7_PROCSET_QUERY);
+
+        let end = pqp_answerable_prefix(job.unanswered()).unwrap();
+        job.mark_answered(end);
+        assert!(job.unanswered().is_empty(), "nothing left to answer");
+        assert_eq!(
+            pqp_query_style(job.as_slice()),
+            Some(QueryStyle::Legacy),
+            "the answered text stays, so the buffer still knows what it is"
+        );
+
+        // The print job that follows displaces the query it followed.
+        job.push(b"%!PS-Adobe-3.0\rshowpage\r%%EOF\r");
+        assert_eq!(job.as_slice(), b"%!PS-Adobe-3.0\rshowpage\r%%EOF\r");
+        let (data, answered) = job.take();
+        assert_eq!(answered, 0, "none of the print job has been answered");
+        assert_eq!(data, b"%!PS-Adobe-3.0\rshowpage\r%%EOF\r");
+        assert!(job.is_empty());
+    }
+
+    #[test]
+    fn job_ends_at_eof_separates_whole_jobs_from_truncated_ones() {
+        assert!(job_ends_at_eof(b"%!PS-Adobe-3.0\rshowpage\r%%EOF\r"));
+        // Some drivers pad the trailer with ^D and blank lines.
+        assert!(job_ends_at_eof(b"%!PS-Adobe-3.0\rshowpage\r%%EOF\r\x04"));
+        // Cut off mid-job: printing this would waste a page.
+        assert!(!job_ends_at_eof(b"%!PS-Adobe-3.0\rshowpage\r"));
+        assert!(!job_ends_at_eof(b"%%EOF is not a trailer here"));
+        assert!(!job_ends_at_eof(b""));
     }
 }

--- a/tailtalk/tests/pap_test.rs
+++ b/tailtalk/tests/pap_test.rs
@@ -436,6 +436,355 @@ async fn test_pap_server_query_session() {
     hub_task.abort();
 }
 
+/// Stands in for a pre-3.0 LaserWriter driver, which `PapClient` cannot impersonate:
+/// it writes a job without ever setting the PAP eof flag, then blocks on the read
+/// waiting for the printer to speak first.
+struct LegacyDriver {
+    conn_id: u8,
+    conn_addr: tailtalk::atp::AtpAddress,
+    atp_req: tailtalk::atp::AtpRequestor,
+    /// The driver's own read sequence number, advanced once each read is answered.
+    read_seq: u16,
+    /// ATP bitmap on a read, i.e. how many response packets the driver will take.
+    read_bitmap: u8,
+    writer: tokio::task::JoinHandle<()>,
+}
+
+impl LegacyDriver {
+    /// OpenConn by hand, then answer the server's SendData polls out of `writes`,
+    /// one `(block, eof)` per poll, going quiet once they run out.
+    async fn connect(
+        client: TestClient,
+        listener_addr: tailtalk::atp::AtpAddress,
+        read_bitmap: u8,
+        writes: Vec<(Vec<u8>, bool)>,
+    ) -> Self {
+        let conn_id = client.atp_req.socket_number;
+        let open = PapPacket {
+            connection_id: conn_id,
+            function: PapFunction::OpenConn,
+            sequence_num: 0,
+            eof: false,
+            data: vec![client.atp_req.socket_number, 0x08, 0x00, 0x00],
+        };
+        let (ub, data) = open.to_atp_parts();
+        let (reply_data, reply_ub) = client
+            .atp_req
+            .send_request_with_bitmap(listener_addr, ub, data.to_vec(), 0x01)
+            .await
+            .expect("OpenConn failed");
+        let reply = PapPacket::parse_from_atp(reply_ub, &reply_data).expect("OpenConnReply parse");
+        assert_eq!(reply.function, PapFunction::OpenConnReply);
+        assert_eq!(&reply.data[2..4], &[0, 0], "OpenConn must succeed, not report busy");
+        let conn_addr = tailtalk::atp::AtpAddress {
+            socket_number: reply.data[0],
+            ..listener_addr
+        };
+
+        let mut atp_resp = client.atp_resp;
+        let writer = tokio::spawn(async move {
+            let mut writes = writes.into_iter();
+            while let Some(req) = atp_resp.next().await {
+                let Ok(pap) = PapPacket::parse_from_atp(req.user_bytes, &req.data) else {
+                    continue;
+                };
+                if pap.function != PapFunction::SendData {
+                    continue;
+                }
+                let Some((block, eof)) = writes.next() else {
+                    continue; // Nothing left to say until the printer answers.
+                };
+                let resp = PapPacket {
+                    connection_id: conn_id,
+                    function: PapFunction::Data,
+                    sequence_num: pap.sequence_num,
+                    eof,
+                    data: block,
+                };
+                let (ub, d) = resp.to_atp_parts();
+                let _ = req.send_response(d, ub).await;
+            }
+        });
+
+        Self { conn_id, conn_addr, atp_req: client.atp_req, read_seq: 1, read_bitmap, writer }
+    }
+
+    /// Post the read the driver blocks on and wait for the printer to speak. Before
+    /// the fix this waited forever, retransmitting with nothing ever coming back.
+    async fn read(&mut self) -> PapPacket {
+        let read = PapPacket {
+            connection_id: self.conn_id,
+            function: PapFunction::SendData,
+            sequence_num: self.read_seq,
+            eof: false,
+            data: vec![],
+        };
+        let (ub, d) = read.to_atp_parts();
+        let (data, user_bytes) = tokio::time::timeout(
+            Duration::from_secs(10),
+            self.atp_req
+                .send_request_with_bitmap(self.conn_addr, ub, d.to_vec(), self.read_bitmap),
+        )
+        .await
+        .expect("no answer: the pre-3.0 query deadlock is back")
+        .expect("read failed");
+        self.read_seq += 1;
+        let answer = PapPacket::parse_from_atp(user_bytes, &data).expect("answer parse");
+        assert_eq!(answer.function, PapFunction::Data);
+        answer
+    }
+}
+
+/// Spin up a printer emulator and return the workstation, its address, and the
+/// jobs its sink collects.
+async fn legacy_printer(
+    name: &str,
+    socket: u8,
+    mac: u8,
+    attrs: tailtalk::pap::PrinterAttributes,
+) -> (
+    TestClient,
+    tailtalk::atp::AtpAddress,
+    Arc<tokio::sync::Mutex<Vec<Vec<u8>>>>,
+    tokio::task::JoinHandle<()>,
+) {
+    let hub = TestHub::new();
+    let (hub_in_tx, hub_in_rx) = mpsc::channel(100);
+    let hub_ref = Arc::new(hub);
+    let hub_runner = hub_ref.clone();
+    let hub_task = tokio::spawn(async move {
+        hub_runner.run(hub_in_rx).await;
+    });
+
+    let workstation = TestClient::new(
+        [0x00, 0x01, 0x02, 0x03, mac, 0xDD],
+        hub_in_tx.clone(),
+        hub_ref.subscribe(),
+        None,
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    let printer = TestClient::new(
+        [0x00, 0x01, 0x02, 0x03, mac, 0xCC],
+        hub_in_tx.clone(),
+        hub_ref.subscribe(),
+        Some(socket),
+    )
+    .await;
+    printer
+        .nbp
+        .register(RegisteredName {
+            name: name.try_into().unwrap(),
+            sock_num: socket,
+        })
+        .await
+        .expect("Printer registration failed");
+
+    let jobs = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let mut server = tailtalk::pap::PapServer::new(
+        printer.atp_resp,
+        printer.ddp.clone(),
+        socket,
+        attrs,
+        Box::new(CollectSink(jobs.clone())),
+    );
+    tokio::spawn(async move {
+        let _ = server.run().await;
+    });
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let found = workstation
+        .nbp
+        .lookup(name.try_into().unwrap())
+        .await
+        .expect("Lookup failed");
+    let target = found.first().expect("printer not found");
+    let addr = tailtalk::atp::AtpAddress {
+        network_number: target.network_number,
+        node_number: target.node_id,
+        socket_number: target.socket_number,
+    };
+    (workstation, addr, jobs, hub_task)
+}
+
+/// A pre-3.0 driver's query: written with no eof flag, then the driver blocks on
+/// the read waiting for the printer to speak first.
+///
+/// LaserWriter 8 ends a query job with the PAP eof flag, which is what tells the
+/// server the job is complete and can be answered. The LaserWriter 7.x-era drivers
+/// (this is a System 7 Mac talking to us as a "Color LaserWriter 12/600") never
+/// send it, so a server that waits for eof and a driver that waits for an answer
+/// sit staring at each other until the user gives up. Captured in the wild as an
+/// endless exchange of unanswered SendData polls in both directions.
+#[tokio::test]
+async fn test_pap_server_answers_query_without_eof() {
+    let _ = tracing_subscriber::fmt().try_init();
+
+    let (workstation, listener_addr, jobs, hub_task) = legacy_printer(
+        "OldPrinter:LaserWriter@*",
+        133,
+        0x04,
+        tailtalk::pap::PrinterAttributes::default(),
+    )
+    .await;
+
+    let query = b"%!PS-Adobe-2.0 Query\r\
+        %%Title: Query for PatchPrep\r\
+        %%?BeginProcSetQuery: \"(AppleDict md)\" 71 0\r\
+        userdict/PV known{userdict begin PV 1 ge{(1)}{(2)}ifelse end}\
+        {/md where{pop(2)}{(0)}ifelse}ifelse = flush\r\
+        %%?EndProcSetQuery: unknown\r"
+        .to_vec();
+    let mut driver = LegacyDriver::connect(workstation, listener_addr, 0x0f, vec![(query, false)]).await;
+
+    let answer = driver.read().await;
+    assert_eq!(
+        answer.data, b"0\r",
+        "the AppleDict ProcSet is not resident, so the answer is 0"
+    );
+    assert!(answer.eof, "eof ends the response so the driver stops reading");
+
+    assert!(
+        jobs.lock().await.is_empty(),
+        "a query must never be handed to the print sink"
+    );
+
+    println!("✓ PAP pre-3.0 query test passed!");
+
+    driver.writer.abort();
+    hub_task.abort();
+}
+
+/// The other pre-3.0 shape, captured from a IIgs-era driver over EtherTalk.
+///
+/// Three things here that the first capture did not have: a `statusdict/jobname`
+/// prologue arriving in its own packet ahead of the job, so the `%!PS-Adobe` header
+/// is not at the front of the buffer; two query blocks crammed into one PAP packet,
+/// which is off-spec but which Netatalk and Apple's spoolers accept; and a font list
+/// query, whose answer has to come back one write per PAP packet rather than all at
+/// once. The driver still never sets eof, and its reads take one packet each.
+#[tokio::test]
+async fn test_pap_server_answers_printer_and_font_list_query() {
+    let _ = tracing_subscriber::fmt().try_init();
+
+    let attrs = tailtalk::pap::PrinterAttributes {
+        product_name: "LaserWriter Plus".to_string(),
+        ps_version: "47.0".to_string(),
+        ps_revision: 1,
+        resident_fonts: vec!["Times-Roman".to_string(), "Helvetica".to_string()],
+        ..tailtalk::pap::PrinterAttributes::default()
+    };
+    let (workstation, listener_addr, jobs, hub_task) =
+        legacy_printer("OldGSPrinter:LaserWriter@*", 134, 0x05, attrs).await;
+
+    let prologue = b"statusdict/jobname(User - Byte Knight, Document - BK.Greet.f.IIgs)put\r".to_vec();
+    let query = b"%!PS-Adobe-2.0 Query\r\
+        %%?BeginPrinterQuery\r\
+        statusdict begin revision == version == product == end flush\r\
+        %%?EndPrinterQuery: Unknown\r\
+        %%?BeginFontListQuery\r\
+        FontDirectory{pop = flush}forall/* = flush\r\
+        %%?EndFontListQuery: /*\r\
+        %%EOF\r"
+        .to_vec();
+    let mut driver =
+        LegacyDriver::connect(workstation, listener_addr, 0x01, vec![(prologue, false), (query, false)]).await;
+
+    // The printer query flushes once, after all three `==`, so its three lines are
+    // one write. It is not the last one, so no eof yet.
+    let first = driver.read().await;
+    assert_eq!(first.data, b"1 \n(47.0)\n(LaserWriter Plus)\n");
+    assert!(!first.eof, "the font list still has to follow");
+
+    // The font list flushes per name, so each one has to come back in a packet of
+    // its own, and so does the `*` that terminates the list. Batching them into one
+    // response is what the driver will not accept.
+    for expected in [&b"Times-Roman\n"[..], b"Helvetica\n"] {
+        let write = driver.read().await;
+        assert_eq!(write.data, expected);
+        assert!(!write.eof, "the font list is not finished yet");
+    }
+    let last = driver.read().await;
+    assert_eq!(last.data, b"*\n");
+    assert!(last.eof, "the last write of the job's output ends it");
+
+    assert!(
+        jobs.lock().await.is_empty(),
+        "a query must never be handed to the print sink"
+    );
+
+    println!("✓ PAP printer/font-list query test passed!");
+
+    driver.writer.abort();
+    hub_task.abort();
+}
+
+/// What the pre-3.0 drivers actually do next: print, over the same connection.
+///
+/// Their query job ends with neither a PAP eof nor a `%%EOF`, so nothing in the
+/// stream says where it stopped. The print job that follows is what says so, by
+/// arriving with a header of its own. Get that wrong and the print job reads as
+/// more of the query, produces no answers, and is dropped without a trace, which
+/// is a worse bug than the deadlock it comes from: the Mac believes it printed.
+///
+/// The driver here also hands the print job over before collecting its query
+/// answer, so the answer has to survive being overtaken.
+#[tokio::test]
+async fn test_pap_server_prints_after_an_unterminated_query() {
+    let _ = tracing_subscriber::fmt().try_init();
+
+    let (workstation, listener_addr, jobs, hub_task) = legacy_printer(
+        "OldPrinter2:LaserWriter@*",
+        135,
+        0x06,
+        tailtalk::pap::PrinterAttributes::default(),
+    )
+    .await;
+
+    // No %%EOF, no eof flag: this query just stops.
+    let query = b"%!PS-Adobe-2.0 Query\r\
+        %%?BeginProcSetQuery: \"(AppleDict md)\" 71 0\r\
+        userdict/PV known{pop(2)}{(0)}ifelse = flush\r\
+        %%?EndProcSetQuery: unknown\r"
+        .to_vec();
+    let ps_job = b"%!PS-Adobe-3.0\r%%Title: (Greetings)\rshowpage\r%%EOF\r".to_vec();
+    let mut driver = LegacyDriver::connect(
+        workstation,
+        listener_addr,
+        0x0f,
+        vec![(query, false), (ps_job.clone(), true)],
+    )
+    .await;
+
+    // Both writes go over before anything is read back, so the query answer is
+    // still sitting unread when the print job completes.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while jobs.lock().await.is_empty() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "the print job never reached the sink: it was swallowed by the query buffer"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(
+        *jobs.lock().await,
+        vec![ps_job],
+        "the sink must get the print job alone, with no query text glued to the front"
+    );
+
+    let answer = driver.read().await;
+    assert_eq!(
+        answer.data, b"0\r",
+        "the query answer must outlive the print job that overtook it"
+    );
+
+    println!("✓ PAP print-after-query test passed!");
+
+    driver.writer.abort();
+    hub_task.abort();
+}
+
 /// A printer emulator built the way the real callers build it: handed only a
 /// responder, with the requesting half dropped.
 ///


### PR DESCRIPTION
We were missing a good bit of handling for these earlier LaserWriter drivers, namely:

- Returning a list of fonts when queried
- Handling the prologue / dictionary sent ahead of the main print job
- Handling UTF-8 data being sent in the PostScript initial setup

The font part was fairly simple, thanks to the info provided by @NJRoadfan where we query a list of common fonts Ghostscript supports and send them back to the client in the expected format. Any not in this list MacOS will forward on to us as part of the PostScript job.

For the prologue part I've built a little capture for it that gets tied to the PAP connection. By telling the printer that we dont have a copy of it each time we can make this be re-sent as part of every new print connection negating the need to store this beyond the length of the connection. All we then do is pass it through to Ghostscript when we get the actual part of the job.

Lastly we had a few cases where we'd bail if non-parseable UTF8 data was seen (i.e MacRoman was sent or equivalent), which prevented the LW7 driver from working. A simple swap over to the _lossy variant allows us to convert it just fine.

A _good_ bit of refactoring was done here to support the new flows as both the 5.2 driver I tested with on System 6.0.7 and the later 7.1.2 driver I grabbed with Adobe PSPrinter 8.1 had different quirks. I am sure I am still missing some more but this commit makes both of these work along with the one on Mac OS 9 so it seemed to be a good stopping point.

I will continue trying to get different versions (like early 8 versions) to make sure we are compatible with those too based on the bug report by @AlanMenhennet.