### PR TITLE
Start embedded support for tailtalk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1753,7 +1753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2428,6 +2428,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2460,6 +2469,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3920,7 +3939,7 @@ dependencies = [
  "mio",
  "nix 0.31.3",
  "serialport",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4088,7 +4107,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5325,7 +5344,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5802,7 +5821,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5859,7 +5878,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6129,7 +6148,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.2.8",
+ "errno 0.3.14",
  "libc",
 ]
 
@@ -6755,8 +6774,8 @@ dependencies = [
  "assert_hex",
  "bitflags 2.13.1",
  "byteorder",
- "bytes",
  "encoding_rs",
+ "heapless",
  "pretty_assertions",
  "thiserror 2.0.19",
 ]
@@ -6812,10 +6831,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7832,7 +7851,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ resolver = "3"
 
 [workspace.dependencies]
 anyhow = "^1.0.104" #unified
-byteorder = "^1.5.0" #unified
-bytes = "^1.12.1" #unified
+byteorder = { version = "^1.5.0", default-features = false } #unified
+bytes = { version = "^1.12.1", default-features = false } #unified
 clap = { version = "^4.6.6", features = ["derive"] } #unified
-encoding_rs = "^0.8.35" #unified
+encoding_rs = { version = "^0.8.35", default-features = false } #unified
 futures = "^0.3.33" #unified
 hfs-reader = { path = "hfs-reader", version = "^0.1.1" } #unified
 prost = "^0.14" #unified
@@ -31,7 +31,7 @@ tailtalk = { path = "tailtalk" } #unified
 tailtalk-packets = { path = "tailtalk-packets", version = "^0.11" } #unified
 tailtalk-proto = { path = "tailtalk-proto", version = "^0.11" } #unified
 tashtalk = { path = "tashtalk", version = "^0.3" } #unified
-thiserror = "^2.0.19" #unified
+thiserror = { version = "^2.0.19", default-features = false } #unified
 tokio = { version = "^1.53.1", features = ["full", "io-util"] } #unified
 tracing = "^0.1.44" #unified
 

--- a/examples/sw-rename/main.rs
+++ b/examples/sw-rename/main.rs
@@ -70,7 +70,7 @@ async fn main() -> anyhow::Result<()> {
         "Found: {} — {}.{} socket {}",
         printer.entity_name, printer.network_number, printer.node_id, printer.socket_number
     );
-    let old_name = printer.entity_name.object.clone();
+    let old_name = printer.entity_name.object;
 
     // The management ADSP port is fixed at socket 129, independent of the PAP
     // socket that NBP advertises.

--- a/tailtalk-gui/ipp_bridge.rs
+++ b/tailtalk-gui/ipp_bridge.rs
@@ -553,12 +553,15 @@ async fn discover(
     // re-exporting them here would advertise a duplicate.
     {
         let bridged = bridged_names.lock().unwrap();
-        tuples.retain(|(_, t)| !bridged.contains(&(t.entity_name.object.clone(), t.socket_number)));
+        tuples.retain(|(_, t)| !bridged.contains(&(t.entity_name.object.to_utf8_string(), t.socket_number)));
     }
 
     let new_keys: HashSet<String> = tuples.iter()
-        .filter(|(_, t)| !make_key(&t.entity_name.object).is_empty())
-        .map(|(kind, t)| printer_key(*kind, &t.entity_name.object, t.service_address()))
+        .filter_map(|(kind, t)| {
+            let name = t.entity_name.object.to_utf8_string();
+            (!make_key(&name).is_empty())
+                .then(|| printer_key(*kind, &name, t.service_address()))
+        })
         .collect();
 
     // Prune vanished printers under a short-lived write lock, then release it:
@@ -584,14 +587,16 @@ async fn discover(
 
     // Names that appear on more than one device this cycle. The mDNS instance
     // name must be unique, so those get disambiguated by address below.
-    let mut name_counts: HashMap<&str, usize> = HashMap::new();
+    let mut name_counts: HashMap<String, usize> = HashMap::new();
     for (_, t) in &tuples {
-        *name_counts.entry(t.entity_name.object.as_str()).or_default() += 1;
+        *name_counts
+            .entry(t.entity_name.object.to_utf8_string())
+            .or_default() += 1;
     }
 
     for (kind, tuple) in &tuples {
         let kind = *kind;
-        let name = tuple.entity_name.object.clone();
+        let name = tuple.entity_name.object.to_utf8_string();
         let addr = tuple.service_address();
         let key = printer_key(kind, &name, addr);
         if make_key(&name).is_empty() || current_keys.contains(&key) {
@@ -628,7 +633,7 @@ async fn discover(
 
         // When two devices share a name, the mDNS instance name (which must be
         // unique) gets an address tag so both show up; unique names stay clean.
-        let instance_name = if name_counts.get(name.as_str()).copied().unwrap_or(0) > 1 {
+        let instance_name = if name_counts.get(&name).copied().unwrap_or(0) > 1 {
             format!("{name} ({}-{})", addr.network_number, addr.node_number)
         } else {
             name.clone()

--- a/tailtalk-gui/network_explorer.rs
+++ b/tailtalk-gui/network_explorer.rs
@@ -563,9 +563,11 @@ async fn discover(handles: &ExplorerHandles) -> anyhow::Result<Vec<Device>> {
                 );
                 continue;
             }
+            let object = t.entity_name.object.to_utf8_string();
+            let entity_type = t.entity_name.entity_type.to_utf8_string();
             let key = (
-                t.entity_name.object.clone(),
-                t.entity_name.entity_type.clone(),
+                object.clone(),
+                entity_type.clone(),
                 t.network_number,
                 t.node_id,
                 t.socket_number,
@@ -574,10 +576,10 @@ async fn discover(handles: &ExplorerHandles) -> anyhow::Result<Vec<Device>> {
                 continue; // already listed from another pattern
             }
             found.push(Device {
-                kind: DeviceKind::from_nbp_type(&t.entity_name.entity_type),
-                name: t.entity_name.object,
-                nbp_type: t.entity_name.entity_type,
-                zone: t.entity_name.zone,
+                kind: DeviceKind::from_nbp_type(&entity_type),
+                name: object,
+                nbp_type: entity_type,
+                zone: t.entity_name.zone.to_utf8_string(),
                 net: t.network_number,
                 node: t.node_id,
                 socket: t.socket_number,

--- a/tailtalk-packets/Cargo.toml
+++ b/tailtalk-packets/Cargo.toml
@@ -9,11 +9,18 @@ repository = "https://github.com/feralfirmware/tailtalk"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["std", "afp"]
+# Links the standard library. Disable for bare-metal targets.
+std = ["byteorder/std", "encoding_rs/alloc", "thiserror/std"]
+# AFP command parsing. Requires an allocator, so it is unavailable on no_std.
+afp = ["std"]
+
 [dependencies]
-bitflags = "2.13"
+bitflags = { version = "2.13", default-features = false }
 byteorder = { workspace = true } #unified
-bytes = { workspace = true } #unified
 encoding_rs = { workspace = true } #unified
+heapless = { version = "0.9.3", default-features = false }
 thiserror = { workspace = true } #unified
 
 [dev-dependencies]

--- a/tailtalk-packets/src/aarp.rs
+++ b/tailtalk-packets/src/aarp.rs
@@ -1,6 +1,4 @@
-use byteorder::{BigEndian, ReadBytesExt};
-use bytes::{BufMut, BytesMut};
-use std::io::{Cursor, Error, Read};
+use byteorder::{BigEndian, ByteOrder};
 
 pub type EthernetMac = [u8; 6];
 
@@ -9,13 +7,6 @@ pub enum AarpError {
     InvalidSize,
     UnknownOpcode(u16),
     UnsupportedHardwareSize(u8),
-    StdIoError(Error),
-}
-
-impl From<Error> for AarpError {
-    fn from(err: Error) -> AarpError {
-        AarpError::StdIoError(err)
-    }
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
@@ -86,12 +77,11 @@ impl AarpPacket {
             return Err(AarpError::InvalidSize);
         }
 
-        let mut cursor = Cursor::new(buf);
-        let hardware_type = cursor.read_u16::<BigEndian>()?;
-        let protocol_type = cursor.read_u16::<BigEndian>()?;
-        let hardware_size = cursor.read_u8()?;
-        let protocol_size = cursor.read_u8()?;
-        let opcode = match cursor.read_u16::<BigEndian>()? {
+        let hardware_type = BigEndian::read_u16(&buf[0..2]);
+        let protocol_type = BigEndian::read_u16(&buf[2..4]);
+        let hardware_size = buf[4];
+        let protocol_size = buf[5];
+        let opcode = match BigEndian::read_u16(&buf[6..8]) {
             1 => AarpOpcode::Request,
             2 => AarpOpcode::Response,
             3 => AarpOpcode::Probe,
@@ -105,13 +95,13 @@ impl AarpPacket {
         let mut proto_buf = [0u8; 4];
 
         let mut sender_mac = [0u8; 6];
-        cursor.read_exact(&mut sender_mac)?;
-        cursor.read_exact(&mut proto_buf)?;
+        sender_mac.copy_from_slice(&buf[8..14]);
+        proto_buf.copy_from_slice(&buf[14..18]);
         let sender_protocol = AppleTalkAddress::decode(proto_buf);
 
         let mut target_mac = [0u8; 6];
-        cursor.read_exact(&mut target_mac)?;
-        cursor.read_exact(&mut proto_buf)?;
+        target_mac.copy_from_slice(&buf[18..24]);
+        proto_buf.copy_from_slice(&buf[24..28]);
         let target_protocol = AppleTalkAddress::decode(proto_buf);
 
         Ok(Self {
@@ -128,27 +118,24 @@ impl AarpPacket {
     }
 
     pub fn to_bytes(&self, buffer: &mut [u8]) -> usize {
-        let mut buf = BytesMut::with_capacity(Self::LEN);
-        buf.put_u16(self.hardware_type);
-        buf.put_u16(self.protocol_type);
-        buf.put_u8(self.hardware_size);
-        buf.put_u8(self.protocol_size);
-        buf.put_u16(self.opcode as u16);
+        BigEndian::write_u16(&mut buffer[0..2], self.hardware_type);
+        BigEndian::write_u16(&mut buffer[2..4], self.protocol_type);
+        buffer[4] = self.hardware_size;
+        buffer[5] = self.protocol_size;
+        BigEndian::write_u16(&mut buffer[6..8], self.opcode as u16);
 
-        buf.put_slice(&self.sender_addr);
+        buffer[8..14].copy_from_slice(&self.sender_addr);
 
         let mut encoded = [0u8; 4];
         self.sender_protocol.encode(&mut encoded);
-        buf.put_slice(&encoded);
+        buffer[14..18].copy_from_slice(&encoded);
 
-        buf.put_slice(&self.target_addr);
+        buffer[18..24].copy_from_slice(&self.target_addr);
 
         self.target_protocol.encode(&mut encoded);
-        buf.put_slice(&encoded);
+        buffer[24..28].copy_from_slice(&encoded);
 
-        let used = buf.len();
-        buffer[..used].copy_from_slice(&buf);
-        used
+        Self::LEN
     }
 }
 

--- a/tailtalk-packets/src/headers.rs
+++ b/tailtalk-packets/src/headers.rs
@@ -20,11 +20,11 @@ pub enum TransportHeader {
 }
 
 #[derive(Debug)]
-pub struct AppleTalkHeaders {
+pub struct AppleTalkHeaders<'a> {
     pub link: EtherTalkPhase2Frame,
     pub net: NetHeader,
     pub transport: Option<TransportHeader>,
-    pub payload: Option<Box<[u8]>>,
+    pub payload: Option<&'a [u8]>,
 }
 
 #[derive(Error, Debug)]
@@ -45,7 +45,7 @@ pub enum AppleTalkError {
     AtpError(AtpError),
 }
 
-impl AppleTalkHeaders {
+impl<'a> AppleTalkHeaders<'a> {
     pub fn encode(mut self, buffer: &mut [u8]) -> Result<usize, AppleTalkError> {
         let net_size = match self.net {
             NetHeader::Ddp(_) => DdpPacket::LEN,
@@ -95,14 +95,14 @@ impl AppleTalkHeaders {
                     found: buffer.len(),
                 });
             }
-            buffer[pos..(pos + payload.len())].copy_from_slice(&payload);
+            buffer[pos..(pos + payload.len())].copy_from_slice(payload);
             pos += payload.len();
         }
 
         Ok(pos)
     }
 
-    pub fn decode(pkt: &[u8]) -> Result<AppleTalkHeaders, AppleTalkError> {
+    pub fn decode(pkt: &[u8]) -> Result<AppleTalkHeaders<'_>, AppleTalkError> {
         let link = EtherTalkPhase2Frame::parse(pkt).map_err(AppleTalkError::LinkHeaderError)?;
 
         let net = match link.protocol {
@@ -133,7 +133,7 @@ impl AppleTalkHeaders {
                         .map_err(AppleTalkError::AtpError)?;
                     let payload_offset = offset + AtpPacket::HEADER_LEN;
                     let payload = if payload_offset < pkt.len() {
-                        Some(pkt[payload_offset..].to_vec().into_boxed_slice())
+                        Some(&pkt[payload_offset..])
                     } else {
                         None
                     };

--- a/tailtalk-packets/src/lib.rs
+++ b/tailtalk-packets/src/lib.rs
@@ -1,5 +1,12 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+/// Re-exported so consumers can name the fixed-capacity types in this crate's
+/// public API without depending on a matching `heapless` version themselves.
+pub use heapless;
+
 pub mod aarp;
 pub mod adsp;
+#[cfg(feature = "afp")]
 pub mod afp;
 pub mod asp;
 
@@ -8,6 +15,7 @@ pub mod atp;
 pub mod ddp;
 pub mod ethertalk;
 pub mod headers;
+pub mod limits;
 pub mod llap;
 pub mod nbp;
 pub mod pap;

--- a/tailtalk-packets/src/limits.rs
+++ b/tailtalk-packets/src/limits.rs
@@ -1,0 +1,145 @@
+//! Capacity bounds for the fixed-size containers used across the packet types.
+//!
+//! Every bound here comes from the AppleTalk wire format itself, so a packet
+//! that parses at all fits within these limits.
+
+/// Largest DDP datagram payload: the 599-byte datagram minus its 13-byte header.
+pub const DDP_MAX_PAYLOAD: usize = 586;
+
+/// Longest entity-name component NBP can express with its 1-byte length prefix.
+pub const MAX_NBP_NAME: usize = 32;
+
+/// NBP packs the tuple count into the low nibble of the control byte.
+pub const MAX_NBP_TUPLES: usize = 15;
+
+/// Smallest RTMP routing tuple: network number (2 bytes) plus distance (1 byte).
+const RTMP_MIN_TUPLE_LEN: usize = 3;
+
+/// Sender info preceding the tuples: network number (2 bytes), ID length, node ID.
+const RTMP_SENDER_INFO_LEN: usize = 4;
+
+/// Most routing tuples an RTMP Data packet can carry in one DDP datagram.
+pub const MAX_RTMP_TUPLES: usize = (DDP_MAX_PAYLOAD - RTMP_SENDER_INFO_LEN) / RTMP_MIN_TUPLE_LEN;
+
+/// Hardware multicast address length on EtherTalk.
+pub const MAX_MULTICAST_LEN: usize = 6;
+
+/// An entity-name component, held in the MacRoman encoding it has on the wire.
+///
+/// MacRoman is not a subset of UTF-8, so names such as `Microsoft(r) Windows(tm)`
+/// are not valid UTF-8 once encoded. Storing the wire bytes keeps those names
+/// intact; use [`MacRomanStr::decode`] to render one as text.
+pub type NbpName = MacRomanStr<MAX_NBP_NAME>;
+
+/// A zone name bounded by the ZIP limit, held in its on-the-wire MacRoman encoding.
+pub type ZoneName = MacRomanStr<{ crate::zip::MAX_ZONE_LENGTH }>;
+
+/// Worst-case UTF-8 expansion when decoding MacRoman: every byte can become a
+/// 3-byte code point.
+pub const UTF8_EXPANSION: usize = 3;
+
+/// Buffer size that holds any name in this module once decoded to UTF-8.
+pub const MAX_NAME_UTF8_LEN: usize = MAX_NBP_NAME * UTF8_EXPANSION;
+
+/// A multicast address as carried in a ZIP GetNetInfo reply.
+pub type MulticastAddr = heapless::Vec<u8, MAX_MULTICAST_LEN, u8>;
+
+/// A length-bounded string stored in the MacRoman encoding used on the AppleTalk wire.
+///
+/// The bytes are kept exactly as they appear in the packet, so encoding a parsed
+/// name reproduces the original datagram byte for byte.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MacRomanStr<const N: usize> {
+    bytes: [u8; N],
+    len: u8,
+}
+
+impl<const N: usize> MacRomanStr<N> {
+    /// Builds a name from its on-the-wire MacRoman bytes.
+    pub fn from_wire(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() > N {
+            return None;
+        }
+        let mut stored = [0u8; N];
+        stored[..bytes.len()].copy_from_slice(bytes);
+        Some(Self {
+            bytes: stored,
+            len: bytes.len() as u8,
+        })
+    }
+
+    /// Encodes UTF-8 text into MacRoman. Returns `None` if the text does not
+    /// fit, or contains characters MacRoman cannot represent.
+    pub fn from_text(text: &str) -> Option<Self> {
+        let mut stored = [0u8; N];
+        let encoder = &mut encoding_rs::MACINTOSH.new_encoder();
+        let (result, _, written) = encoder.encode_from_utf8_without_replacement(text, &mut stored, true);
+        match result {
+            encoding_rs::EncoderResult::InputEmpty => Some(Self {
+                bytes: stored,
+                len: written as u8,
+            }),
+            _ => None,
+        }
+    }
+
+    /// The name as it appears on the wire.
+    pub fn as_wire(&self) -> &[u8] {
+        &self.bytes[..self.len as usize]
+    }
+
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Decodes the name to UTF-8 in `buf`, which must hold [`UTF8_EXPANSION`]
+    /// bytes per wire byte. Returns `None` if `buf` is too small.
+    pub fn decode<'b>(&self, buf: &'b mut [u8]) -> Option<&'b str> {
+        let decoder = &mut encoding_rs::MACINTOSH.new_decoder_without_bom_handling();
+        let (result, _, written) =
+            decoder.decode_to_utf8_without_replacement(self.as_wire(), buf, true);
+        match result {
+            encoding_rs::DecoderResult::InputEmpty => {
+                core::str::from_utf8(&buf[..written]).ok()
+            }
+            _ => None,
+        }
+    }
+}
+
+impl<const N: usize> Default for MacRomanStr<N> {
+    fn default() -> Self {
+        Self { bytes: [0; N], len: 0 }
+    }
+}
+
+impl<const N: usize> TryFrom<&str> for MacRomanStr<N> {
+    type Error = ();
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::from_text(value).ok_or(())
+    }
+}
+
+impl<const N: usize> core::fmt::Display for MacRomanStr<N> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut buf = [0u8; MAX_NAME_UTF8_LEN];
+        match self.decode(&mut buf) {
+            Some(text) => f.write_str(text),
+            None => Err(core::fmt::Error),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<const N: usize> MacRomanStr<N> {
+    /// Decodes the name to an owned UTF-8 string, replacing anything MacRoman
+    /// cannot round-trip.
+    pub fn to_utf8_string(&self) -> String {
+        encoding_rs::MACINTOSH.decode(self.as_wire()).0.into_owned()
+    }
+}

--- a/tailtalk-packets/src/nbp.rs
+++ b/tailtalk-packets/src/nbp.rs
@@ -1,13 +1,40 @@
 #![allow(dead_code)]
 
-use std::fmt::Display;
+use crate::limits::{MAX_NBP_NAME, MAX_NBP_TUPLES, NbpName};
+use core::fmt::Display;
+use thiserror::Error;
+
+/// NBP wildcard matching any name, as it appears on the wire.
+const WILDCARD_STAR: u8 = b'*';
+/// NBP wildcard matching the current zone.
+const WILDCARD_EQUALS: u8 = b'=';
+/// The MacRoman encoding of the `≈` wildcard.
+const WILDCARD_APPROX: u8 = 0xC5;
+
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum NbpError {
+    #[error("packet too short to be valid")]
+    TooShort,
+    #[error("field exceeds packet bounds")]
+    OutOfBounds,
+    #[error("name component exceeds the {MAX_NBP_NAME}-byte NBP maximum")]
+    NameTooLong,
+    #[error("name component is not valid UTF-8")]
+    NameNotUtf8,
+    #[error("more than {MAX_NBP_TUPLES} tuples")]
+    TooManyTuples,
+    #[error("buffer too small: need {needed} bytes but only {available} available")]
+    BufferTooSmall { needed: usize, available: usize },
+    #[error("malformed entity name: {0}")]
+    MalformedEntityName(&'static str),
+}
 
 /// Represents an NBP packet for AppleTalk.
 #[derive(Debug)]
 pub struct NbpPacket {
     pub operation: NbpOperation, // NBP operation type
     pub transaction_id: u8,      // Transaction ID for matching requests and responses
-    pub tuples: Vec<NbpTuple>,   // List of NBP tuples
+    pub tuples: heapless::Vec<NbpTuple, MAX_NBP_TUPLES>, // List of NBP tuples
 }
 
 /// Enum for NBP operation types.
@@ -79,16 +106,16 @@ impl NbpTuple {
 /// Represents an entity name in NBP.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct EntityName {
-    pub object: String,      // Object name
-    pub entity_type: String, // Type of the entity (e.g., service type)
-    pub zone: String,        // Zone name
+    pub object: NbpName,      // Object name
+    pub entity_type: NbpName, // Type of the entity (e.g., service type)
+    pub zone: NbpName,        // Zone name
 }
 
 impl NbpPacket {
     /// Parses an NBP packet from raw bytes.
-    pub fn from_bytes(data: &[u8]) -> Result<Self, String> {
+    pub fn from_bytes(data: &[u8]) -> Result<Self, NbpError> {
         if data.len() < 2 {
-            return Err("Packet too short to be valid".to_string());
+            return Err(NbpError::TooShort);
         }
 
         let control_byte = data[0];
@@ -96,11 +123,11 @@ impl NbpPacket {
         let tuple_count = control_byte & 0x0F;
         let transaction_id = data[1];
         let mut offset = 2;
-        let mut tuples = Vec::new();
+        let mut tuples = heapless::Vec::new();
 
         for _ in 0..tuple_count {
             if offset + 5 > data.len() {
-                return Err("Packet too short for declared tuple count".to_string());
+                return Err(NbpError::TooShort);
             }
 
             let network_number = u16::from_be_bytes([data[offset], data[offset + 1]]);
@@ -112,13 +139,15 @@ impl NbpPacket {
             let (entity_name, name_length) = EntityName::from_bytes(&data[offset..])?;
             offset += name_length;
 
-            tuples.push(NbpTuple {
-                network_number,
-                node_id,
-                socket_number,
-                enumerator,
-                entity_name,
-            });
+            tuples
+                .push(NbpTuple {
+                    network_number,
+                    node_id,
+                    socket_number,
+                    enumerator,
+                    entity_name,
+                })
+                .map_err(|_| NbpError::TooManyTuples)?;
         }
 
         Ok(NbpPacket {
@@ -130,11 +159,11 @@ impl NbpPacket {
 
     /// Serializes the NBP packet into a byte slice.
     /// Returns the size of the serialized data.
-    pub fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, String> {
+    pub fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, NbpError> {
         let mut offset = 0;
 
         if buffer.len() < 2 {
-            return Err("Buffer too small to hold the header".to_string());
+            return Err(NbpError::BufferTooSmall { needed: 2, available: buffer.len() });
         }
 
         // Write control byte (operation and tuple count)
@@ -148,7 +177,10 @@ impl NbpPacket {
         // Write tuples
         for tuple in &self.tuples {
             if offset + 5 > buffer.len() {
-                return Err("Buffer too small to hold tuple data".to_string());
+                return Err(NbpError::BufferTooSmall {
+                    needed: offset + 5,
+                    available: buffer.len(),
+                });
             }
 
             buffer[offset..offset + 2].copy_from_slice(&tuple.network_number.to_be_bytes());
@@ -172,82 +204,78 @@ impl NbpPacket {
 }
 
 impl TryFrom<&str> for EntityName {
-    type Error = &'static str;
+    type Error = NbpError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         let first_index = value
             .find(':')
-            .ok_or("malformed entity name - missing : separator")?;
+            .ok_or(NbpError::TooShort)?;
         let second_index = value
             .find('@')
-            .ok_or("malformed entity name - missing @ separator")?;
+            .ok_or(NbpError::TooShort)?;
 
         if first_index > second_index {
-            return Err("malformed entity name - : was found after @");
+            return Err(NbpError::MalformedEntityName("malformed entity name - : was found after @"));
         }
 
         let object = &value[..first_index];
         if object.is_empty() {
-            return Err("malformed entity name - object is empty");
+            return Err(NbpError::MalformedEntityName("malformed entity name - object is empty"));
         }
 
         let entity_type = &value[first_index + 1..second_index];
         if entity_type.is_empty() {
-            return Err("malformed entity name - type is empty");
+            return Err(NbpError::MalformedEntityName("malformed entity name - type is empty"));
         }
 
         let zone = &value[second_index + 1..];
         if zone.is_empty() {
-            return Err("malformed entity name - zone is empty");
+            return Err(NbpError::MalformedEntityName("malformed entity name - zone is empty"));
         }
 
         Ok(EntityName {
-            object: object.into(),
-            entity_type: entity_type.into(),
-            zone: zone.into(),
+            object: object.try_into().map_err(|_| NbpError::NameTooLong)?,
+            entity_type: entity_type.try_into().map_err(|_| NbpError::NameTooLong)?,
+            zone: zone.try_into().map_err(|_| NbpError::NameTooLong)?,
         })
     }
 }
 
 impl Display for EntityName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}:{}@{}", self.object, self.entity_type, self.zone)
     }
 }
 
 impl EntityName {
     /// Parses an entity name (object, type, zone) from raw bytes.
-    pub fn from_bytes(data: &[u8]) -> Result<(Self, usize), String> {
+    pub fn from_bytes(data: &[u8]) -> Result<(Self, usize), NbpError> {
         let mut offset = 0;
 
-        let object_length = *data.get(offset).ok_or("Missing object length")? as usize;
+        let object_length = *data.get(offset).ok_or(NbpError::TooShort)? as usize;
         offset += 1;
 
         if offset + object_length > data.len() {
-            return Err("Object name field exceeds packet bounds".to_string());
+            return Err(NbpError::OutOfBounds);
         }
-        let (object_cow, _, _) =
-            encoding_rs::MACINTOSH.decode(&data[offset..offset + object_length]);
-        let object = object_cow.into_owned();
+        let object = name_from_wire(&data[offset..offset + object_length])?;
         offset += object_length;
 
-        let type_length = *data.get(offset).ok_or("Missing type length")? as usize;
+        let type_length = *data.get(offset).ok_or(NbpError::TooShort)? as usize;
         offset += 1;
 
         if offset + type_length > data.len() {
-            return Err("Type name field exceeds packet bounds".to_string());
+            return Err(NbpError::OutOfBounds);
         }
-        let (type_cow, _, _) = encoding_rs::MACINTOSH.decode(&data[offset..offset + type_length]);
-        let entity_type = type_cow.into_owned();
+        let entity_type = name_from_wire(&data[offset..offset + type_length])?;
         offset += type_length;
 
-        let zone_length = *data.get(offset).ok_or("Missing zone length")? as usize;
+        let zone_length = *data.get(offset).ok_or(NbpError::TooShort)? as usize;
         offset += 1;
         if offset + zone_length > data.len() {
-            return Err("Zone name field exceeds packet bounds".to_string());
+            return Err(NbpError::OutOfBounds);
         }
-        let (zone_cow, _, _) = encoding_rs::MACINTOSH.decode(&data[offset..offset + zone_length]);
-        let zone = zone_cow.into_owned();
+        let zone = name_from_wire(&data[offset..offset + zone_length])?;
         offset += zone_length;
 
         Ok((
@@ -262,64 +290,66 @@ impl EntityName {
 
     /// Serializes the entity name into a byte slice.
     /// Returns the size of the serialized data.
-    pub fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, String> {
+    pub fn to_bytes(&self, buffer: &mut [u8]) -> Result<usize, NbpError> {
         let mut offset = 0;
 
-        let (object_cow, _, _) = encoding_rs::MACINTOSH.encode(self.object.as_str());
-        let object = object_cow.into_owned();
-        let (type_cow, _, _) = encoding_rs::MACINTOSH.encode(self.entity_type.as_str());
-        let entity_type = type_cow.into_owned();
-        let (zone_cow, _, _) = encoding_rs::MACINTOSH.encode(self.zone.as_str());
-        let zone = zone_cow.into_owned();
+        let object = self.object.as_wire();
+        let entity_type = self.entity_type.as_wire();
+        let zone = self.zone.as_wire();
 
         let calc_size = 1 + object.len() + 1 + entity_type.len() + 1 + zone.len();
         if buffer.len() < calc_size {
-            return Err(format!(
-                "Buffer too small to hold entity name. Buf is: {}, calc_size: {calc_size}",
-                buffer.len()
-            ));
+            return Err(NbpError::BufferTooSmall {
+                needed: calc_size,
+                available: buffer.len(),
+            });
         }
 
         buffer[offset] = object.len() as u8;
         offset += 1;
-        buffer[offset..offset + object.len()].copy_from_slice(&object);
+        buffer[offset..offset + object.len()].copy_from_slice(object);
         offset += object.len();
 
         buffer[offset] = entity_type.len() as u8;
         offset += 1;
-        buffer[offset..offset + entity_type.len()].copy_from_slice(&entity_type);
+        buffer[offset..offset + entity_type.len()].copy_from_slice(entity_type);
         offset += entity_type.len();
 
         buffer[offset] = zone.len() as u8;
         offset += 1;
-        buffer[offset..offset + zone.len()].copy_from_slice(&zone);
+        buffer[offset..offset + zone.len()].copy_from_slice(zone);
         offset += zone.len();
 
         Ok(offset)
     }
 
     pub fn matches(&self, pattern: &EntityName) -> bool {
-        let match_part = |concrete: &str, pattern: &str| -> bool {
-            if pattern == "=" || pattern == "≈" || pattern == "*" {
+        let match_part = |concrete: &[u8], pattern: &[u8]| -> bool {
+            if matches!(pattern, [WILDCARD_EQUALS] | [WILDCARD_APPROX] | [WILDCARD_STAR]) {
                 return true;
             }
             concrete.eq_ignore_ascii_case(pattern)
         };
 
-        match_part(&self.object, &pattern.object)
-            && match_part(&self.entity_type, &pattern.entity_type)
-            && match_part(&self.zone, &pattern.zone)
+        match_part(self.object.as_wire(), pattern.object.as_wire())
+            && match_part(self.entity_type.as_wire(), pattern.entity_type.as_wire())
+            && match_part(self.zone.as_wire(), pattern.zone.as_wire())
     }
 
     pub fn fully_qualified(&self) -> bool {
-        const LOOKUP_FLAGS: [char; 3] = ['*', '=', '≈'];
+        const LOOKUP_FLAGS: [u8; 3] = [WILDCARD_STAR, WILDCARD_EQUALS, WILDCARD_APPROX];
         // Object and type must not contain wildcard characters.
         // Zone is allowed to be "*" (meaning "my current zone") since that is the standard
         // AppleTalk convention for service registration; the router resolves the real zone.
-        !LOOKUP_FLAGS
-            .iter()
-            .any(|&f| self.object.contains(f) || self.entity_type.contains(f))
+        !LOOKUP_FLAGS.iter().any(|f| {
+            self.object.as_wire().contains(f) || self.entity_type.as_wire().contains(f)
+        })
     }
+}
+
+/// Builds an entity-name component from its on-the-wire MacRoman bytes.
+fn name_from_wire(bytes: &[u8]) -> Result<NbpName, NbpError> {
+    NbpName::from_wire(bytes).ok_or(NbpError::NameTooLong)
 }
 
 #[cfg(test)]
@@ -351,9 +381,9 @@ mod tests {
 
         let entity: EntityName = example_name.try_into().expect("failed to parse");
 
-        assert_eq!(entity.object, "Judy");
-        assert_eq!(entity.entity_type, "Mailbox");
-        assert_eq!(entity.zone, "Bandley3");
+        assert_eq!(entity.object.as_wire(), b"Judy");
+        assert_eq!(entity.entity_type.as_wire(), b"Mailbox");
+        assert_eq!(entity.zone.as_wire(), b"Bandley3");
     }
 
     #[test]

--- a/tailtalk-packets/src/pap.rs
+++ b/tailtalk-packets/src/pap.rs
@@ -52,7 +52,7 @@ impl TryFrom<u8> for PapFunction {
 ///   high byte of sequence number (SendData only)
 /// - Byte 3: Low byte of sequence number (SendData only; always 0 for Data)
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PapPacket {
+pub struct PapPacket<'a> {
     pub connection_id: u8,
     pub function: PapFunction,
     /// Sequence number. Meaningful only for `SendData` (ATP user bytes 2-3, big-endian).
@@ -60,15 +60,15 @@ pub struct PapPacket {
     pub sequence_num: u16,
     /// End-of-file flag; only meaningful for `Data` packets.
     pub eof: bool,
-    pub data: Vec<u8>,
+    pub data: &'a [u8],
 }
 
-impl PapPacket {
+impl<'a> PapPacket<'a> {
     /// Minimum header length (connection_id + function)
     pub const MIN_HEADER_LEN: usize = 2;
 
     /// Parse a PAP packet from bytes
-    pub fn parse(buf: &[u8]) -> Result<Self, PapError> {
+    pub fn parse(buf: &'a [u8]) -> Result<Self, PapError> {
         if buf.len() < Self::MIN_HEADER_LEN {
             return Err(PapError::InvalidSize {
                 expected: Self::MIN_HEADER_LEN,
@@ -100,7 +100,7 @@ impl PapPacket {
             _ => (0, false, 2),
         };
 
-        let data = buf[data_start..].to_vec();
+        let data = &buf[data_start..];
 
         Ok(Self {
             connection_id,
@@ -138,9 +138,9 @@ impl PapPacket {
                 buf[2] = (self.sequence_num >> 8) as u8;
                 buf[3] = self.sequence_num as u8;
             }
-            buf[4..total_len].copy_from_slice(&self.data);
+            buf[4..total_len].copy_from_slice(self.data);
         } else {
-            buf[2..total_len].copy_from_slice(&self.data);
+            buf[2..total_len].copy_from_slice(self.data);
         }
 
         Ok(total_len)
@@ -184,11 +184,11 @@ impl PapPacket {
             _ => {}
         }
 
-        (user_bytes, &self.data)
+        (user_bytes, self.data)
     }
 
     /// Parse from ATP user bytes and data payload
-    pub fn parse_from_atp(user_bytes: [u8; 4], data: &[u8]) -> Result<Self, PapError> {
+    pub fn parse_from_atp(user_bytes: [u8; 4], data: &'a [u8]) -> Result<Self, PapError> {
         let connection_id = user_bytes[0];
         let function = PapFunction::try_from(user_bytes[1])?;
 
@@ -203,7 +203,7 @@ impl PapPacket {
             function,
             sequence_num,
             eof,
-            data: data.to_vec(),
+            data,
         })
     }
 }
@@ -222,7 +222,7 @@ mod tests {
         assert_eq!(packet.connection_id, 0);
         assert_eq!(packet.function, PapFunction::OpenConn);
         assert_eq!(packet.sequence_num, 0);
-        assert_eq!(packet.data, vec![0x42, 0x00, 0x08]);
+        assert_eq!(packet.data, &[0x42, 0x00, 0x08]);
     }
 
     #[test]
@@ -245,7 +245,7 @@ mod tests {
             function: PapFunction::OpenConnReply,
             sequence_num: 0,
             eof: false,
-            data: vec![0x42, 0x00, 0x08, 0x00, 0x01], // socket, flow_quantum, result
+            data: &[0x42, 0x00, 0x08, 0x00, 0x01], // socket, flow_quantum, result
         };
 
         let mut buf = [0u8; 32];
@@ -262,7 +262,7 @@ mod tests {
             function: PapFunction::Data,
             sequence_num: 42,
             eof: false,
-            data: b"PostScript data".to_vec(),
+            data: b"PostScript data",
         };
 
         let mut buf = [0u8; 64];
@@ -283,7 +283,7 @@ mod tests {
             function: PapFunction::Tickle,
             sequence_num: 0,
             eof: false,
-            data: vec![],
+            data: &[],
         };
 
         let mut buf = [0u8; 32];
@@ -301,7 +301,7 @@ mod tests {
             function: PapFunction::SendData,
             sequence_num: 100,
             eof: false,
-            data: b"Test print job data".to_vec(),
+            data: b"Test print job data",
         };
 
         let mut buf = [0u8; 64];
@@ -330,7 +330,7 @@ mod tests {
             function: PapFunction::Status,
             sequence_num: 0,
             eof: false,
-            data: vec![1, 2, 3, 4, 5],
+            data: &[1, 2, 3, 4, 5],
         };
 
         let mut buf = [0u8; 4]; // Too small
@@ -347,7 +347,7 @@ mod tests {
             function: PapFunction::SendData,
             sequence_num: 0x0139, // 313
             eof: false,
-            data: b"Data Payload".to_vec(),
+            data: b"Data Payload",
         };
 
         let (user_bytes, data) = original.to_atp_parts();
@@ -370,7 +370,7 @@ mod tests {
             function: PapFunction::Data,
             sequence_num: 0,
             eof: true,
-            data: b"tail".to_vec(),
+            data: b"tail",
         };
 
         let (user_bytes, data) = original.to_atp_parts();

--- a/tailtalk-packets/src/rtmp.rs
+++ b/tailtalk-packets/src/rtmp.rs
@@ -1,3 +1,4 @@
+use crate::limits::MAX_RTMP_TUPLES;
 use thiserror::Error;
 
 /// Well-known DDP socket for both RTMP Data and RTMP Request packets.
@@ -11,6 +12,8 @@ pub enum RtmpError {
     UnsupportedIdLength { length: u8 },
     #[error("unknown RTMP function code {code}")]
     UnknownFunction { code: u8 },
+    #[error("more than {MAX_RTMP_TUPLES} routing tuples")]
+    TooManyTuples,
 }
 
 /// Function code carried in an RTMP Request or Route Data Request packet.
@@ -64,7 +67,7 @@ pub struct RtmpDataPacket {
     /// Node ID of the router port through which this packet was sent.
     pub node_id: u8,
     /// Routing tuples from the sending router's routing table.
-    pub tuples: Vec<RtmpTuple>,
+    pub tuples: heapless::Vec<RtmpTuple, MAX_RTMP_TUPLES>,
 }
 
 impl RtmpDataPacket {
@@ -91,24 +94,28 @@ impl RtmpDataPacket {
             rest = &rest[3..];
         }
 
-        let mut tuples = Vec::new();
+        let mut tuples = heapless::Vec::new();
         while !rest.is_empty() {
             match rest {
                 // Non-extended tuple: network (2B) + distance (1B, high bit clear).
                 [hi, lo, dist @ 0..=0x7F, tail @ ..] => {
-                    tuples.push(RtmpTuple::NonExtended {
-                        network: u16::from_be_bytes([*hi, *lo]),
-                        distance: *dist,
-                    });
+                    tuples
+                        .push(RtmpTuple::NonExtended {
+                            network: u16::from_be_bytes([*hi, *lo]),
+                            distance: *dist,
+                        })
+                        .map_err(|_| RtmpError::TooManyTuples)?;
                     rest = tail;
                 }
                 // Extended tuple: range_start (2B) + distance|0x80 (1B) + range_end (2B) + $82 (1B).
                 [s_hi, s_lo, dist, e_hi, e_lo, _unused, tail @ ..] => {
-                    tuples.push(RtmpTuple::Extended {
-                        range_start: u16::from_be_bytes([*s_hi, *s_lo]),
-                        distance: *dist & 0x7F,
-                        range_end: u16::from_be_bytes([*e_hi, *e_lo]),
-                    });
+                    tuples
+                        .push(RtmpTuple::Extended {
+                            range_start: u16::from_be_bytes([*s_hi, *s_lo]),
+                            distance: *dist & 0x7F,
+                            range_end: u16::from_be_bytes([*e_hi, *e_lo]),
+                        })
+                        .map_err(|_| RtmpError::TooManyTuples)?;
                     rest = tail;
                 }
                 _ => {

--- a/tailtalk-packets/src/zip.rs
+++ b/tailtalk-packets/src/zip.rs
@@ -16,6 +16,7 @@
 //! Op codes, flag bits, and the wire layout mirror Netatalk's
 //! `include/atalk/zip.h` and `bin/getzones/getzones.c`.
 
+use crate::limits::{MAX_MULTICAST_LEN, MulticastAddr, ZoneName};
 use thiserror::Error;
 
 /// ZIP is carried on DDP socket 6 (the ZIP socket) on both ends.
@@ -48,6 +49,8 @@ pub enum ZipError {
     ZoneTooLong { length: usize },
     #[error("buffer too small: need {needed} bytes but only {available} available")]
     BufferTooSmall { needed: usize, available: usize },
+    #[error("multicast address is {length} bytes; the maximum is {MAX_MULTICAST_LEN}")]
+    MulticastTooLong { length: usize },
 }
 
 /// A ZIP GetNetInfo request (ZIP operation 5), sent node → routers.
@@ -57,7 +60,7 @@ pub enum ZipError {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct GetNetInfoRequest {
     /// Zone name the node is asking the router to confirm; empty if it has none.
-    pub zone: String,
+    pub zone: ZoneName,
 }
 
 impl GetNetInfoRequest {
@@ -83,13 +86,8 @@ impl GetNetInfoRequest {
     }
 
     pub fn to_bytes(&self, buf: &mut [u8]) -> Result<usize, ZipError> {
-        let (zone_cow, _, _) = encoding_rs::MACINTOSH.encode(&self.zone);
-        if zone_cow.len() > MAX_ZONE_LENGTH {
-            return Err(ZipError::ZoneTooLong {
-                length: zone_cow.len(),
-            });
-        }
-        let needed = Self::MIN_LEN + zone_cow.len();
+        let zone_bytes = self.zone.as_wire();
+        let needed = Self::MIN_LEN + zone_bytes.len();
         if buf.len() < needed {
             return Err(ZipError::BufferTooSmall {
                 needed,
@@ -98,7 +96,7 @@ impl GetNetInfoRequest {
         }
         buf[0] = ZIPOP_GNI;
         buf[1..6].fill(0);
-        write_pbytes(buf, 6, &zone_cow);
+        write_pbytes(buf, 6, zone_bytes);
         Ok(needed)
     }
 }
@@ -119,13 +117,13 @@ pub struct GetNetInfoReply {
     /// Last network number of the cable range.
     pub range_end: u16,
     /// The zone name echoed back from the request.
-    pub zone: String,
+    pub zone: ZoneName,
     /// Multicast (hardware) address for the zone; empty when the reply sets
     /// [`ZIPGNI_USE_BROADCAST`] or the link has no multicast.
-    pub multicast: Vec<u8>,
+    pub multicast: MulticastAddr,
     /// Default zone name for the cable. Present (and adopted by the node) when
     /// the requested zone was invalid.
-    pub default_zone: Option<String>,
+    pub default_zone: Option<ZoneName>,
 }
 
 impl GetNetInfoReply {
@@ -170,7 +168,8 @@ impl GetNetInfoReply {
         let (zone, consumed) = read_pstring(buf, offset)?;
         offset += consumed;
         let (multicast, consumed) = read_pbytes(buf, offset)?;
-        let multicast = multicast.to_vec();
+        let multicast = MulticastAddr::from_slice(multicast)
+            .map_err(|_| ZipError::MulticastTooLong { length: multicast.len() })?;
         offset += consumed;
 
         // The default zone is only present when the router chose to send it
@@ -194,20 +193,8 @@ impl GetNetInfoReply {
     }
 
     pub fn to_bytes(&self, buf: &mut [u8]) -> Result<usize, ZipError> {
-        let (zone, _, _) = encoding_rs::MACINTOSH.encode(&self.zone);
-        if zone.len() > MAX_ZONE_LENGTH {
-            return Err(ZipError::ZoneTooLong { length: zone.len() });
-        }
-        let default_zone = self
-            .default_zone
-            .as_ref()
-            .map(|z| encoding_rs::MACINTOSH.encode(z).0);
-        if let Some(default_zone) = &default_zone
-            && default_zone.len() > MAX_ZONE_LENGTH {
-                return Err(ZipError::ZoneTooLong {
-                    length: default_zone.len(),
-                });
-            }
+        let zone = self.zone.as_wire();
+        let default_zone = self.default_zone.as_ref().map(|z| z.as_wire());
 
         let needed = 6
             + (1 + zone.len())
@@ -225,7 +212,7 @@ impl GetNetInfoReply {
         buf[2..4].copy_from_slice(&self.range_start.to_be_bytes());
         buf[4..6].copy_from_slice(&self.range_end.to_be_bytes());
         let mut offset = 6;
-        offset += write_pbytes(buf, offset, &zone);
+        offset += write_pbytes(buf, offset, zone);
         offset += write_pbytes(buf, offset, &self.multicast);
         if let Some(default_zone) = &default_zone {
             offset += write_pbytes(buf, offset, default_zone);
@@ -283,11 +270,14 @@ fn read_pbytes(buf: &[u8], offset: usize) -> Result<(&[u8], usize), ZipError> {
     Ok((slice, 1 + len))
 }
 
-/// Like [`read_pbytes`] but decodes the payload as a MacRoman zone name.
-fn read_pstring(buf: &[u8], offset: usize) -> Result<(String, usize), ZipError> {
+/// Like [`read_pbytes`] but reads the payload as a zone name, which stays in
+/// its on-the-wire MacRoman encoding.
+fn read_pstring(buf: &[u8], offset: usize) -> Result<(ZoneName, usize), ZipError> {
     let (bytes, consumed) = read_pbytes(buf, offset)?;
-    let (name, _, _) = encoding_rs::MACINTOSH.decode(bytes);
-    Ok((name.into_owned(), consumed))
+    let name = ZoneName::from_wire(bytes).ok_or(ZipError::ZoneTooLong {
+        length: bytes.len(),
+    })?;
+    Ok((name, consumed))
 }
 
 /// Writes `data` as a length-prefixed byte string at `offset`. The caller must
@@ -309,7 +299,7 @@ mod tests {
         const WIRE: &[u8] = &[0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
 
         let req = GetNetInfoRequest::parse(WIRE).expect("failed to parse GNI request");
-        assert_eq!(req.zone, "");
+        assert_eq!(req.zone.as_wire(), b"");
 
         let mut buf = [0u8; WIRE.len()];
         let n = req.to_bytes(&mut buf).expect("failed to encode");
@@ -319,7 +309,7 @@ mod tests {
     #[test]
     fn test_getnetinfo_request_named_zone() {
         let req = GetNetInfoRequest {
-            zone: "Bandley3".into(),
+            zone: "Bandley3".try_into().unwrap(),
         };
         let mut buf = [0u8; 64];
         let n = req.to_bytes(&mut buf).expect("failed to encode");
@@ -353,7 +343,7 @@ mod tests {
         assert!(!reply.zone_invalid());
         assert_eq!(reply.range_start, 1);
         assert_eq!(reply.range_end, 1);
-        assert_eq!(reply.zone, "MyZone");
+        assert_eq!(reply.zone.as_wire(), b"MyZone");
         assert!(reply.multicast.is_empty());
         assert_eq!(reply.default_zone, None);
 
@@ -370,9 +360,9 @@ mod tests {
             flags: ZIPGNI_INVALID,
             range_start: 3,
             range_end: 5,
-            zone: "BogusZone".into(),
-            multicast: vec![0x09, 0x00, 0x07, 0xff, 0xff, 0xff],
-            default_zone: Some("Engineering".into()),
+            zone: "BogusZone".try_into().unwrap(),
+            multicast: MulticastAddr::from_slice(&[0x09, 0x00, 0x07, 0xff, 0xff, 0xff]).unwrap(),
+            default_zone: Some("Engineering".try_into().unwrap()),
         };
 
         let mut buf = [0u8; 128];
@@ -382,7 +372,10 @@ mod tests {
         assert_eq!(round, reply);
         assert!(round.zone_invalid());
         assert_eq!(round.multicast.len(), 6);
-        assert_eq!(round.default_zone.as_deref(), Some("Engineering"));
+        assert_eq!(
+            round.default_zone.map(|z| z.as_wire().to_vec()),
+            Some(b"Engineering".to_vec())
+        );
     }
 
     #[test]

--- a/tailtalk/src/afp/server.rs
+++ b/tailtalk/src/afp/server.rs
@@ -126,9 +126,13 @@ impl AfpServer {
 
         // Create NBP entity name
         let entity_name = EntityName {
-            object: config.server_name.clone(),
-            entity_type: "AFPServer".to_string(),
-            zone: "*".to_string(),
+            object: config
+                .server_name
+                .as_str()
+                .try_into()
+                .map_err(|_| anyhow::anyhow!("server name is too long for NBP: {}", config.server_name))?,
+            entity_type: "AFPServer".try_into().expect("literal fits"),
+            zone: "*".try_into().expect("literal fits"),
         };
 
         // Bind ASP service

--- a/tailtalk/src/imagewriter.rs
+++ b/tailtalk/src/imagewriter.rs
@@ -282,9 +282,11 @@ impl ImageWriter {
     /// for any, and the type is always [`NBP_TYPE`].
     pub async fn lookup(nbp: &NbpHandle, object: &str) -> Result<Vec<NbpTuple>> {
         let entity = EntityName {
-            object: object.to_string(),
-            entity_type: NBP_TYPE.to_string(),
-            zone: "*".to_string(),
+            object: object
+                .try_into()
+                .map_err(|_| anyhow::anyhow!("object name is too long for NBP: {object}"))?,
+            entity_type: NBP_TYPE.try_into().expect("literal fits"),
+            zone: "*".try_into().expect("literal fits"),
         };
         Ok(nbp.lookup(entity).await?)
     }

--- a/tailtalk/src/nbp.rs
+++ b/tailtalk/src/nbp.rs
@@ -1,3 +1,4 @@
+use tailtalk_packets::limits::MAX_NAME_UTF8_LEN;
 use crate::{
     addressing::AddressingHandle,
     ddp::{DdpHandle, DdpSocket},
@@ -127,7 +128,9 @@ impl Nbp {
                                 // falling back to a local broadcast only when there is none.
                                 // That is exactly the "=" (all zones) dispatch; the two differ
                                 // only in the zone carried in the request, which stays intact.
-                                let dispatch = match lookup.request.zone.as_str() {
+                                let mut zone_buf = [0u8; MAX_NAME_UTF8_LEN];
+                                let zone = lookup.request.zone.decode(&mut zone_buf).unwrap_or("");
+                                let dispatch = match zone {
                                     "*" | "=" => self.route_table.nbp_dispatch(NbpZone::All),
                                     z => self.route_table.nbp_dispatch(NbpZone::Named(z)),
                                 };
@@ -166,7 +169,11 @@ impl Nbp {
                                             let packet = NbpPacket {
                                                 operation: NbpOperation::BroadcastRequest,
                                                 transaction_id: tid,
-                                                tuples: vec![make_tuple(our_addr)],
+                                                tuples: {
+                                                    let mut t = tailtalk_packets::heapless::Vec::new();
+                                                    let _ = t.push(make_tuple(our_addr));
+                                                    t
+                                                },
                                             };
                                             let size = packet.to_bytes(&mut buf).expect("failed to serialize");
 
@@ -207,7 +214,11 @@ impl Nbp {
                                             let packet = NbpPacket {
                                                 operation: NbpOperation::Lookup,
                                                 transaction_id: tid,
-                                                tuples: vec![make_tuple(our_addr)],
+                                                tuples: {
+                                                    let mut t = tailtalk_packets::heapless::Vec::new();
+                                                    let _ = t.push(make_tuple(our_addr));
+                                                    t
+                                                },
                                             };
                                             let size = packet.to_bytes(&mut buf).expect("failed to serialize");
 
@@ -429,22 +440,27 @@ impl Nbp {
     ) -> NbpPacket {
         let our_addr = self.addr_on(Some(Interface::from(source))).await;
 
-        let mut tuples = Vec::new();
+        let mut tuples = tailtalk_packets::heapless::Vec::new();
 
         for req_tuple in &nbp.tuples {
             for name in &self.registered_names {
                 if name.name.matches(&req_tuple.entity_name) {
-                    tuples.push(NbpTuple {
+                    let pushed = tuples.push(NbpTuple {
                         network_number: our_addr.network_number,
                         node_id: our_addr.node_number,
                         socket_number: name.sock_num,
                         enumerator: 0,
                         entity_name: EntityName {
-                            object: name.name.object.clone(),
-                            entity_type: name.name.entity_type.clone(),
-                            zone: "*".into(),
+                            object: name.name.object,
+                            entity_type: name.name.entity_type,
+                            zone: "*".try_into().expect("literal fits"),
                         },
                     });
+                    // NBP carries at most 15 tuples per reply; further matches
+                    // wait for the requester to look up again.
+                    if pushed.is_err() {
+                        break;
+                    }
                 }
             }
         }

--- a/tailtalk/src/pap.rs
+++ b/tailtalk/src/pap.rs
@@ -113,7 +113,7 @@ impl PapClient {
             function: PapFunction::OpenConn,
             sequence_num: 0,
             eof: false,
-            data: vec![self.atp_requestor.socket_number, 0x08, 0x00, 0x00],
+            data: &[self.atp_requestor.socket_number, 0x08, 0x00, 0x00],
         };
         let (user_bytes, data) = open_packet.to_atp_parts();
         let deadline = tokio::time::Instant::now() + timeout;
@@ -257,7 +257,7 @@ impl PapClient {
                                 function: PapFunction::Data,
                                 sequence_num: seq_num,
                                 eof,
-                                data: buf,
+                                data: &buf,
                             };
                             let (user_bytes, chunk_data) = pap_resp.to_atp_parts();
                             req.send_response_chunked(chunk_data, user_bytes, PAP_MAX_DATA_PER_PACKET).await?;
@@ -289,7 +289,7 @@ impl PapClient {
                                 function: PapFunction::CloseConnReply,
                                 sequence_num: 0,
                                 eof: false,
-                                data: vec![],
+                                data: &[],
                             };
                             let (ub, d) = reply.to_atp_parts();
                             let _ = req.send_response(d, ub).await;
@@ -312,7 +312,7 @@ impl PapClient {
                         function: PapFunction::Tickle,
                         sequence_num: 0,
                         eof: false,
-                        data: vec![],
+                        data: &[],
                     };
                     let (ub, _) = tickle.to_atp_parts();
                     let _ = self.atp_requestor.send_alo(self.server_addr, ub).await;
@@ -356,7 +356,7 @@ impl PapClient {
                 function: PapFunction::SendData,
                 sequence_num: self.read_seq,
                 eof: false,
-                data: vec![],
+                data: &[],
             };
             let (ub, d) = pkt.to_atp_parts();
             let (resp_data, resp_ub) = self.atp_requestor
@@ -370,7 +370,7 @@ impl PapClient {
 
             self.read_seq = next_pap_seq(self.read_seq);
 
-            response.extend_from_slice(&data_pkt.data);
+            response.extend_from_slice(data_pkt.data);
             if data_pkt.eof {
                 break;
             }
@@ -392,7 +392,7 @@ impl PapClient {
             function: PapFunction::CloseConn,
             sequence_num: 0,
             eof: false,
-            data: vec![],
+            data: &[],
         };
         let (ub, d) = close_pkt.to_atp_parts();
         // Must go to server_addr (per-connection socket), not remote_addr (NBP listening socket).
@@ -429,7 +429,7 @@ impl PapClient {
             function: PapFunction::SendStatus,
             sequence_num: 0,
             eof: false,
-            data: vec![],
+            data: &[],
         };
         let (ub, d) = pkt.to_atp_parts();
         let (resp_data, resp_ub) = atp
@@ -745,7 +745,7 @@ impl PapServer {
                         function: PapFunction::Status,
                         sequence_num: 0,
                         eof: false,
-                        data: status_payload,
+                        data: &status_payload,
                     };
                     let (ub, d) = reply.to_atp_parts();
                     let _ = req.send_response(d, ub).await;
@@ -794,7 +794,7 @@ impl PapServer {
             function: PapFunction::OpenConnReply,
             sequence_num: 0,
             eof: false,
-            data: reply_data,
+            data: &reply_data,
         };
         let (ub, d) = reply.to_atp_parts();
         if let Err(e) = open_req.send_response(d, ub).await {
@@ -815,7 +815,7 @@ impl PapServer {
                     function: PapFunction::SendData,
                     sequence_num: seq,
                     eof: false,
-                    data: vec![],
+                    data: &[],
                 };
                 let (ub, d) = send_data.to_atp_parts();
                 requestor.send_request(client_data_addr, ub, d.to_vec()).await
@@ -888,7 +888,7 @@ impl PapServer {
                                 data_pkt.data.len(),
                                 data_pkt.eof
                             );
-                            job.push(&data_pkt.data);
+                            job.push(data_pkt.data);
 
                             if data_pkt.eof && job.is_empty() {
                                 // A zero-byte job (PapClient's post-EOF drain sends one)
@@ -1014,7 +1014,7 @@ impl PapServer {
                                 function: PapFunction::CloseConnReply,
                                 sequence_num: 0,
                                 eof: false,
-                                data: vec![],
+                                data: &[],
                             };
                             let (ub, d) = reply.to_atp_parts();
                             let _ = req.send_response(d, ub).await;
@@ -1075,7 +1075,7 @@ impl PapServer {
                                 function: PapFunction::Status,
                                 sequence_num: 0,
                                 eof: false,
-                                data: status_payload,
+                                data: &status_payload,
                             };
                             let (ub, d) = reply.to_atp_parts();
                             let _ = req.send_response(d, ub).await;
@@ -1090,7 +1090,7 @@ impl PapServer {
                                 function: PapFunction::OpenConnReply,
                                 sequence_num: 0,
                                 eof: false,
-                                data: reply_data,
+                                data: &reply_data,
                             };
                             let (ub, d) = reply.to_atp_parts();
                             let _ = req.send_response(d, ub).await;
@@ -1109,7 +1109,7 @@ impl PapServer {
                         function: PapFunction::Tickle,
                         sequence_num: 0,
                         eof: false,
-                        data: vec![],
+                        data: &[],
                     };
                     let (tub, _) = tickle.to_atp_parts();
                     let _ = conn_requestor.send_alo(client_data_addr, tub).await;
@@ -1142,7 +1142,7 @@ impl PapServer {
                     function: PapFunction::Data,
                     sequence_num: 0,
                     eof,
-                    data: chunk,
+                    data: &chunk,
                 };
                 let (ub, d) = reply.to_atp_parts();
                 let _ = req

--- a/tailtalk/src/zip.rs
+++ b/tailtalk/src/zip.rs
@@ -28,6 +28,7 @@
 //! [`RouteTable`] is the single source of truth; this actor's job is to keep
 //! it fresh.
 
+use tailtalk_packets::limits::MAX_NAME_UTF8_LEN;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -161,7 +162,11 @@ impl Zip {
     async fn send_request(&self) -> Result<(), io::Error> {
         let mut buf = [0u8; 64];
         let n = GetNetInfoRequest {
-            zone: self.remembered_zone.clone().unwrap_or_default(),
+            zone: self
+                .remembered_zone
+                .as_deref()
+                .and_then(|z| z.try_into().ok())
+                .unwrap_or_default(),
         }
         .to_bytes(&mut buf)
         .map_err(io::Error::other)?;
@@ -203,9 +208,13 @@ impl Zip {
             Some(reply.zone)
         };
 
+        let mut zone_buf = [0u8; MAX_NAME_UTF8_LEN];
+        let zone_text = zone
+            .as_ref()
+            .and_then(|z| z.decode(&mut zone_buf))
+            .unwrap_or("<none>");
         tracing::info!(
-            "ZIP GetNetInfo ({iface:?}): network range {lo}-{hi}, zone {}",
-            zone.as_deref().unwrap_or("<none>")
+            "ZIP GetNetInfo ({iface:?}): network range {lo}-{hi}, zone {zone_text}"
         );
 
         if lo != 0 {
@@ -230,11 +239,14 @@ impl Zip {
         }
 
         if let Some(zone) = zone {
-            self.route_table.insert_zone(&zone, &[(lo, hi)]);
-            if let Some(path) = &self.zone_cache {
-                save_zone(path, &zone);
+            let mut buf = [0u8; MAX_NAME_UTF8_LEN];
+            if let Some(name) = zone.decode(&mut buf) {
+                self.route_table.insert_zone(name, &[(lo, hi)]);
+                if let Some(path) = &self.zone_cache {
+                    save_zone(path, name);
+                }
+                self.remembered_zone = Some(name.to_string());
             }
-            self.remembered_zone = Some(zone);
         }
     }
 }

--- a/tailtalk/tests/client_exchange.rs
+++ b/tailtalk/tests/client_exchange.rs
@@ -200,7 +200,7 @@ async fn test_client_exchange() {
 
     assert!(!results.is_empty(), "Client B found no results");
     let target = &results[0];
-    assert_eq!(target.entity_name.object, "ClientA");
+    assert_eq!(target.entity_name.object.as_wire(), b"ClientA");
 
     println!(
         "Client B resolved Client A to: {}.{}",
@@ -280,8 +280,8 @@ async fn test_nbp_lookup() {
         .expect("Lookup failed");
 
     assert_eq!(results.len(), 1, "Should find exactly one FileServer");
-    assert_eq!(results[0].entity_name.object, "FileServer");
-    assert_eq!(results[0].entity_name.entity_type, "AFPServer");
+    assert_eq!(results[0].entity_name.object.as_wire(), b"FileServer");
+    assert_eq!(results[0].entity_name.entity_type.as_wire(), b"AFPServer");
     assert_eq!(results[0].socket_number, 100);
 
     // 6. Client B looks up with wildcard

--- a/tailtalk/tests/nbp_dual_interface.rs
+++ b/tailtalk/tests/nbp_dual_interface.rs
@@ -103,9 +103,9 @@ async fn local_lookup_names_our_address_on_each_cable() {
     tokio::spawn(async move {
         let _ = nbp
             .lookup(EntityName {
-                object: "=".into(),
-                entity_type: "LaserWriter".into(),
-                zone: "*".into(),
+                object: "=".try_into().unwrap(),
+                entity_type: "LaserWriter".try_into().unwrap(),
+                zone: "*".try_into().unwrap(),
             })
             .await;
     });

--- a/tailtalk/tests/pap_test.rs
+++ b/tailtalk/tests/pap_test.rs
@@ -239,7 +239,7 @@ async fn test_pap_print_job() {
             function: PapFunction::OpenConnReply,
             sequence_num: 0,
             eof: false,
-            data: vec![130, 8, 0, 0], // Socket=130, Flow=8, Result=0
+            data: &[130, 8, 0, 0], // Socket=130, Flow=8, Result=0
         };
         let (ub, d) = reply.to_atp_parts();
         req.send_response(d.to_vec(), ub)
@@ -275,7 +275,7 @@ async fn test_pap_print_job() {
         function: PapFunction::SendData,
         sequence_num: 1,
         eof: false,
-        data: vec![],
+        data: &[],
     };
     let (ub, d) = send_data_pkt.to_atp_parts();
 
@@ -465,7 +465,7 @@ impl LegacyDriver {
             function: PapFunction::OpenConn,
             sequence_num: 0,
             eof: false,
-            data: vec![client.atp_req.socket_number, 0x08, 0x00, 0x00],
+            data: &[client.atp_req.socket_number, 0x08, 0x00, 0x00],
         };
         let (ub, data) = open.to_atp_parts();
         let (reply_data, reply_ub) = client
@@ -499,7 +499,7 @@ impl LegacyDriver {
                     function: PapFunction::Data,
                     sequence_num: pap.sequence_num,
                     eof,
-                    data: block,
+                    data: &block,
                 };
                 let (ub, d) = resp.to_atp_parts();
                 let _ = req.send_response(d, ub).await;
@@ -511,13 +511,13 @@ impl LegacyDriver {
 
     /// Post the read the driver blocks on and wait for the printer to speak. Before
     /// the fix this waited forever, retransmitting with nothing ever coming back.
-    async fn read(&mut self) -> PapPacket {
+    async fn read(&mut self) -> ReadAnswer {
         let read = PapPacket {
             connection_id: self.conn_id,
             function: PapFunction::SendData,
             sequence_num: self.read_seq,
             eof: false,
-            data: vec![],
+            data: &[],
         };
         let (ub, d) = read.to_atp_parts();
         let (data, user_bytes) = tokio::time::timeout(
@@ -531,8 +531,17 @@ impl LegacyDriver {
         self.read_seq += 1;
         let answer = PapPacket::parse_from_atp(user_bytes, &data).expect("answer parse");
         assert_eq!(answer.function, PapFunction::Data);
-        answer
+        ReadAnswer {
+            data: answer.data.to_vec(),
+            eof: answer.eof,
+        }
     }
+}
+
+/// What a `read` came back with, owned so it outlives the response buffer.
+struct ReadAnswer {
+    data: Vec<u8>,
+    eof: bool,
 }
 
 /// Spin up a printer emulator and return the workstation, its address, and the
@@ -694,7 +703,7 @@ async fn test_pap_server_answers_printer_and_font_list_query() {
     // The printer query flushes once, after all three `==`, so its three lines are
     // one write. It is not the last one, so no eof yet.
     let first = driver.read().await;
-    assert_eq!(first.data, b"1 \n(47.0)\n(LaserWriter Plus)\n");
+    assert_eq!(first.data, b"1 \n(47.0)\n(LaserWriter Plus)\n"[..]);
     assert!(!first.eof, "the font list still has to follow");
 
     // The font list flushes per name, so each one has to come back in a packet of
@@ -706,7 +715,7 @@ async fn test_pap_server_answers_printer_and_font_list_query() {
         assert!(!write.eof, "the font list is not finished yet");
     }
     let last = driver.read().await;
-    assert_eq!(last.data, b"*\n");
+    assert_eq!(last.data, b"*\n"[..]);
     assert!(last.eof, "the last write of the job's output ends it");
 
     assert!(


### PR DESCRIPTION
InkTalk is an upcoming project that will utilise this project's AppleTalk support. Since this will be a no_std project, we need to make the necessary components actually work there since a lot of it relies on std currently.

This first change is largely a mechanical one - it pulls in heapless and replaces the majority of the std alloc types with heapless' version with fixed sizes based on the Inside AppleTalk spec. The only one that is not changed is AFP as that one relies _way_ more on std and honestly I dont think make sense on an embedded target.

With this tailtalk-packets now successfully builds and can be run for no_std targets.

BREAKING CHANGE: Note that this is a breaking change for a good portion of TailTalk's packet API. It should be a pretty easy migration over.